### PR TITLE
Reduce Memory Usage for Non-Aligned Downloads

### DIFF
--- a/cloudvolume/lib.py
+++ b/cloudvolume/lib.py
@@ -276,6 +276,17 @@ class Bbox(object):
     )
 
   @classmethod
+  def intersects(cls, bbx1, bbx2):
+    return (
+          bbx1.minpt.x < bbx2.maxpt.x 
+      and bbx1.maxpt.x > bbx2.minpt.x 
+      and bbx1.minpt.y < bbx2.maxpt.y
+      and bbx1.maxpt.y > bbx2.minpt.y
+      and bbx1.minpt.z < bbx2.maxpt.z
+      and bbx1.maxpt.z > bbx2.minpt.z 
+    )
+
+  @classmethod
   def from_vec(cls, vec):
     return Bbox( (0,0,0), vec )
 

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -91,6 +91,14 @@ def test_non_aligned_read():
     img2 = cv[:, :, :, :][::2, ::2, ::2, :]
     assert np.array_equal(img1, img2)
 
+    # read a single pixel
+    delete_layer()
+    cv, data = create_layer(size=(256,256,64,1), offset=(3,7,11))
+    # the last dimension is the number of channels
+    assert cv[22:77:2, 22:197:3, 22:32].shape == (28,59,10,1) 
+    assert data[19:74:2, 15:190:3, 11:21,:].shape == (28,59,10,1) 
+    assert np.all(cv[22:77:2, 22:197:3, 22:32] == data[19:74:2, 15:190:3, 11:21,:])
+
 def test_write():
     delete_layer()
     cv, data = create_layer(size=(50,50,50,1), offset=(0,0,0))

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -129,6 +129,17 @@ def test_bbox_division():
 
   assert (box/2) == Bbox( (0,1.5,2), (2,4,8) )
 
+def test_bbox_intersect():
+  box = Bbox( (0,0,0), (10, 10, 10) )
+  
+  assert Bbox.intersects(box, box)
+  assert Bbox.intersects(box, Bbox((1,1,1), (11,11,11)) )
+  assert Bbox.intersects(box, Bbox((-1,-1,-1), (9,9,9)) ) 
+  assert Bbox.intersects(box, Bbox((5, -5, 0), (15, 5, 10)))
+  assert not Bbox.intersects(box, Bbox( (30,30,30), (40,40,40) ))
+  assert not Bbox.intersects(box, Bbox( (-30,-30,-30), (-40,-40,-40) ))
+  assert not Bbox.intersects(box, Bbox( (10, 0, 0), (20, 10, 10) ))
+
 def test_jsonify():
   obj = {
     'x': [ np.array([1,2,3,4,5], dtype=np.uint64) ],


### PR DESCRIPTION
Only allocate as much memory as the final cutout requires.

Resolves #75 