### PR TITLE
Fix DataCorruption Error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ protobuf==3.3.0
 requests==2.18.4
 six==1.10.0
 tenacity==4.4.0
-tqdm==4.7.6
+tqdm==4.19.4
 urllib3[secure]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ boto3==1.4.7
 chardet==3.0.4
 google-auth==1.0.2
 google-cloud==0.27
+google-resumable-media==0.2.3
 intern==0.9.4
 json5==0.5.1
 jsonschema==2.6.0

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -67,7 +67,7 @@ def test_read_write():
 def test_delete():
     urls = [
         "file:///tmp/removeme/delete",
-        # "gs://seunglab-test/cloudvolume/delete",
+        "gs://seunglab-test/cloudvolume/delete",
         "s3://seunglab-test/cloudvolume/delete"
     ]
 
@@ -88,7 +88,7 @@ def test_delete():
 def test_compression():
     urls = [
         "file:///tmp/removeme/compression",
-        # "gs://seunglab-test/cloudvolume/compression",
+        "gs://seunglab-test/cloudvolume/compression",
         "s3://seunglab-test/cloudvolume/compression"
     ]
 


### PR DESCRIPTION
Google introduced a bug into google-resumable-media 0.3.0 where they checked the checksum of the gzipped file and compared it with the uncompressed version. Reverted to 0.2.3 in the meantime while they fix it. 

https://stackoverflow.com/questions/46804668/gcs-datacorruption-checksum-mismatch-while-downloading