### PR TITLE
fix: cache + fill_missing interaction crash

### DIFF
--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -797,7 +797,8 @@ class CloudVolume(object):
         paths = []
         for item in cloud_files:
           if item['error'] is None:
-            paths.append( (item['filename'], item['content']) )
+            content = item['content'] or b''
+            paths.append( (item['filename'], content) )
 
         storage.put_files(paths, 
           content_type=self._content_type(), 

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -19,6 +19,32 @@ def test_cloud_access():
     vol = CloudVolume('gs://seunglab-test/test_v0/image')
     vol = CloudVolume('s3://seunglab-test/test_dataset/image')
 
+def test_fill_missing():
+  info = CloudVolume.create_new_info(
+    num_channels=1, # Increase this number when we add more tests for RGB
+    layer_type='image', 
+    data_type='uint8', 
+    encoding='raw',
+    resolution=[ 1,1,1 ], 
+    voxel_offset=[0,0,0], 
+    volume_size=[128,128,64],
+    mesh='mesh', 
+    chunk_size=[ 64,64,64 ],
+  )
+
+  vol = CloudVolume('file:///tmp/cloudvolume/empty_volume', mip=0, info=info)
+  vol.commit_info()
+
+  vol = CloudVolume('file:///tmp/cloudvolume/empty_volume', mip=0, fill_missing=True)
+  assert np.count_nonzero(vol[:]) == 0
+
+  vol = CloudVolume('file:///tmp/cloudvolume/empty_volume', mip=0, fill_missing=True, cache=True)
+  assert np.count_nonzero(vol[:]) == 0
+  assert np.count_nonzero(vol[:]) == 0
+
+  vol.flush_cache()
+  delete_layer('/tmp/cloudvolume/empty_volume')
+
 def test_aligned_read():
     delete_layer()
     cv, data = create_layer(size=(50,50,50,1), offset=(0,0,0))


### PR DESCRIPTION
The caching logic would crash trying to compress `None` objects.



```
vol = CloudVolume("gs://neuroglancer/drosophila_sergiy/dummy_mask", cache=True, bounded=False, fill_missing=True)                                                                                                                                                    
vol.flush_cache()
print vol[0:5,0:5,0:5]  

Traceback (most recent call last):
  File "test.py", line 37, in <module>
    print vol[0:5,0:5,0:5]                                                                                                                                                                                                                                                
  File "/Users/wms/cloud-volume/cloudvolume/cloudvolume.py", line 736, in __getitem__
    cutout = self._cutout(requested_bbox, steps, channel_slice)
  File "/Users/wms/cloud-volume/cloudvolume/cloudvolume.py", line 819, in _cutout
    files = self._fetch_data(cloudpaths)
  File "/Users/wms/cloud-volume/cloudvolume/cloudvolume.py", line 804, in _fetch_data
    compress=self._should_compress()
  File "/Users/wms/cloud-volume/cloudvolume/storage.py", line 109, in put_files
    content = self._compress(content)
  File "/Users/wms/cloud-volume/cloudvolume/storage.py", line 241, in _compress
    gzip_obj.write(content)
  File "/usr/local/Cellar/python/2.7.13_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/gzip.py", line 240, in write
    if len(data) > 0:
TypeError: object of type 'NoneType' has no len()```