### PR TITLE
Python Compressed Segmentation Codec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ ENV/
 # OS X 
 .DS_Store
 
+.pytest_cache
 test.py
 
 # Saved Images Cache

--- a/cloudvolume/chunks.py
+++ b/cloudvolume/chunks.py
@@ -92,27 +92,27 @@ def encode_compressed_segmentation(subvol, block_size):
     assert np.dtype(subvol.dtype) in (np.uint32, np.uint64)
     return compressed_segmentation.encode_chunk(subvol.T, block_size=block_size)
 
+def encode_raw(subvol):
+    return subvol.tostring('F')
+
+def decode_npz(string):
+    fileobj = io.BytesIO(zlib.decompress(string))
+    return np.load(fileobj)
+
 def decode_jpeg(bytestring, shape=(64,64,64), dtype=np.uint8):
     img = Image.open(io.BytesIO(bytestring))
     data = np.array(img.getdata(), dtype=dtype)
 
     return data.reshape(shape[::-1]).T
 
-
-def decode_npz(string):
-    fileobj = io.BytesIO(zlib.decompress(string))
-    return np.load(fileobj)
-
-def encode_raw(subvol):
-    return subvol.tostring('F')
-
 def decode_raw(bytestring, shape=(64,64,64), dtype=np.uint32):
     return np.frombuffer(bytestring, dtype=dtype).reshape(shape[::-1]).T
 
-def decode_compressed_segmentation(subvol, shape, dtype, block_size):
+def decode_compressed_segmentation(bytestring, shape, dtype, block_size):
     assert block_size is not None
-    chunk = np.empty(shape=shape, dtype=dtype)
-    return compressed_segmentation.decode_chunk_into(chunk, buf, block_size=block_size).T
+    chunk = np.empty(shape=shape[::-1], dtype=dtype)
+    compressed_segmentation.decode_chunk_into(chunk, bytestring, block_size=block_size)
+    return chunk.T
 
 
 

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -486,7 +486,7 @@ class CloudVolume(object):
 
   @property
   def compressed_segmentation_block_size(self):
-    return self.compressed_segmentation_block_size(self.mip)
+    return self.mip_compressed_segmentation_block_size(self.mip)
 
   def mip_compressed_segmentation_block_size(self, mip):
     if 'compressed_segmentation_block_size' in self.info['scales'][mip]:

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -304,6 +304,21 @@ class CloudVolume(object):
     if self.path.protocol == 'boss':
       return self 
 
+    for scale in self.scales:
+      if scale['encoding'] == 'compressed_segmentation':
+        if 'compressed_segmentation_block_size' not in scale.keys():
+          raise KeyError("""
+            'compressed_segmentation_block_size' must be set if 
+            compressed_segmentation is set as the encoding.
+
+            A typical value for compressed_segmentation_block_size is (8,8,8)
+
+            Info file specification:
+            https://github.com/google/neuroglancer/blob/master/src/neuroglancer/datasource/precomputed/README.md#info-json-file-specification
+          """)
+        elif self.dtype not in ('uint32', 'uint64'):
+          raise ValueError("compressed_segmentation can only be used with uint32 and uint64 data types.")
+
     infojson = jsonify(self.info, 
       sort_keys=True,
       indent=2, 
@@ -468,6 +483,15 @@ class CloudVolume(object):
 
   def mip_encoding(self, mip):
     return self.info['scales'][mip]['encoding']
+
+  @property
+  def compressed_segmentation_block_size(self):
+    return self.compressed_segmentation_block_size(self.mip)
+
+  def mip_compressed_segmentation_block_size(self, mip):
+    if 'compressed_segmentation_block_size' in self.info['scales'][mip]:
+      return self.info['scales'][mip]['compressed_segmentation_block_size']
+    return None
 
   @property
   def num_channels(self):

--- a/cloudvolume/compressed_segmentation.py
+++ b/cloudvolume/compressed_segmentation.py
@@ -1,0 +1,258 @@
+# Copyright (c) 2016, 2017, 2018 Forschungszentrum Juelich GmbH
+# Author: Yann Leprince <y.leprince@fz-juelich.de>
+# 
+# Later modifications (c) 2018 by William Silversmith <ws9@princeton.edu>
+#
+# This software is made available under the MIT license, see bottom of file.
+
+import functools
+import itertools
+import struct
+
+import numpy as np
+
+def ceil_div(a, b):
+    """Ceil integer division (``ceil(a / b)`` using integer arithmetic)."""
+    return (a - 1) // b + 1
+
+
+class InvalidFormatError(Exception):
+    """Raised when chunk data cannot be decoded properly."""
+    pass
+
+def pad_block(block, block_size):
+    """Pad a block to block_size with its most frequent value"""
+    unique_vals, unique_counts = np.unique(block, return_counts=True)
+    most_frequent_value = unique_vals[np.argmax(unique_counts)]
+    return np.pad(block,
+                  tuple((0, desired_size - actual_size)
+                        for desired_size, actual_size
+                        in zip(block_size, block.shape)),
+                  mode="constant", constant_values=most_frequent_value)
+
+
+def number_of_encoding_bits(elements):
+    for bits in (0, 1, 2, 4, 8, 16, 32):
+        if 2 ** bits >= elements:
+            return bits
+    raise ValueError("Too many elements!")
+
+
+COMPRESSED_SEGMENTATION_DATA_TYPES = (
+    np.dtype(np.uint32).newbyteorder("<"),
+    np.dtype(np.uint64).newbyteorder("<"),
+)
+
+
+def encode_chunk(chunk, block_size):
+    # Construct file in memory step by step
+    num_channels = chunk.shape[0]
+    buf = bytearray(4 * num_channels)
+
+    assert chunk.dtype in COMPRESSED_SEGMENTATION_DATA_TYPES
+
+    for channel in range(num_channels):
+        # Write offset of the current channel into the header
+        assert len(buf) % 4 == 0
+        struct.pack_into("<I", buf, channel * 4, len(buf) // 4)
+
+        buf += _encode_channel(
+            chunk[channel, :, :, :], block_size)
+    return buf
+
+
+def _encode_channel(chunk_channel, block_size):
+    # Grid size (number of blocks in the chunk)
+    gx = ceil_div(chunk_channel.shape[2], block_size[0])
+    gy = ceil_div(chunk_channel.shape[1], block_size[1])
+    gz = ceil_div(chunk_channel.shape[0], block_size[2])
+    stored_lut_offsets = {}
+    buf = bytearray(gx * gy * gz * 8)
+    for z, y, x in np.ndindex((gz, gy, gx)):
+        block = chunk_channel[
+            z*block_size[2] : (z+1)*block_size[2],
+            y*block_size[1] : (y+1)*block_size[1],
+            x*block_size[0] : (x+1)*block_size[0]
+        ]
+        if block.shape != block_size:
+            block = pad_block(block, block_size)
+
+        # TODO optimization: to improve additional compression (gzip), sort the
+        # list of unique symbols by decreasing frequency using
+        # return_counts=True so that low-value symbols are used more often.
+        # Alternatively, sort by label value to improve sharing of lookup
+        # tables...
+        (lookup_table, encoded_values) = np.unique(
+            block, return_inverse=True, return_counts=False)
+        bits = number_of_encoding_bits(len(lookup_table))
+
+        # Write look-up table to the buffer (or re-use another one)
+        lut_bytes = lookup_table.astype(block.dtype).tobytes()
+        if lut_bytes in stored_lut_offsets:
+            lookup_table_offset = stored_lut_offsets[lut_bytes]
+        else:
+            assert len(buf) % 4 == 0
+            lookup_table_offset = len(buf) // 4
+            buf += lut_bytes
+            stored_lut_offsets[lut_bytes] = lookup_table_offset
+
+        assert len(buf) % 4 == 0
+        encoded_values_offset = len(buf) // 4
+        buf += _pack_encoded_values(encoded_values, bits)
+
+        assert lookup_table_offset == (lookup_table_offset & 0xFFFFFF)
+        struct.pack_into("<II", buf, 8 * (x + gx * (y + gy * z)),
+                         lookup_table_offset | (bits << 24),
+                         encoded_values_offset)
+    return buf
+
+
+def _pack_encoded_values(encoded_values, bits):
+    # TODO optimize with np.packbits for bits == 1
+    if bits == 0:
+        return bytes()
+    else:
+        values_per_32bit = 32 // bits
+        assert np.all(encoded_values == encoded_values & ((1 << bits) - 1))
+        padded_values = np.empty(
+            values_per_32bit * ceil_div(len(encoded_values), values_per_32bit),
+            dtype="<I")
+        padded_values[:len(encoded_values)] = encoded_values
+        padded_values[len(encoded_values):] = 0
+        packed_values = functools.reduce(
+            np.bitwise_or,
+            (padded_values[shift::values_per_32bit] << (shift * bits)
+             for shift in range(values_per_32bit)))
+        return packed_values.tobytes()
+
+
+def decode_chunk_into(chunk, buf, block_size):
+    num_channels = chunk.shape[0]
+    # Grid size (number of blocks in the chunk)
+    gx = ceil_div(chunk.shape[3], block_size[0])
+    gy = ceil_div(chunk.shape[2], block_size[1])
+    gz = ceil_div(chunk.shape[1], block_size[2])
+
+    if len(buf) < num_channels * (4 + 8 * gx * gy * gz):
+        raise InvalidFormatError("compressed_segmentation file too short")
+
+    channel_offsets = [
+        4 * ret[0]
+        for ret in struct.iter_unpack("<I", buf[:4*num_channels])
+    ]
+    for channel, (offset, next_offset) in enumerate(
+            itertools.zip_longest(channel_offsets,
+                                  channel_offsets[1:])):
+        # next_offset will be None for the last channel
+        if offset + 8 * gx * gy * gz > len(buf):
+            raise InvalidFormatError("compressed_segmentation channel offset "
+                                     "is too large (truncated file?)")
+        _decode_channel_into(
+            chunk, channel, buf[offset:next_offset], block_size
+        )
+
+    return chunk
+
+
+def _decode_channel_into(chunk, channel, buf, block_size):
+    # Grid size (number of blocks in the chunk)
+    gx = ceil_div(chunk.shape[3], block_size[0])
+    gy = ceil_div(chunk.shape[2], block_size[1])
+    gz = ceil_div(chunk.shape[1], block_size[2])
+    block_num_elem = block_size[0] * block_size[1] * block_size[2]
+    for z, y, x in np.ndindex((gz, gy, gx)):
+        # Read the block header
+        res = struct.unpack_from("<II", buf, 8 * (x + gx * (y + gy * z)))
+        lookup_table_offset = 4 * (res[0] & 0x00FFFFFF)
+        bits = res[0] >> 24
+        if bits not in (0, 1, 2, 4, 8, 16, 32):
+            raise InvalidFormatError("Invalid number of encoding bits for "
+                                     "compressed_segmentation block ({0})"
+                                     .format(bits))
+        encoded_values_offset = 4 * res[1]
+        if bits != 0 and encoded_values_offset > len(buf):
+            raise InvalidFormatError("Invalid offset for encoded values in "
+                                     "compressed_segmentation block "
+                                     "(truncated file?)")
+        lookup_table_past_end = lookup_table_offset + chunk.itemsize * min(
+            (2 ** bits),
+            ((len(buf) - lookup_table_offset) // chunk.itemsize)
+        )
+        lookup_table = np.frombuffer(
+            buf[lookup_table_offset:lookup_table_past_end], dtype=chunk.dtype)
+        if bits == 0:
+            block = np.empty(block_size, dtype=chunk.dtype)
+            try:
+                block[...] = lookup_table[0]
+            except IndexError as exc:
+                raise InvalidFormatError(
+                    "Invalid compressed_segmentation data: indexing out of "
+                    "the lookup table")
+        else:
+            values_per_32bit = 32 // bits
+            encoded_values_end = encoded_values_offset + 4 * (
+                ceil_div(block_num_elem, values_per_32bit)
+            )
+            packed_values = np.frombuffer(buf[encoded_values_offset:
+                                              encoded_values_end], dtype="<I")
+            encoded_values = _unpack_encoded_values(packed_values, bits,
+                                                    block_num_elem)
+            # Apply the lookup table
+            try:
+                decoded_values = lookup_table[encoded_values]
+            except IndexError as exc:
+                raise InvalidFormatError(
+                    "Invalid compressed_segmentation data: indexing out of "
+                    "the lookup table")
+            block = decoded_values.reshape((block_size[2],
+                                            block_size[1],
+                                            block_size[0]))
+
+        # Remove padding
+        zmax = min(block_size[2], chunk.shape[1] - z * block_size[2])
+        ymax = min(block_size[1], chunk.shape[2] - y * block_size[1])
+        xmax = min(block_size[0], chunk.shape[3] - x * block_size[0])
+        chunk[
+            channel,
+            z*block_size[2] : (z+1)*block_size[2],
+            y*block_size[1] : (y+1)*block_size[1],
+            x*block_size[0] : (x+1)*block_size[0]
+        ] = block[:zmax, :ymax, :xmax]
+
+
+def _unpack_encoded_values(packed_values, bits, num_values):
+    if bits == 0:
+        return np.zeros(num_values, dtype="<I")
+    else:
+        bitmask = (1 << bits) - 1
+        values_per_32bit = 32 // bits
+        padded_values = np.empty(
+            values_per_32bit * ceil_div(num_values, values_per_32bit),
+            dtype="<I")
+        for shift in range(values_per_32bit):
+            padded_values[shift::values_per_32bit] = (
+                (packed_values >> (shift * bits)) & bitmask)
+        return padded_values[:num_values]
+
+
+# MIT License
+
+# Copyright (c) 2016 Forschungszentrum Juelich GmbH
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/cloudvolume/compressed_segmentation.py
+++ b/cloudvolume/compressed_segmentation.py
@@ -134,6 +134,7 @@ def decode_chunk_into(chunk, buf, block_size):
     gz = ceil_div(chunk.shape[1], block_size[2])
 
     if len(buf) < num_channels * (4 + 8 * gx * gy * gz):
+        print(gx,gy,gz,len(buf),num_channels)
         raise InvalidFormatError("compressed_segmentation file too short")
 
     channel_offsets = [

--- a/cloudvolume/compression.py
+++ b/cloudvolume/compression.py
@@ -1,6 +1,7 @@
 from six import StringIO, BytesIO
 
 import gzip
+import sys
 
 class DecodingError(Exception):
   pass
@@ -56,6 +57,10 @@ def compress(content, method='gzip'):
 def gzip_compress(content):
   stringio = BytesIO()
   gzip_obj = gzip.GzipFile(mode='wb', fileobj=stringio)
+
+  if sys.version_info < (3,):
+    content = str(content)
+
   gzip_obj.write(content)
   gzip_obj.close()
   return stringio.getvalue()

--- a/cloudvolume/txrx.py
+++ b/cloudvolume/txrx.py
@@ -178,7 +178,11 @@ def decode(vol, filename, content):
 
   try:
     return chunks.decode(
-      content, vol.encoding, shape, vol.dtype, vol.compressed_segmentation_block_size
+      content, 
+      encoding=vol.encoding, 
+      shape=shape, 
+      dtype=vol.dtype, 
+      block_size=vol.compressed_segmentation_block_size,
     )
   except Exception as error:
     print(red('File Read Error: {} bytes, {}, {}, errors: {}'.format(

--- a/cloudvolume/txrx.py
+++ b/cloudvolume/txrx.py
@@ -178,7 +178,7 @@ def decode(vol, filename, content):
 
   try:
     return chunks.decode(
-      content, vol.encoding, shape, vol.dtype
+      content, vol.encoding, shape, vol.dtype, vol.compressed_segmentation_block_size
     )
   except Exception as error:
     print(red('File Read Error: {} bytes, {}, {}, errors: {}'.format(
@@ -318,7 +318,7 @@ def upload_chunks(vol, iterator, n_threads=DEFAULT_THREADS):
     )
 
     cloudpath = os.path.join(vol.key, filename)
-    encoded = chunks.encode(imgchunk, vol.encoding)
+    encoded = chunks.encode(imgchunk, vol.encoding, vol.compressed_segmentation_block_size)
 
     cloudstorage.put_file(
       file_path=cloudpath, 

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -276,6 +276,20 @@ def test_writer_last_chunk_smaller():
     assert np.array_equal(ept, (100,64,64))
     assert img.shape == (36,64,64,1)
 
+def test_write_compressed_segmentation():
+    delete_layer()
+    cv, data = create_layer(size=(128,64,64,1), offset=(0,0,0))
+
+    cv.info['data_type'] = 'uint32'
+    cv.scale['encoding'] = 'compressed_segmentation'
+    cv.scale['compressed_segmentation_block_size'] = (8,8,8)
+    cv.commit_info()
+
+    cv[:] = data.astype(np.uint32)
+    data2 = cv[:]
+
+    assert np.all(data == data2)
+
 # def test_reader_negative_indexing():
 #     """negative indexing is supported"""
 #     delete_layer()

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -290,6 +290,14 @@ def test_write_compressed_segmentation():
 
     assert np.all(data == data2)
 
+    cv.info['data_type'] = 'uint64'
+    cv.commit_info()
+
+    cv[:] = data.astype(np.uint64)
+    data2 = cv[:]
+    
+    assert np.all(data == data2)
+
 # def test_reader_negative_indexing():
 #     """negative indexing is supported"""
 #     delete_layer()


### PR DESCRIPTION
compressed_segmentation is a format invented by JBMS for use with neuroglancer. It takes labels e.g. uint64s and renumbers the voxels inside to smaller numbers so that storage takes less space while affording random access. In tests, it typically comes out smaller than merely gzipped segmentation.

https://github.com/google/neuroglancer/tree/master/src/neuroglancer/sliceview/compressed_segmentation

This PR introduces to CloudVolume a pure python encoder/decoder by Yann Leprince at HBP.
https://github.com/HumanBrainProject/neuroglancer-scripts/blob/master/src/neuroglancer_scripts/_compressed_segmentation.py

There is a C++ version due to Stephen Plaza at Janelia that might be worth integrating with Cython here: https://github.com/janelia-flyem/compressedseg

