### PR TITLE
perf: use fortran order internally in numpy arrays

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,12 @@
 CHANGES
 =======
 
+0.17.0
+------
+
+* Version 0.17.0
+* feat: parallel uploads (#98)
+
 0.16.0
 ------
 

--- a/cloudvolume/chunks.py
+++ b/cloudvolume/chunks.py
@@ -99,14 +99,14 @@ def decode_npz(string):
     fileobj = io.BytesIO(zlib.decompress(string))
     return np.load(fileobj)
 
-def decode_jpeg(bytestring, shape=(64,64,64), dtype=np.uint8):
+def decode_jpeg(bytestring, shape, dtype):
     img = Image.open(io.BytesIO(bytestring))
     data = np.array(img.getdata(), dtype=dtype)
 
-    return data.reshape(shape[::-1]).T
+    return data.reshape(shape, order='F')
 
-def decode_raw(bytestring, shape=(64,64,64), dtype=np.uint32):
-    return np.frombuffer(bytestring, dtype=dtype).reshape(shape[::-1]).T
+def decode_raw(bytestring, shape, dtype):
+    return np.frombuffer(bytestring, dtype=dtype).reshape(shape, order='F')
 
 def decode_compressed_segmentation(bytestring, shape, dtype, block_size):
     assert block_size is not None

--- a/cloudvolume/sharedmemory.py
+++ b/cloudvolume/sharedmemory.py
@@ -105,7 +105,7 @@ def ndarray_fs(shape, dtype, location, lock):
   with open(filename, 'r+b') as f:
     array_like = mmap.mmap(f.fileno(), 0) # map entire file
   
-  renderbuffer = np.ndarray(buffer=array_like, dtype=dtype, shape=shape)
+  renderbuffer = np.ndarray(buffer=array_like, dtype=dtype, shape=shape, order='F')
   return array_like, renderbuffer
 
 def ndarray_shm(shape, dtype, location):
@@ -142,7 +142,7 @@ def ndarray_shm(shape, dtype, location):
     shared = posix_ipc.SharedMemory(location, flags=O_CREAT, size=int(nbytes))
     array_like = mmap.mmap(shared.fd, shared.size)
     os.close(shared.fd)
-    renderbuffer = np.ndarray(buffer=array_like, dtype=dtype, shape=shape)
+    renderbuffer = np.ndarray(buffer=array_like, dtype=dtype, shape=shape, order='F')
   except OSError as err:
     if err.errno == errno.ENOMEM: # Out of Memory
       posix_ipc.unlink_shared_memory(location)      

--- a/cloudvolume/txrx.py
+++ b/cloudvolume/txrx.py
@@ -122,7 +122,7 @@ def cutout(vol, requested_bbox, steps, channel_slice=slice(None), parallel=1):
       array_like, renderbuffer = shm.bbox2array(vol, requested_bbox, lock=fs_lock)
       shm.track_mmap(array_like)
     else:
-      renderbuffer = np.zeros(shape=shape, dtype=vol.dtype)
+      renderbuffer = np.zeros(shape=shape, dtype=vol.dtype, order='F')
 
     def process(img3d, bbox):
       shade(renderbuffer, requested_bbox, img3d, bbox)

--- a/cloudvolume/volumecutout.py
+++ b/cloudvolume/volumecutout.py
@@ -10,7 +10,7 @@ from .lib import mkdir
 class VolumeCutout(np.ndarray):
 
   def __new__(cls, buf, dataset_name, layer, mip, layer_type, bounds, handle, *args, **kwargs):
-    return super(VolumeCutout, cls).__new__(cls, shape=buf.shape, buffer=np.ascontiguousarray(buf), dtype=buf.dtype)
+    return super(VolumeCutout, cls).__new__(cls, shape=buf.shape, buffer=np.asfortranarray(buf), dtype=buf.dtype, order='F')
 
   def __init__(self, buf, dataset_name, layer, mip, layer_type, bounds, handle, *args, **kwargs):
     super(VolumeCutout, self).__init__()


### PR DESCRIPTION
This matches the underlying data in the cloud and how Julia and other languages interfacing with CV expects it anyway.