### PR TITLE
feat: progress flag for CloudVolume, Storage

### DIFF
--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -694,7 +694,7 @@ class CloudVolume(object):
     if str(self.dtype) != str(img.dtype):
       raise ValueError('The uploaded image data type must match the volume data type. volume: {}, image: {}'.format(self.dtype, img.dtype))
 
-    iterator = tqdm(self._generate_chunks(img, offset), disable=(not self.progress), desc='rechunking image')
+    iterator = tqdm(self._generate_chunks(img, offset), desc='Rechunking image', disable=(not self.progress))
 
     uploads = []
     for imgchunk, spt, ept in iterator:

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -19,6 +19,11 @@ from .lib import mkdir, clamp, xyzrange, Vec, Bbox, min2, max2, check_bounds
 from .provenance import DataLayerProvenance
 from .storage import Storage
 
+# Set the interpreter bool
+try:
+    INTERACTIVE = bool(sys.ps1)
+except AttributeError:
+    INTERACTIVE = bool(sys.flags.interactive)
 
 if sys.version_info < (3,):
     integer_types = (int, long,)
@@ -67,10 +72,11 @@ class CloudVolume(object):
         False: Throw an error
     info: (dict) in lieu of fetching a neuroglancer info file, use this provided one.
             This is useful when creating new datasets.
-    progress: (bool) Show tqdm progress bars.
+    progress: (bool) Show tqdm progress bars. 
+        Defaults True in interactive python, False in script execution mode.
   """
   def __init__(self, cloudpath, mip=0, bounded=True, fill_missing=False, 
-      progress=False, info=None):
+      progress=INTERACTIVE, info=None):
 
     super(self.__class__, self).__init__()
 

--- a/cloudvolume/threaded_queue.py
+++ b/cloudvolume/threaded_queue.py
@@ -217,7 +217,8 @@ class ThreadedQueue(object):
       while not self._queue.empty():
         size = self._queue.qsize()
         delta = last - self._queue.qsize()
-        pbar.update(delta)
+        if delta != 0: # We should crash on negative numbers
+          pbar.update(delta)
         last = size
         self._check_errors()
         time.sleep(0.1)

--- a/cloudvolume/threaded_queue.py
+++ b/cloudvolume/threaded_queue.py
@@ -6,6 +6,8 @@ from functools import partial
 import threading
 import time
 
+from tqdm import tqdm
+
 class ThreadedQueue(object):
   """Grant threaded task processing to any derived class."""
   def __init__(self, n_threads, queue_size=0):
@@ -18,6 +20,7 @@ class ThreadedQueue(object):
 
     self._processed_lock = threading.Lock()
     self.processed = 0
+    self._inserted = 0
 
     self.start_threads(n_threads)
 
@@ -41,6 +44,7 @@ class ThreadedQueue(object):
 
     Returns: self
     """
+    self._inserted += 1
     self._queue.put(fn, block=True)
     return self
 
@@ -175,30 +179,61 @@ class ThreadedQueue(object):
         self.processed += 1
         self._queue.task_done()
 
-  def wait(self):
+  def _check_errors(self):
+    try:
+      err = self._error_queue.get(block=False) 
+      self._error_queue.task_done()
+      self.kill_threads()
+      raise err
+    except Queue.Empty:
+      pass
+
+  def wait(self, progress=None):
     """
     Allow background threads to process until the
     task queue is empty. If there are no threads,
     in theory the queue should always be empty
     as processing happens immediately on the main thread.
 
-    Required: None
+    Optional:
+      progress: (bool or str) show a tqdm progress bar optionally
+        with a description if a string is provided
     
     Returns: self (for chaining)
 
     Raises: The first exception recieved from threads
     """
-    if len(self._threads):
-        self._queue.join()
+    if not len(self._threads):
+      return self
 
-    try:
-      # no blocking because we're guaranteed
-      # that all threads have finished processing
-      err = self._error_queue.get(block=False) 
-      self._error_queue.task_done()
-      raise err
-    except Queue.Empty:
-      pass
+    desc = None
+    if type(progress) is str:
+      desc = progress
+
+    last = self._inserted
+    with tqdm(total=self._inserted, disable=(not progress), desc=desc) as pbar:
+      # Allow queue to consume, but check up on
+      # progress and errors every tenth of a second
+      while not self._queue.empty():
+        size = self._queue.qsize()
+        delta = last - self._queue.qsize()
+        pbar.update(delta)
+        last = size
+        self._check_errors()
+        time.sleep(0.1)
+
+      # Wait until all tasks in the queue are 
+      # fully processed. queue.task_done must be
+      # called for each task.
+      self._queue.join() 
+      self._check_errors()
+
+      final = self._inserted - last
+      if final:
+        pbar.update(final)
+
+    if self._queue.empty():
+      self._inserted = 0
 
     return self
 

--- a/cloudvolume/threaded_queue.py
+++ b/cloudvolume/threaded_queue.py
@@ -216,7 +216,7 @@ class ThreadedQueue(object):
       # progress and errors every tenth of a second
       while not self._queue.empty():
         size = self._queue.qsize()
-        delta = last - self._queue.qsize()
+        delta = last - size
         if delta != 0: # We should crash on negative numbers
           pbar.update(delta)
         last = size

--- a/test/test_threadedqueue.py
+++ b/test/test_threadedqueue.py
@@ -19,14 +19,14 @@ def test_threading():
   with ThreadedQueue(n_threads=1) as tq:
     for idnum in range(execution_count):
       fn = partial(addone, idnum)
-      tq._queue.put(fn)
+      tq.put(fn)
   assert all(executions)
 
   executions = reset_executions()
   tq = ThreadedQueue(n_threads=40)
   for idnum in range(execution_count):
     fn = partial(addone, idnum)
-    tq._queue.put(fn)
+    tq.put(fn)
   tq.wait().kill_threads()
   assert tq.processed == execution_count
   assert all(executions)
@@ -51,7 +51,7 @@ def test_derived_class():
 
   with DerivedThreadedQueue(n_threads=1) as tq:
     for _ in range(1000):
-      tq._queue.put(what_fun)
+      tq.put(what_fun)
 
     tq.wait()
     assert tq.processed == 1000


### PR DESCRIPTION
```
CloudVolume(..., progress=True) # Shows progress bars
Storage(..., progress=True) # shows progress bars
```

ThreadedQueue now checks every 0.1 seconds for exceptions and updates
a progress indicator. Storage now takes advantage of this for
multithreaded uploads and downloads. CloudVolume now supports a
vol.progress flag that switches tqdm output on and off, default False.

Updated some comments for Storage as well.

Resolves #20 