### PR TITLE
fix: missing module secrets

### DIFF
--- a/cloudvolume/__init__.py
+++ b/cloudvolume/__init__.py
@@ -2,3 +2,4 @@ from .cloudvolume import CloudVolume, EmptyVolumeException
 from .provenance import DataLayerProvenance
 from .storage import Storage
 from .threaded_queue import ThreadedQueue
+import secrets


### PR DESCRIPTION
Needed to export secrets from the package in __init__

Resolves #23 