### PR TITLE
Add parallel option to CloudVolume

### DIFF
--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -927,7 +927,8 @@ class CloudVolume(object):
           layer = cachedir
       renderbuffer = decode(fname, SimpleStorage(layer).get_file(fname))
     else:
-      with ThreadedQueue(n_threads=20) as tq:
+      progress = 'Downloading' if self.progress else None
+      with ThreadedQueue(n_threads=20, progress=progress) as tq:
         for filename in locations['local']:
           dl = partial(download, cachedir, filename, False)
           tq.put(dl)

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+from functools import partial
 import json
 import json5
 import os
@@ -8,7 +9,7 @@ import sys
 import shutil
 import weakref
 
-from builtins import range
+from six.moves import range
 import numpy as np
 from PIL import Image
 from tqdm import tqdm
@@ -27,7 +28,8 @@ from .lib import (
 )
 from .meshservice import PrecomputedMeshService
 from .provenance import DataLayerProvenance
-from .storage import Storage
+from .storage import SimpleStorage, Storage
+from .threaded_queue import ThreadedQueue
 
 # Set the interpreter bool
 try:
@@ -865,82 +867,73 @@ class CloudVolume(object):
 
     return { 'local': already_have, 'remote': download_paths }
 
-  def _fetch_data(self, cloudpaths):
-    locs = self._compute_data_locations(cloudpaths)
-
-    local_files = []
-    if locs['local']:
-      cachedir = os.path.join(self.cache_path, self.key)
-      with Storage('file://' + cachedir) as storage:
-        local_files = storage.get_files(locs['local'])
-
-    cloud_files = []
-
-    if locs['remote']:
-      with Storage(self.layer_cloudpath, progress=self.progress) as storage:
-        cloud_files = storage.get_files(locs['remote'])
-
-    if self.cache and cloud_files:
-      with Storage('file://' + self.cache_path, progress=self.progress) as storage:
-        paths = []
-        for item in cloud_files:
-          if item['error'] is None:
-            content = item['content'] or b''
-            paths.append( (item['filename'], content) )
-
-        storage.put_files(paths, 
-          content_type=self._content_type(), 
-          compress=self._should_compress()
-        )
-
-    return local_files + cloud_files
-
   def _cutout(self, requested_bbox, steps, channel_slice=slice(None)):
     realized_bbox = self.__realized_bbox(requested_bbox)
-    
+    cloudpaths = self.__chunknames(realized_bbox, self.bounds, self.key, self.underlying)
+
     def multichannel_shape(bbox):
       shape = bbox.size3()
       return (shape[0], shape[1], shape[2], self.num_channels)
 
-    cloudpaths = self.__chunknames(realized_bbox, self.bounds, self.key, self.underlying)
-    files = self._fetch_data(cloudpaths)
+    def decode(filename, content):
+      bbox = Bbox.from_filename(filename)
+      content_len = len(content) if content is not None else 0
 
-    def decode(fileinfo):
-      if fileinfo['error'] is not None:
-        raise fileinfo['error']
-
-      bbox = Bbox.from_filename(fileinfo['filename'])
-      content_len = len(fileinfo['content']) if fileinfo['content'] is not None else 0
-
-      if not fileinfo['content']:
+      if not content:
         if self.fill_missing:
-          fileinfo['content'] = ''
+          content = ''
         else:
-          raise EmptyVolumeException(fileinfo['filename'])
+          raise EmptyVolumeException(filename)
 
       try:
         return chunks.decode(
-          fileinfo['content'], self.encoding, multichannel_shape(bbox), self.dtype
+          content, self.encoding, multichannel_shape(bbox), self.dtype
         )
       except Exception:
         print(red('File Read Error: {} bytes, {}, {}, errors: {}'.format(
-            content_len, bbox, fileinfo['filename'], fileinfo['error'])))
+            content_len, bbox, filename, error)))
         raise
 
-    if len(files) == 1:
-      renderbuffer = decode(files[0])
-    else:
-      renderbuffer = np.zeros(shape=multichannel_shape(realized_bbox), dtype=self.dtype)
-      fileiter = tqdm(files, total=len(cloudpaths), desc="Rendering Image", disable=(not self.progress))
-      for fileinfo in fileiter:
-        bbox = Bbox.from_filename(fileinfo['filename'])
-        img3d = decode(fileinfo)
+    renderbuffer = np.zeros(shape=multichannel_shape(realized_bbox), dtype=self.dtype)
+
+    def paint(filename, content):
+        bbox = Bbox.from_filename(filename)
+        img3d = decode(filename, content)
         start = bbox.minpt - realized_bbox.minpt
         end = min2(start + self.underlying, renderbuffer.shape[:3] )
         delta = min2(end - start, img3d.shape[:3])
         end = start + delta
-
         renderbuffer[ start.x:end.x, start.y:end.y, start.z:end.z, : ] = img3d[ :delta.x, :delta.y, :delta.z, : ]
+
+    def download(cloudpath, filename, cache, iface):
+      content = SimpleStorage(cloudpath).get_file(filename)
+      paint(filename, content)
+      if cache:
+        content = content or b''
+        SimpleStorage('file://' + self.cache_path).put_file(
+          file_path=filename, 
+          content=content, 
+          content_type=self._content_type(), 
+          compress=self._should_compress()
+        )
+
+    locations = self._compute_data_locations(cloudpaths)
+    cachedir = 'file://' + os.path.join(self.cache_path, self.key)
+
+    if len(cloudpaths) == 1:
+      fname = cloudpaths[0]
+      layer = self.layer_cloudpath
+      if locations['local']:
+          layer = cachedir
+      renderbuffer = decode(fname, SimpleStorage(layer).get_file(fname))
+    else:
+      with ThreadedQueue(n_threads=20) as tq:
+        for filename in locations['local']:
+          dl = partial(download, cachedir, filename, False)
+          tq.put(dl)
+        for filename in locations['remote']:
+          dl = partial(download, self.layer_cloudpath, filename, self.cache)
+          tq.put(dl)
 
     bounded_request = Bbox.clamp(requested_bbox, self.bounds)
     lp = bounded_request.minpt - realized_bbox.minpt # low realized point

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -33,7 +33,7 @@ from .lib import (
 )
 from .meshservice import PrecomputedMeshService
 from .provenance import DataLayerProvenance
-from .storage import SimpleStorage, Storage
+from .storage import SimpleStorage, Storage, reset_connection_pools
 from .threaded_queue import ThreadedQueue
 
 # Set the interpreter bool
@@ -906,7 +906,6 @@ class CloudVolume(object):
       spd = partial(multi_process_download, self, realized_bbox)
       pool.map(spd, cloudpaths_by_process)
       self.provenance = provenance
-
       shared, array_like, renderbuffer = open_renderbuffer(self, realized_bbox)
       renderbuffer = np.copy(renderbuffer)
       array_like.close()
@@ -1243,6 +1242,7 @@ def single_process_download(cv, realized_bbox, cloudpaths, renderbuffer):
       tq.put(dl)
 
 def multi_process_download(cv, realized_bbox, cloudpaths):
+  reset_connection_pools() # otherwise multi-process hangs
   shared, array_like, renderbuffer = open_renderbuffer(cv, realized_bbox)
   single_process_download(cv, realized_bbox, cloudpaths, renderbuffer)
   array_like.close()
@@ -1352,6 +1352,7 @@ def single_process_upload(vol, img_bbox, chunk_ranges, renderbuffer):
 
 
 def multi_process_upload(vol, img_bbox, chunk_ranges):
+  reset_connection_pools()
   shared, array_like, renderbuffer = open_renderbuffer(vol, img_bbox)
   single_process_upload(vol, img_bbox, chunk_ranges, renderbuffer)
   array_like.close()

--- a/cloudvolume/connectionpools.py
+++ b/cloudvolume/connectionpools.py
@@ -1,7 +1,6 @@
 from six.moves import queue as Queue
 import threading
 import time
-import signal
 from functools import partial
 
 from google.cloud.storage import Client
@@ -32,12 +31,6 @@ class ConnectionPool(object):
         self.pool = Queue.Queue(maxsize=0)
         self.outstanding = 0
         self._lock = threading.Lock()
-
-        def handler(signum, frame):
-            self.reset_pool()
-
-        signal.signal(signal.SIGINT, handler)
-        signal.signal(signal.SIGTERM, handler)
 
     def total_connections(self):
         return self.pool.qsize() + self.outstanding

--- a/cloudvolume/storage.py
+++ b/cloudvolume/storage.py
@@ -28,8 +28,15 @@ class keydefaultdict(defaultdict):
             ret = self[key] = self.default_factory(key)
             return ret
 
-S3_POOL = S3ConnectionPool()
-GC_POOL = keydefaultdict(lambda bucket_name: GCloudBucketPool(bucket_name))
+S3_POOL = None
+GC_POOL = None
+def reset_connection_pools():
+    global S3_POOL
+    global GC_POOL
+    S3_POOL = S3ConnectionPool()
+    GC_POOL = keydefaultdict(lambda bucket_name: GCloudBucketPool(bucket_name))
+
+reset_connection_pools()
 
 retry = tenacity.retry(
     reraise=True, 

--- a/cloudvolume/threaded_queue.py
+++ b/cloudvolume/threaded_queue.py
@@ -10,7 +10,7 @@ from tqdm import tqdm
 
 class ThreadedQueue(object):
   """Grant threaded task processing to any derived class."""
-  def __init__(self, n_threads, queue_size=0):
+  def __init__(self, n_threads, queue_size=0, progress=None):
     self._n_threads = n_threads
 
     self._queue = Queue.Queue(maxsize=queue_size) # 0 = infinite size
@@ -22,7 +22,7 @@ class ThreadedQueue(object):
     self.processed = 0
     self._inserted = 0
 
-    self.with_progress = None
+    self.with_progress = progress
 
     self.start_threads(n_threads)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ numpy>=1.13.3
 pytest>=3.3.1 
 python-jsonschema-objects==0.2.1
 Pillow>=4.2.1
+posix_ipc==1.0.4
 protobuf>=3.3.0
 requests>=2.18.4
 six==1.10.0

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -126,15 +126,15 @@ def test_writer_last_chunk_smaller():
 
     assert len(chunks) == 2
 
-    img, spt, ept = chunks[0]
+    startpt, endpt, spt, ept = chunks[0]
     assert np.array_equal(spt, (0,0,0))
     assert np.array_equal(ept, (64,64,64))
-    assert img.shape == (64,64,64,1)
+    # assert img.shape == (64,64,64,1)
 
-    img, spt, ept = chunks[1]
+    startpt, endpt, spt, ept = chunks[1]
     assert np.array_equal(spt, (64,0,0))
     assert np.array_equal(ept, (100,64,64))
-    assert img.shape == (36,64,64,1)
+    # assert img.shape == (36,64,64,1)
 
 # def test_reader_negative_indexing():
 #     """negative indexing is supported"""


### PR DESCRIPTION
Beats gsutil download substantially for very small chunks, loses by about 1.5-2x for large chunks. 

Needs a lot of cleanup....

Upload needs to be implemented as well.

High memory usage... due to mmap? downloads?

![figure_1](https://user-images.githubusercontent.com/2517065/36625840-5330910c-18f5-11e8-9d18-eb32d31498ad.png)

Downloading uint16 segmentation chunked as 128x128x8 w/ 8 processes.

Another run plotted as a summation:

![figure_1](https://user-images.githubusercontent.com/2517065/36625858-9828c752-18f5-11e8-8579-f949892e4e16.png)
