### PR TITLE
fix: pool on buckets instead of clients for gcloud

### DIFF
--- a/cloudvolume/connectionpools.py
+++ b/cloudvolume/connectionpools.py
@@ -98,9 +98,15 @@ class S3ConnectionPool(ConnectionPool):
     def _close_function(self):
         return lambda conn: conn.close()
 
-class GCloudConnectionPool(ConnectionPool):
+class GCloudBucketPool(ConnectionPool):
+    def __init__(self, bucket):
+        self.bucket = bucket
+        super(GCloudBucketPool, self).__init__()
+
     def _create_connection(self):
-        return Client(
+        client = Client(
             credentials=google_credentials,
             project=PROJECT_NAME
         )
+
+        return client.get_bucket(self.bucket)

--- a/test/test_connectionpools.py
+++ b/test/test_connectionpools.py
@@ -4,12 +4,12 @@ from six.moves import range
 import tenacity
 from tqdm import tqdm
 
-from cloudvolume.connectionpools import S3ConnectionPool, GCloudConnectionPool
+from cloudvolume.connectionpools import S3ConnectionPool, GCloudBucketPool
 from cloudvolume.threaded_queue import ThreadedQueue
 from cloudvolume.storage import Storage
 
 S3_POOL = S3ConnectionPool()
-GC_POOL = GCloudConnectionPool()
+GC_POOL = GCloudBucketPool('seunglab-test')
 
 retry = tenacity.retry(
     reraise=True, 
@@ -26,12 +26,11 @@ def test_gc_stresstest():
 
   @retry
   def create_conn(interface):
-    conn = GC_POOL.get_connection()
     # assert GC_POOL.total_connections() <= GC_POOL.max_connections * 5
-    bucket = conn.get_bucket('seunglab-test')
+    bucket = GC_POOL.get_connection()
     blob = bucket.get_blob('cloudvolume/connection_pool/test')
     blob.download_as_string()
-    GC_POOL.release_connection(conn)
+    GC_POOL.release_connection(bucket)
     pbar.update()
 
   with ThreadedQueue(n_threads=20) as tq:


### PR DESCRIPTION
We never use clients other than to get buckets. For a dataset
where we were doing multiprocessing, the gcloud buckets were
stalling out threads. It took a while to find out why.