### PR TITLE
feat: shared memory emulation using the filesystem for OSX

### DIFF
--- a/cloudvolume/sharedmemory.py
+++ b/cloudvolume/sharedmemory.py
@@ -1,15 +1,28 @@
 import errno
 import mmap
 import os
+import sys
 
+import multiprocessing as mp
+
+from six.moves import range
 import posix_ipc
 from posix_ipc import O_CREAT
 import numpy as np
 import psutil
 
-from .lib import Bbox, Vec
+import time
+
+from .lib import Bbox, Vec, mkdir
 
 mmaps = []
+
+SHM_DIRECTORY = '/dev/shm/'
+OSX_SHM_DIRECTORY = '/tmp/cloudvolume-shm'
+
+PLATFORM_SHM_DIRECTORY = SHM_DIRECTORY
+if sys.platform == 'darwin':
+  PLATFORM_SHM_DIRECTORY = OSX_SHM_DIRECTORY
 
 class MemoryAllocationError(Exception):
   pass
@@ -19,17 +32,48 @@ def reinit():
   global mmaps
   mmaps = []
 
-def bbox2array(vol, bbox):
+def bbox2array(vol, bbox, lock=None):
   shape = list(bbox.size3()) + [ vol.num_channels ]
-  return ndarray(shape=shape, dtype=vol.dtype, location=vol.shared_memory_id)
+  return ndarray(shape=shape, dtype=vol.dtype, location=vol.shared_memory_id, lock=lock)
 
-def ndarray(shape, dtype, location):
+def ndarray(shape, dtype, location, lock=None):
+  # OS X has problems with shared memory so 
+  # emulate it using a file on disk
+  if sys.platform == 'darwin':
+    return ndarray_fs(shape, dtype, location, lock)
+  return ndarray_shm(shape, dtype, location)
+
+def ndarray_fs(shape, dtype, location, lock):
+  nbytes = Vec(*shape).rectVolume() * np.dtype(dtype).itemsize
+  block = 10 * 1024 * 1024 # 10 MiB
+  directory = mkdir(OSX_SHM_DIRECTORY)
+  filename = os.path.join(directory, location)
+
+  if lock:
+    lock.acquire(timeout=2)
+
+  if not os.path.exists(filename):
+    zeros = np.zeros(shape=shape, dtype=dtype)
+    with open(filename, 'wb') as f:
+      f.write(zeros.tostring('F'))
+    del zeros
+
+  if lock:
+    lock.release()
+
+  with open(filename, 'r+b') as f:
+    array_like = mmap.mmap(f.fileno(), 0) # map entire file
+  
+  renderbuffer = np.ndarray(buffer=array_like, dtype=dtype, shape=shape)
+  return array_like, renderbuffer
+
+def ndarray_shm(shape, dtype, location):
   nbytes = Vec(*shape).rectVolume() * np.dtype(dtype).itemsize
   available = psutil.virtual_memory().available
 
   preexisting = 0
   # This might only work on Ubuntu
-  shmloc = os.path.join('/dev/shm/', location)
+  shmloc = os.path.join(SHM_DIRECTORY, location)
   if os.path.exists(shmloc):
     preexisting = os.path.getsize(shmloc)
 
@@ -77,6 +121,15 @@ def cleanup():
   mmaps = []
 
 def unlink(location):
+  if sys.platform == 'darwin':
+    directory = mkdir(OSX_SHM_DIRECTORY)
+    try:
+      filename = os.path.join(directory, location)
+      os.unlink(filename)
+      return True
+    except OSError:
+      return False
+
   try:
     posix_ipc.unlink_shared_memory(location)
   except posix_ipc.ExistentialError:

--- a/test/test_sharedmemory.py
+++ b/test/test_sharedmemory.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import numpy as np
 import posix_ipc
@@ -17,14 +18,21 @@ def test_ndarray():
 	assert np.all(array[:] == 100)
 	array_like.close()
 
-	assert os.path.exists('/dev/shm/' + location)
-	assert os.path.getsize('/dev/shm/' + location) == 8
+	filename = os.path.join(shm.PLATFORM_SHM_DIRECTORY, location)
+
+	assert os.path.exists(filename)
+	assert os.path.getsize(filename) == 8
 
 	assert shm.unlink(location) == True
 	assert shm.unlink(location) == False
 
-	assert not os.path.exists('/dev/shm/' + location)
+	assert not os.path.exists(filename)
 
+	# OS X uses on disk emulation
+	# no point in testing based on available memory
+	if sys.platform == 'darwin':
+		return
+	
 	available = psutil.virtual_memory().available
 	array_like, array = shm.ndarray(shape=(available // 10,2,2), dtype=np.uint8, location=location)
 	array_like.close()


### PR DESCRIPTION
There were errors associated with shared memory allocation.

1) ValueError: The name is too long 
   OSX supports only smaller shared memory names (~25 characters?) and doesn't fit the UUID I was using.
2)  ValueError: The size is invalid or the memory is read-only

I couldn't find good documentation of how that system works. OS X also doesn't have easily viewable shared memory allocations like linux does at /dev/shm. Therefore, I emulated shared memory via files.

Linux will still use real shared memory. This is mainly so I can run pytest in peace.
