### PR TITLE
feat: added cache flag to CloudVolume

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ dist: trusty
 before_install:
 - PYTHON_MAJOR_VERSION=`echo $TRAVIS_PYTHON_VERSION | head -c 1`
 - if [[ $PYTHON_MAJOR_VERSION == 3 ]]; then sudo apt-get install python3-pip; fi
-- mkdir -p ~/.neuroglancer/secrets/
+- mkdir -p ~/.cloudvolume/secrets/
 - openssl aes-256-cbc -K $encrypted_1f1d44165f5b_key -iv $encrypted_1f1d44165f5b_iv -in credentials.tar.enc -out credentials.tar -d
 - tar -xvf credentials.tar
-- mv google-secret.json ~/.neuroglancer/secrets/
-- mv aws-secret.json ~/.neuroglancer/secrets/
-- mv project_name ~/.neuroglancer/
+- mv google-secret.json ~/.cloudvolume/secrets/
+- mv aws-secret.json ~/.cloudvolume/secrets/
+- mv project_name ~/.cloudvolume/
 - rm credentials.tar
 install:
 - if [[ $PYTHON_MAJOR_VERSION == 2 ]]; then virtualenv venv; fi

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ You'll need to set up your cloud credentials as well as the main install.
 ### Credentials
 
 ```
-mkdir -p ~/.neuroglancer/secrets/
-echo $GOOGLE_STORAGE_PROJECT > ~/.neuroglancer/project_name # needed for Google
-mv aws-secret.json ~/.neuroglancer/secrets/ # needed for Google
-mv google-secret.json ~/.neuroglancer/secrets/ # needed for Amazon
-mv boss-secret.json ~/.neuroglancer/secrets/ # needed for the BOSS
+mkdir -p ~/.cloudvolume/secrets/
+echo $GOOGLE_STORAGE_PROJECT > ~/.cloudvolume/project_name # needed for Google
+mv aws-secret.json ~/.cloudvolume/secrets/ # needed for Google
+mv google-secret.json ~/.cloudvolume/secrets/ # needed for Amazon
+mv boss-secret.json ~/.cloudvolume/secrets/ # needed for the BOSS
 ```
 
 ### pip
@@ -65,7 +65,7 @@ vol[64:128, 64:128, 64:128] = image # Write a 64^3 image to the volume
 vol.save_mesh(12345) # save 12345 as ./12345.obj
 vol.save_mesh([12345, 12346, 12347]) # merge three segments into one obj
 
-# Caching, located at $HOME/.neuroglancer/cache/$PROTOCOL/$BUCKET/$DATASET/$LAYER/$RESOLUTION
+# Caching, located at $HOME/.cloudvolume/cache/$PROTOCOL/$BUCKET/$DATASET/$LAYER/$RESOLUTION
 vol = CloudVolume('gs://mybucket/retina/image', cache=True) # Basic Example
 image = vol[0:10,0:10,0:10] # Download partial image and cache
 vol[0:10,0:10,0:10] = image # Upload partial image and cache
@@ -104,7 +104,7 @@ Accessed as `vol.$PROPERTY` like `vol.mip`. Parens next to each property mean (d
 * mip (uint:0, rw) - Read from and write to this mip level (0 is highest res). Each additional increment in the number is typically a 2x reduction in resolution.
 * bounded (bool:True, rw) - If a region outside of volume bounds is accessed throw an error if True or Fill the region with black (useful for e.g. marching cubes's 1px boundary) if False.
 * fill_missing (bool:False, rw) - If a file inside volume bounds is unable to be fetched use a block of zeros if True, else throw an error.
-* cache (bool:False, rw) - If true, on reading, check local disk cache before downloading, and save downloaded chunks to cache. When writing, write to the cloud then save the chunks you wrote to cache. If false, bypass cache completely. The cache is located at `$HOME/.neuroglancer/cache`.
+* cache (bool:False, rw) - If true, on reading, check local disk cache before downloading, and save downloaded chunks to cache. When writing, write to the cloud then save the chunks you wrote to cache. If false, bypass cache completely. The cache is located at `$HOME/.cloudvolume/cache`.
 * info (dict, rw) - Python dict representation of Neuroglancer info JSON file. You must call `vol.commit_info()` to save your changes to storage.
 * provenance (dict-like, rw) - Data layer provenance file representation. You must call `vol.commit_provenance()` to save your changes to storage.
 * available_mips (list of ints, r) - Query which mip levels are defined for reading and writing.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ listing = vol.exists( np.s_[0:64, 0:128, 0:64] ) # get a report on which chunks 
 vol[64:128, 64:128, 64:128] = image # Write a 64^3 image to the volume
 vol.save_mesh(12345) # save 12345 as ./12345.obj
 vol.save_mesh([12345, 12346, 12347]) # merge three segments into one obj
+
+# Caching, located at $HOME/.neuroglancer/cache/$PROTOCOL/$BUCKET/$DATASET/$LAYER/$RESOLUTION
+vol = CloudVolume('gs://mybucket/retina/image', cache=True) # Basic Example
+image = vol[0:10,0:10,0:10] # Download partial image and cache
+vol[0:10,0:10,0:10] = image # Upload partial image and cache
+vol.flush_cache() # Delete local cache for this layer at this mip level
 ```
 
 ### CloudVolume Constructor
@@ -97,7 +103,8 @@ Accessed as `vol.$PROPERTY` like `vol.mip`. Parens next to each property mean (d
 
 * mip (uint:0, rw) - Read from and write to this mip level (0 is highest res). Each additional increment in the number is typically a 2x reduction in resolution.
 * bounded (bool:True, rw) - If a region outside of volume bounds is accessed throw an error if True or Fill the region with black (useful for e.g. marching cubes's 1px boundary) if False.
-* fill_missing (bool:False, rw) - If a file inside volume bounds is unable to be fetched use a block of zeros if True, else throw an error
+* fill_missing (bool:False, rw) - If a file inside volume bounds is unable to be fetched use a block of zeros if True, else throw an error.
+* cache (bool:False, rw) - If true, on reading, check local disk cache before downloading, and save downloaded chunks to cache. When writing, write to the cloud then save the chunks you wrote to cache. If false, bypass cache completely. The cache is located at `$HOME/.neuroglancer/cache`.
 * info (dict, rw) - Python dict representation of Neuroglancer info JSON file. You must call `vol.commit_info()` to save your changes to storage.
 * provenance (dict-like, rw) - Data layer provenance file representation. You must call `vol.commit_provenance()` to save your changes to storage.
 * available_mips (list of ints, r) - Query which mip levels are defined for reading and writing.

--- a/cloudvolume/__init__.py
+++ b/cloudvolume/__init__.py
@@ -1,4 +1,4 @@
-from .cloudvolume import CloudVolume, EmptyVolumeException
+from .cloudvolume import CloudVolume, EmptyVolumeException, EmptyRequestException
 from .provenance import DataLayerProvenance
 from .storage import Storage
 from .threaded_queue import ThreadedQueue

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -283,7 +283,7 @@ class CloudVolume(object):
     if self._protocol == 'boss':
       return self.provenance
 
-    self._storage.put_file('provenance', self.provenance.serialize())
+    self._storage.put_file('provenance', self.provenance.serialize(), 'application/json')
     self._maybe_cache_provenance()
     return self.provenance
 

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -435,8 +435,8 @@ class CloudVolume(object):
   def cache_path(self):
     if type(self.cache) is not str:
       return toabs(os.path.join(CLOUD_VOLUME_DIR, 'cache', 
-        self._protocol, self._bucket.replace('/', ''),
-        self._dataset_name, self._layer
+        self.path.protocol, self.path.bucket.replace('/', ''),
+        self.path.dataset, self.path.layer
       ))
     else:
       return toabs(self.cache)

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -561,7 +561,7 @@ class CloudVolume(object):
         shutil.rmtree(self.cache_path) 
 
   def _fetch_data(self, cloudpaths):
-    if not self.cache or self._protocol == 'file':
+    if not self.cache:
       with Storage(self.layer_cloudpath) as storage:
         files = storage.get_files(cloudpaths)
       return files

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -106,10 +106,6 @@ class CloudVolume(object):
       if not os.access(self.cache_path, os.R_OK|os.W_OK):
         raise IOError('Cache directory needs read/write permission: ' + self.cache_path)
 
-    self._storage = None
-    if self._protocol != 'boss':
-      self._storage = Storage(self.layer_cloudpath, n_threads=0)
-
     if info is None:
       self.refresh_info()
     else:

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -258,6 +258,7 @@ class CloudVolume(object):
         jsonfile = storage.get_file(filename)
 
       if jsonfile:
+        jsonfile = jsonfile.decode('utf-8')
         return json.loads(jsonfile)
       else:
         return None

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -339,7 +339,7 @@ class CloudVolume(object):
   @property
   def cache_path(self):
     return toabs(os.path.join(CLOUD_VOLUME_DIR, 'cache', 
-      self._protocol, self._bucket, 
+      self._protocol, self._bucket.replace('/', ''),
       self._dataset_name, self._layer
     ))
 

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -99,8 +99,12 @@ class CloudVolume(object):
     self.fill_missing = fill_missing
     self.cache = cache
 
-    if self.cache and not os.access(self.cache_path, os.R_OK|os.W_OK):
-      raise IOError('Cache directory needs read/write permission: ' + self.cache_path)
+    if self.cache:
+      if not os.path.exists(self.cache_path):
+        mkdir(self.cache_path)
+
+      if not os.access(self.cache_path, os.R_OK|os.W_OK):
+        raise IOError('Cache directory needs read/write permission: ' + self.cache_path)
 
     self._storage = None
     if self._protocol != 'boss':

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -74,8 +74,11 @@ class CloudVolume(object):
     fill_missing: (bool) If a file inside volume bounds is unable to be fetched:
         True: Use a block of zeros
         False: Throw an error
-    cache: (bool) Store downloaded and uploaded files in a cache on disk 
-      and preferentially read from it before redownloading.
+    cache: (bool or str) Store downloaded and uploaded files in a cache on disk 
+      and preferentially read from it before redownloading. 
+        - falsey value: no caching will occur.
+        - True: cache will be located in a standard location.
+        - non-empty string: cache is located at this file path
     info: (dict) in lieu of fetching a neuroglancer info file, use this provided one.
             This is useful when creating new datasets.
   """

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -213,13 +213,13 @@ class CloudVolume(object):
       change invalidates your cache. 
 
       If VALID do one of:
-        1) Manually delete the cached info file (see location below)
+        1) Manually delete the cache (see location below)
         2) Refresh your on-disk cache as follows:
           vol = CloudVolume(..., cache=False) # refreshes from source
           vol.cache = True
           vol.commit_info() # writes to disk
       If INVALID do one of: 
-        1) Delete the info file manually (see cache location below) 
+        1) Delete the cache manually (see cache location below) 
         2) Instantiate as follows: 
           vol = CloudVolume(..., cache=False) # refreshes info from source
           vol.flush_cache() # deletes cache

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 
 from intern.remote.boss import BossRemote
 from intern.resource.boss.resource import ChannelResource, ExperimentResource, CoordinateFrameResource
-from .secrets import boss_credentials
+from .secrets import boss_credentials, CLOUD_VOLUME_DIR
 
 from . import lib, chunks, mesh2obj
 from .lib import toabs, mkdir, clamp, xyzrange, Vec, Bbox, min2, max2, check_bounds
@@ -293,7 +293,7 @@ class CloudVolume(object):
 
   @property
   def cache_path(self):
-    return toabs(os.path.join('~/.neuroglancer/cache/', 
+    return toabs(os.path.join(CLOUD_VOLUME_DIR, 'cache', 
       self._protocol, self._bucket, 
       self._dataset_name, self._layer
     ))

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -994,9 +994,6 @@ class VolumeCutout(np.ndarray):
   def num_channels(self):
     return self.shape[3]
 
-  def upload(self, info):
-    bounds = self.bounds.shrunk_to_chunk_size( DEFAULT_CHUNK_SIZE )
-
   def save_images(self, axis='z', channel=None, directory=None, image_format='PNG'):
 
     if directory is None:

--- a/cloudvolume/lib.py
+++ b/cloudvolume/lib.py
@@ -16,7 +16,8 @@ from tqdm import tqdm
 
 def toabs(path):
   home = os.path.join(os.environ['HOME'], '')
-  return re.sub('^~/?', home, path)
+  path = re.sub('^~/?', home, path)
+  return os.path.abspath(path)
 
 def mkdir(path):
   path = toabs(path)

--- a/cloudvolume/lib.py
+++ b/cloudvolume/lib.py
@@ -14,11 +14,12 @@ from itertools import product
 import numpy as np
 from tqdm import tqdm
 
+def toabs(path):
+  home = os.path.join(os.environ['HOME'], '')
+  return re.sub('^~/?', home, path)
 
 def mkdir(path):
-
-  home = os.path.join(os.environ['HOME'], '')
-  path = re.sub('^~/?', home, path)
+  path = toabs(path)
 
   try:
     if path != '' and not os.path.exists(path):

--- a/cloudvolume/secrets.py
+++ b/cloudvolume/secrets.py
@@ -7,11 +7,7 @@ from google.oauth2 import service_account
 
 from .lib import mkdir
 
-BASE_LOCATION = os.environ['HOME']
-if 'CLOUD_VOLUME_DIR' in os.environ:
-  BASE_LOCATION = os.environ['CLOUD_VOLUME_DIR']
-
-CLOUD_VOLUME_DIR = mkdir(os.path.join(BASE_LOCATION, '.cloudvolume/'))
+CLOUD_VOLUME_DIR = mkdir(os.path.join(os.environ['HOME'], '.cloudvolume/'))
 secret_path = mkdir(os.path.join(CLOUD_VOLUME_DIR, 'secrets/'))
 
 PROJECT_NAME = None

--- a/cloudvolume/secrets.py
+++ b/cloudvolume/secrets.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 import json
 
@@ -5,11 +7,15 @@ from google.oauth2 import service_account
 
 from .lib import mkdir
 
-ngpath = mkdir(os.path.join(os.environ['HOME'], '.neuroglancer/'))
-secret_path = mkdir(os.path.join(ngpath, 'secrets/'))
+BASE_LOCATION = os.environ['HOME']
+if 'CLOUD_VOLUME_DIR' in os.environ:
+  BASE_LOCATION = os.environ['CLOUD_VOLUME_DIR']
+
+CLOUD_VOLUME_DIR = mkdir(os.path.join(BASE_LOCATION, '.cloudvolume/'))
+secret_path = mkdir(os.path.join(CLOUD_VOLUME_DIR, 'secrets/'))
 
 PROJECT_NAME = None
-project_name_path = os.path.join(ngpath, 'project_name')
+project_name_path = os.path.join(CLOUD_VOLUME_DIR, 'project_name')
 if os.path.exists(project_name_path):
   with open(project_name_path, 'r') as f:
     PROJECT_NAME = f.read()

--- a/cloudvolume/storage.py
+++ b/cloudvolume/storage.py
@@ -301,7 +301,7 @@ class FileInterface(object):
             
         if compressed:
             path += '.gz'
-
+        
         try:
             with open(path, 'rb') as f:
                 data = f.read()

--- a/test/layer_harness.py
+++ b/test/layer_harness.py
@@ -16,29 +16,29 @@ def create_storage(layer_name='layer'):
     stor_path = os.path.join(layer_path, layer_name)
     return Storage('file://' + stor_path, n_threads=0)
 
-def create_layer(size, offset, layer_type="image", layer_name='layer', dtype=None):
-
+def create_image(size, layer_type="image", dtype=None):
     default = lambda dt: dtype or dt
 
     if layer_type == "image":
-        random_data = np.random.randint(255, size=size, dtype=default(np.uint8))
+        return np.random.randint(255, size=size, dtype=default(np.uint8))
     elif layer_type == 'affinities':
-        random_data = np.random.uniform(low=0, high=1, size=size).astype(default(np.float32))
+        return np.random.uniform(low=0, high=1, size=size).astype(default(np.float32))
     elif layer_type == "segmentation":
-        random_data = np.random.randint(0xFFFFFF, size=size, dtype=np.uint32)
+        return np.random.randint(0xFFFFFF, size=size, dtype=np.uint32)
     else:
         high = np.array([0], dtype=default(np.uint32)) - 1
-        random_data = np.random.randint(high[0], size=size, dtype=default(np.uint32))
-        
+        return np.random.randint(high[0], size=size, dtype=default(np.uint32))
+
+def create_layer(size, offset, layer_type="image", layer_name='layer', dtype=None):
+    random_data = create_image(size, layer_type, dtype)
     vol = upload_image(random_data, offset, layer_type, layer_name)
-    
     return vol, random_data
 
 def upload_image(image, offset, layer_type, layer_name):
     lpath = 'file://{}'.format(os.path.join(layer_path, layer_name))
     
     # Jpeg encoding is lossy so it won't work
-    vol = create_info_file_from_image(
+    vol = create_volume_from_image(
         image, 
         offset=offset,
         layer_path=lpath,
@@ -46,8 +46,6 @@ def upload_image(image, offset, layer_type, layer_name):
         encoding="raw", 
         resolution=[1,1,1]
     )
-
-    vol[:,:,:] = image
     
     return vol
 
@@ -57,7 +55,7 @@ def delete_layer(path=layer_path):
 
 # Helper Functions
 
-def create_info_file_from_image(image, offset, layer_path, layer_type, resolution, encoding):
+def create_volume_from_image(image, offset, layer_path, layer_type, resolution, encoding):
   assert layer_type in ('image', 'segmentation', 'affinities')
 
   offset = Vec(*offset)
@@ -72,7 +70,7 @@ def create_info_file_from_image(image, offset, layer_path, layer_type, resolutio
     num_channels=1, # Increase this number when we add more tests for RGB
     layer_type=layer_type, 
     data_type=data_type, 
-    encoding=encoding, 
+    encoding=encoding,
     resolution=resolution, 
     voxel_offset=bounds.minpt, 
     volume_size=bounds.size3(),
@@ -82,4 +80,5 @@ def create_info_file_from_image(image, offset, layer_path, layer_type, resolutio
 
   vol = CloudVolume(layer_path, mip=0, info=info)
   vol.commit_info()
+  vol[:,:,:] = image
   return vol

--- a/test/layer_harness.py
+++ b/test/layer_harness.py
@@ -9,6 +9,7 @@ from cloudvolume import Storage, CloudVolume
 from cloudvolume.lib import Bbox, Vec, min2, max2, find_closest_divisor
 
 TEST_NUMBER = np.random.randint(0, 999999)
+CLOUD_BUCKET = 'seunglab-test'
 
 layer_path = '/tmp/removeme/'
 

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -187,7 +187,7 @@ def test_extract_path():
 
     shoulderror('lucifer://bucket/dataset/layer/')
     shoulderror('gs://///')
-    shoulderror('gs://neuroglancer//segmentation')
+    shoulderror('gs://seunglab-test//segmentation')
 
     path = CloudVolume.extract_path('file:///tmp/removeme/layer/')
     assert path.protocol == 'file'
@@ -217,7 +217,7 @@ def test_caching():
     vol = create_volume_from_image(
         image=image, 
         offset=(0,0,0), 
-        layer_path='gs://neuroglancer/removeme/caching', 
+        layer_path='gs://seunglab-test/cloudvolume/caching', 
         layer_type='image', 
         resolution=(1,1,1), 
         encoding='raw'

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -272,7 +272,7 @@ def test_caching():
     image[0:64,64:128,64:128] = 7
     image[64:128,64:128,64:128] = 8
 
-    dirpath = '/tmp/cloudvolume/caching-' + str(TEST_NUMBER)
+    dirpath = '/tmp/cloudvolume/caching-volume-' + str(TEST_NUMBER)
     layer_path = 'file://' + dirpath
 
     vol = create_volume_from_image(
@@ -340,6 +340,19 @@ def test_caching():
     assert len(files) == 8
 
     vol.flush_cache()
+
+    # Test Non-standard Cache Destination
+    dirpath = '/tmp/cloudvolume/caching-cache-' + str(TEST_NUMBER)
+    vol.cache = dirpath
+    vol[:,:,:] = image
+
+    assert len(os.listdir(os.path.join(dirpath, vol.key))) == 8
+
+    vol.flush_cache()
+
+
+
+
 
 
 def test_exists():

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -7,9 +7,8 @@ import shutil
 import gzip
 import json
 
-from cloudvolume import CloudVolume
+from cloudvolume import CloudVolume, chunks, Storage
 from cloudvolume.lib import mkdir, Bbox
-from cloudvolume import chunks
 from layer_harness import (
     TEST_NUMBER, create_image, 
     delete_layer, create_layer,
@@ -273,10 +272,13 @@ def test_caching():
     image[0:64,64:128,64:128] = 7
     image[64:128,64:128,64:128] = 8
 
+    dirpath = '/tmp/cloudvolume/caching-' + str(TEST_NUMBER)
+    layer_path = 'file://' + dirpath
+
     vol = create_volume_from_image(
         image=image, 
         offset=(0,0,0), 
-        layer_path='gs://seunglab-test/cloudvolume/caching', 
+        layer_path=layer_path, 
         layer_type='image', 
         resolution=(1,1,1), 
         encoding='raw'

--- a/test/test_connectionpools.py
+++ b/test/test_connectionpools.py
@@ -18,7 +18,7 @@ retry = tenacity.retry(
 )
 
 def test_gc_stresstest():
-  with Storage('gs://neuroglancer/removeme/connection_pool/', n_threads=0) as stor:
+  with Storage('gs://seunglab-test/cloudvolume/connection_pool/', n_threads=0) as stor:
     stor.put_file('test', 'some string')
 
   n_trials = 500
@@ -28,8 +28,8 @@ def test_gc_stresstest():
   def create_conn(interface):
     conn = GC_POOL.get_connection()
     # assert GC_POOL.total_connections() <= GC_POOL.max_connections * 5
-    bucket = conn.get_bucket('neuroglancer')
-    blob = bucket.get_blob('removeme/connection_pool/test')
+    bucket = conn.get_bucket('seunglab-test')
+    blob = bucket.get_blob('cloudvolume/connection_pool/test')
     blob.download_as_string()
     GC_POOL.release_connection(conn)
     pbar.update()
@@ -41,7 +41,7 @@ def test_gc_stresstest():
   pbar.close()
 
 def test_s3_stresstest():
-  with Storage('s3://neuroglancer/removeme/connection_pool/', n_threads=0) as stor:
+  with Storage('s3://seunglab-test/cloudvolume/connection_pool/', n_threads=0) as stor:
     stor.put_file('test', 'some string')
 
   n_trials = 500
@@ -52,8 +52,8 @@ def test_s3_stresstest():
     conn = S3_POOL.get_connection()  
     # assert S3_POOL.total_connections() <= S3_POOL.max_connections * 5
     bucket = conn.get_object(
-      Bucket='neuroglancer',
-      Key='removeme/connection_pool/test',
+      Bucket='seunglab-test',
+      Key='cloudvolume/connection_pool/test',
     )
     S3_POOL.release_connection(conn)
     pbar.update()

--- a/test/test_provenance.py
+++ b/test/test_provenance.py
@@ -59,7 +59,7 @@ def test_data_layer_provenance():
   prov = DataLayerProvenance()
 
   prov.description = 'example dataset'
-  prov.sources = [ 'gs://neuroglancer/example/image' ]
+  prov.sources = [ 'gs://seunglab-test/example/image' ]
   prov.processing = [ 
     { 'method': 'convnet', 'by': 'gradstudent@princeton.edu' },
   ]
@@ -75,7 +75,7 @@ def test_data_layer_provenance():
 
   assert data == { 
     'description': 'example dataset', 
-    'sources': [ 'gs://neuroglancer/example/image' ],
+    'sources': [ 'gs://seunglab-test/example/image' ],
     'processing': [
       { 'method': 'convnet', 'by': 'gradstudent@princeton.edu' },
     ],
@@ -88,7 +88,7 @@ def test_data_layer_provenance():
     prov = DataLayerProvenance().from_json(provjson)
 
   assert prov.description == 'example dataset'
-  assert prov.sources == [ 'gs://neuroglancer/example/image' ]
+  assert prov.sources == [ 'gs://seunglab-test/example/image' ]
   assert prov.processing == [ { 'method': 'convnet', 'by': 'gradstudent@princeton.edu' } ]
   assert prov.owners == [ 'gradstudent@princeton.edu' ]
 

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -18,17 +18,17 @@ def test_path_extraction():
 
     assert Storage.extract_path('s3://dataset_name') is None
 
-    assert (Storage.extract_path('s3://neuroglancer/intermediate/path/dataset_name/layer_name') 
-        == Storage.ExtractedPath('s3', 'neuroglancer', 'intermediate/path/','dataset_name', 'layer_name'))
+    assert (Storage.extract_path('s3://seunglab-test/intermediate/path/dataset_name/layer_name') 
+        == Storage.ExtractedPath('s3', 'seunglab-test', 'intermediate/path/','dataset_name', 'layer_name'))
 
     assert (Storage.extract_path('file:///tmp/dataset_name/layer_name') 
         == Storage.ExtractedPath('file', "/tmp",  None, 'dataset_name', 'layer_name'))
 
-    assert (Storage.extract_path('file://neuroglancer/intermediate/path/dataset_name/layer_name') 
-        == Storage.ExtractedPath('file', 'neuroglancer','intermediate/path/','dataset_name', 'layer_name'))
+    assert (Storage.extract_path('file://seunglab-test/intermediate/path/dataset_name/layer_name') 
+        == Storage.ExtractedPath('file', 'seunglab-test','intermediate/path/','dataset_name', 'layer_name'))
 
-    assert (Storage.extract_path('gs://neuroglancer/intermediate/path/dataset_name/layer_name') 
-        == Storage.ExtractedPath('gs', 'neuroglancer', 'intermediate/path/','dataset_name', 'layer_name'))
+    assert (Storage.extract_path('gs://seunglab-test/intermediate/path/dataset_name/layer_name') 
+        == Storage.ExtractedPath('gs', 'seunglab-test', 'intermediate/path/','dataset_name', 'layer_name'))
 
     assert Storage.extract_path('s3://dataset_name/layer_name/') is None
 
@@ -36,8 +36,8 @@ def test_path_extraction():
 def test_read_write():
     urls = [
         "file:///tmp/removeme/read_write",
-        "gs://neuroglancer/removeme/read_write",
-        "s3://neuroglancer/removeme/read_write"
+        "gs://seunglab-test/cloudvolume/read_write",
+        "s3://seunglab-test/cloudvolume/read_write"
     ]
 
     for num_threads in range(0,11,5):
@@ -67,8 +67,8 @@ def test_read_write():
 def test_delete():
     urls = [
         "file:///tmp/removeme/delete",
-        "gs://neuroglancer/removeme/delete",
-        "s3://neuroglancer/removeme/delete"
+        "gs://seunglab-test/cloudvolume/delete",
+        "s3://seunglab-test/cloudvolume/delete"
     ]
 
     for url in urls:
@@ -88,8 +88,8 @@ def test_delete():
 def test_compression():
     urls = [
         "file:///tmp/removeme/compression",
-        "gs://neuroglancer/removeme/compression",
-        "s3://neuroglancer/removeme/compression"
+        "gs://seunglab-test/cloudvolume/compression",
+        "s3://seunglab-test/cloudvolume/compression"
     ]
 
     for url in urls:
@@ -107,8 +107,8 @@ def test_compression():
 def test_list():  
     urls = [
         "file:///tmp/removeme/list",
-        "gs://neuroglancer/removeme/list",
-        "s3://neuroglancer/removeme/list"
+        "gs://seunglab-test/cloudvolume/list",
+        "s3://seunglab-test/cloudvolume/list"
     ]
 
     for url in urls:
@@ -153,8 +153,8 @@ def test_list():
 def test_exists():
     urls = [
         "file:///tmp/removeme/exists",
-        "gs://neuroglancer/removeme/exists",
-        "s3://neuroglancer/removeme/exists"
+        "gs://seunglab-test/cloudvolume/exists",
+        "s3://seunglab-test/cloudvolume/exists"
     ]
 
     for url in urls:


### PR DESCRIPTION
You can now set cache=True to enable reading from disk after downloading.
This is only recommended for jobs less than a few gigabytes, large jobs
will fill up your disk.

Cache location: `$HOME/.neuroglancer/cache/$PROTOCOL/$BUCKET/$DATASET/$LAYER/$RESOLUTION`

You can flush the cache your object is referring to with `vol.flush_cache()` and globally with `rm -r $HOME/.neuroglancer/cache/`

Note: Doesn't support Boss protocol yet. That's more complicated.

Resolves #10 