### PR TITLE
feat: upload from shared memory

### DIFF
--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -896,8 +896,8 @@ class CloudVolume(object):
 
     delta_box = cutout_bbox.clone() - bbox.minpt
     cutout_image = shared_image[ delta_box.to_slices() ]
-
-    txrx.upload_image(self, shared_image, cutout_bbox.minpt, parallel=self.parallel, 
+    
+    txrx.upload_image(self, cutout_image, cutout_bbox.minpt, parallel=self.parallel, 
       manual_shared_memory_id=location, manual_shared_memory_bbox=bbox)
     mmap_handle.close() 
 

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -833,7 +833,73 @@ class CloudVolume(object):
     if self.path.protocol == 'boss':
       self.upload_boss_image(img, bbox.minpt)
     else:
-      txrx.upload_image(self, img, bbox.minpt)
+      txrx.upload_image(self, img, bbox.minpt, parallel=self.parallel)
+
+  def upload_from_shared_memory(self, location, bbox, cutout_bbox=None):
+    """
+    Upload from a shared memory array. 
+
+    MEMORY LIFECYCLE WARNING: You are responsible for managing the lifecycle of the 
+      shared memory. CloudVolume will merely read from it, it will not unlink the 
+      memory automatically. To fully clear the shared memory you must unlink the 
+      location and close any mmap file handles. You can use `cloudvolume.sharedmemory.unlink(...)`
+      to help you unlink the shared memory file.
+
+    EXPERT MODE WARNING: If you aren't sure you need this function (e.g. to relieve 
+      memory pressure or improve performance in some way) you should use the ordinary 
+      upload method of vol[:] = img. A typical use case it transferring arrays between 
+      different processes without making copies. For reference, this feature was created
+      for uploading a 62 GB array that originated in Julia.
+
+    Required:
+      location: (str) Shared memory location e.g. 'cloudvolume-shm-RANDOM-STRING'
+        This typically corresponds to a file in `/dev/shm` or `/run/shm/`. It can 
+        also be a file if you're using that for mmap.
+      bbox: (Bbox or list of slices) the bounding box the shared array represents. For instance
+        if you have a 1024x1024x128 volume and you're uploading only a 512x512x64 corner
+        touching the origin, your Bbox would be `Bbox( (0,0,0), (512,512,64) )`.
+    Optional:
+      cutout_bbox: (bbox or list of slices) If you only want to upload a section of the
+        array, give the bbox in volume coordinates (not image coordinates) that should 
+        be cut out. For example, if you only want to upload 256x256x32 of the upper 
+        rightmost corner of the above example but the entire 512x512x64 array is stored 
+        in memory, you would provide: `Bbox( (256, 256, 32), (512, 512, 64) )`
+
+        By default, just upload the entire image.
+
+    Returns: void
+    """
+    def tobbox(x):
+      if type(x) == Bbox:
+        return x 
+      return Bbox.from_slices(x)
+        
+    bbox = tobbox(bbox)
+    cutout_bbox = tobbox(cutout_bbox) if cutout_bbox else bbox.clone()
+
+    if not bbox.contains_bbox(cutout_bbox):
+      raise IndexError("""
+        The provided cutout is not wholly contained in the given array. 
+        Bbox:        {}
+        Cutout:      {}
+      """.format(bbox, cutout_bbox))
+
+    if self.autocrop:
+      cutout_bbox = Bbox.intersection(cutout_bbox, self.bounds)
+
+    if cutout_bbox.volume() < 1:
+      return
+
+    shape = list(bbox.size3()) + [ self.num_channels ]
+    mmap_handle, shared_image = sharedmemory.ndarray(
+      location=location, shape=shape, dtype=self.dtype, readonly=True)
+
+    delta_box = cutout_bbox.clone() - bbox.minpt
+    cutout_image = shared_image[ delta_box.to_slices() ]
+
+    txrx.upload_image(self, shared_image, cutout_bbox.minpt, parallel=self.parallel, 
+      manual_shared_memory_id=location, manual_shared_memory_bbox=bbox)
+    mmap_handle.close() 
 
   def upload_boss_image(self, img, offset):
     shape = Vec(*img.shape[:3])

--- a/cloudvolume/sharedmemory.py
+++ b/cloudvolume/sharedmemory.py
@@ -120,6 +120,7 @@ def ndarray_fs(shape, dtype, location, lock, readonly=False, order='F', **kwargs
     array_like = mmap.mmap(f.fileno(), 0) # map entire file
   
   renderbuffer = np.ndarray(buffer=array_like, dtype=dtype, shape=shape, order=order, **kwargs)
+  renderbuffer.setflags(write=(not readonly))
   return array_like, renderbuffer
 
 def ndarray_shm(shape, dtype, location, readonly=False, order='F', **kwargs):
@@ -176,6 +177,7 @@ def ndarray_shm(shape, dtype, location, readonly=False, order='F', **kwargs):
       posix_ipc.unlink_shared_memory(location)      
     raise
 
+  renderbuffer.setflags(write=(not readonly))
   return array_like, renderbuffer
 
 def track_mmap(array_like):

--- a/cloudvolume/sharedmemory.py
+++ b/cloudvolume/sharedmemory.py
@@ -24,8 +24,10 @@ EMULATED_SHM_DIRECTORY = '/tmp/cloudvolume-shm'
 EMULATE_SHM = not os.path.isdir(SHM_DIRECTORY)
 PLATFORM_SHM_DIRECTORY = SHM_DIRECTORY if not EMULATE_SHM else EMULATED_SHM_DIRECTORY
 
+class SharedMemoryReadError(Exception):
+  pass
 
-class MemoryAllocationError(Exception):
+class SharedMemoryAllocationError(Exception):
   pass
 
 def reinit():
@@ -41,7 +43,7 @@ def bbox2array(vol, bbox, order='F', lock=None):
   shape = list(bbox.size3()) + [ vol.num_channels ]
   return ndarray(shape=shape, dtype=vol.dtype, location=vol.shared_memory_id, lock=lock, order=order)
 
-def ndarray(shape, dtype, location, order='F', lock=None, **kwargs):
+def ndarray(shape, dtype, location, order='F', readonly=False, lock=None, **kwargs):
   """
   Create a shared memory numpy array. 
   Lock is only necessary while doing multiprocessing on 
@@ -65,10 +67,10 @@ def ndarray(shape, dtype, location, order='F', lock=None, **kwargs):
   Returns: (mmap filehandle, shared ndarray)
   """
   if EMULATE_SHM:
-    return ndarray_fs(shape, dtype, location, lock, order, **kwargs)
-  return ndarray_shm(shape, dtype, location, order, **kwargs)
+    return ndarray_fs(shape, dtype, location, lock, readonly, order, **kwargs)
+  return ndarray_shm(shape, dtype, location, readonly, order, **kwargs)
 
-def ndarray_fs(shape, dtype, location, lock, order='F', **kwargs):
+def ndarray_fs(shape, dtype, location, lock, readonly=False, order='F', **kwargs):
   """Emulate shared memory using the filesystem."""
   dbytes = np.dtype(dtype).itemsize
   nbytes = Vec(*shape).rectVolume() * dbytes
@@ -78,8 +80,17 @@ def ndarray_fs(shape, dtype, location, lock, order='F', **kwargs):
   if lock:
     lock.acquire()
 
-  if os.path.exists(filename): 
-    size = os.path.getsize(filename)
+  exists = os.path.exists(filename)
+  size = 0 if not exists else os.path.getsize(filename)
+
+  if readonly and not exists:
+    raise SharedMemoryReadError(filename + " has not been allocated. Requested " + str(nbytes) + " bytes.")
+  elif readonly and size != nbytes:
+    raise SharedMemoryReadError("{} exists, but the allocation size ({} bytes) does not match the request ({} bytes).".format(
+      filename, size, nbytes
+    ))
+
+  if exists: 
     if size > nbytes:
       with open(filename, 'wb') as f:
         os.ftruncate(f.fileno(), nbytes)
@@ -89,7 +100,9 @@ def ndarray_fs(shape, dtype, location, lock, order='F', **kwargs):
       # we could just append zeros
       os.unlink(filename) 
 
-  if not os.path.exists(filename):
+  exists = os.path.exists(filename)
+
+  if not exists:
     blocksize = 1024 * 1024 * 10 * dbytes
     steps = int(math.ceil(float(nbytes) / float(blocksize)))
     total = 0
@@ -108,8 +121,8 @@ def ndarray_fs(shape, dtype, location, lock, order='F', **kwargs):
   renderbuffer = np.ndarray(buffer=array_like, dtype=dtype, shape=shape, order=order, **kwargs)
   return array_like, renderbuffer
 
-def ndarray_shm(shape, dtype, location, order='F', **kwargs):
-  """Create a shared memory numpy array. Requires """
+def ndarray_shm(shape, dtype, location, readonly=False, order='F', **kwargs):
+  """Create a shared memory numpy array. Requires /dev/shm to exist."""
   nbytes = Vec(*shape).rectVolume() * np.dtype(dtype).itemsize
   available = psutil.virtual_memory().available
 
@@ -118,11 +131,18 @@ def ndarray_shm(shape, dtype, location, order='F', **kwargs):
   shmloc = os.path.join(SHM_DIRECTORY, location)
   if os.path.exists(shmloc):
     preexisting = os.path.getsize(shmloc)
+  elif readonly:
+    raise SharedMemoryReadError(shmloc + " has not been allocated. Requested " + str(nbytes) + " bytes.")
+
+  if readonly and preexisting != nbytes:
+    raise SharedMemoryReadError("{} exists, but the allocation size ({} bytes) does not match the request ({} bytes).".format(
+      shmloc, preexisting, nbytes
+    ))
 
   if (nbytes - preexisting) > available:
     overallocated = nbytes - preexisting - available
     overpercent = (100 * overallocated / (preexisting + available))
-    raise MemoryAllocationError("""
+    raise SharedMemoryAllocationError("""
       Requested more memory than is available. 
 
       Shared Memory Location:  {}
@@ -138,8 +158,15 @@ def ndarray_shm(shape, dtype, location, order='F', **kwargs):
       * Preexisting is only correct on linux systems that support /dev/shm/""" \
         .format(location, shape, nbytes, available, preexisting, overallocated, overpercent))
 
+  # This might seem like we're being "extra safe" but consider
+  # a threading condition where the condition of the shared memory
+  # was adjusted between the check above and now. Better to make sure
+  # that we don't accidently change anything if readonly is set.
+  flags = 0 if readonly else O_CREAT 
+  size = 0 if readonly else int(nbytes) 
+
   try:
-    shared = posix_ipc.SharedMemory(location, flags=O_CREAT, size=int(nbytes))
+    shared = posix_ipc.SharedMemory(location, flags=flags, size=size)
     array_like = mmap.mmap(shared.fd, shared.size)
     os.close(shared.fd)
     renderbuffer = np.ndarray(buffer=array_like, dtype=dtype, shape=shape, order=order, **kwargs)

--- a/cloudvolume/sharedmemory.py
+++ b/cloudvolume/sharedmemory.py
@@ -35,13 +35,14 @@ def reinit():
   global mmaps
   mmaps = []
 
-def bbox2array(vol, bbox, order='F', lock=None):
+def bbox2array(vol, bbox, order='F', readonly=False, lock=None):
   """Convenince method for creating a 
   shared memory numpy array based on a CloudVolume
   and Bbox. c.f. sharedmemory.ndarray for information
   on the optional lock parameter."""
   shape = list(bbox.size3()) + [ vol.num_channels ]
-  return ndarray(shape=shape, dtype=vol.dtype, location=vol.shared_memory_id, lock=lock, order=order)
+  return ndarray(shape=shape, dtype=vol.dtype, location=vol.shared_memory_id, 
+    readonly=readonly, lock=lock, order=order)
 
 def ndarray(shape, dtype, location, order='F', readonly=False, lock=None, **kwargs):
   """

--- a/cloudvolume/txrx.py
+++ b/cloudvolume/txrx.py
@@ -344,7 +344,12 @@ def multi_process_upload(vol, img_shape, offset, shared_memory_id, manual_shared
   global fs_lock
   reset_connection_pools()
   vol.init_submodules(caching)
-  array_like, renderbuffer = shm.ndarray(shape=img_shape, dtype=vol.dtype, 
+
+  shared_shape = img_shape
+  if manual_shared_memory_bbox:
+    shared_shape = list(manual_shared_memory_bbox.size3()) + [ vol.num_channels ]
+
+  array_like, renderbuffer = shm.ndarray(shape=shared_shape, dtype=vol.dtype, 
       location=shared_memory_id, lock=fs_lock, readonly=True)
 
   if manual_shared_memory_bbox:

--- a/cloudvolume/txrx.py
+++ b/cloudvolume/txrx.py
@@ -262,7 +262,8 @@ def check_grid_aligned(vol, img, offset):
   is_aligned = np.all(alignment_check.minpt == bounds.minpt) and np.all(alignment_check.maxpt == bounds.maxpt)
   return (is_aligned, bounds, alignment_check) 
 
-def upload_image(vol, img, offset):
+def upload_image(vol, img, offset, parallel=1, 
+  manual_shared_memory_id=None, manual_shared_memory_bbox=None):
   """Upload img to vol with offset. This is the primary entry point for uploads."""
   global NON_ALIGNED_WRITE
 
@@ -272,7 +273,8 @@ def upload_image(vol, img, offset):
   (is_aligned, bounds, expanded) = check_grid_aligned(vol, img, offset)
 
   if is_aligned:
-    upload_aligned(vol, img, offset)
+    upload_aligned(vol, img, offset, parallel=parallel, 
+      manual_shared_memory_id=manual_shared_memory_id, manual_shared_memory_bbox=manual_shared_memory_bbox)
     return
   elif vol.non_aligned_writes == False:
     msg = NON_ALIGNED_WRITE.format(offset=vol.voxel_offset, got=bounds, check=expanded)
@@ -282,7 +284,8 @@ def upload_image(vol, img, offset):
   retracted = bounds.shrink_to_chunk_size(vol.underlying, vol.voxel_offset)
   core_bbox = retracted.clone() - bounds.minpt
   core_img = img[ core_bbox.to_slices() ] 
-  upload_aligned(vol, core_img, retracted.minpt)
+  upload_aligned(vol, core_img, retracted.minpt, parallel=parallel, 
+    manual_shared_memory_id=manual_shared_memory_id, manual_shared_memory_bbox=manual_shared_memory_bbox)
 
   # Download the shell, paint, and upload
   all_chunks = set(chunknames(expanded, vol.bounds, vol.key, vol.underlying))
@@ -298,43 +301,57 @@ def upload_image(vol, img, offset):
 
   download_multiple(vol, shell_chunks, fn=shade_and_upload)
 
-def upload_aligned(vol, img, offset):
+def upload_aligned(vol, img, offset, parallel=1, 
+  manual_shared_memory_id=None, manual_shared_memory_bbox=None):
   global fs_lock
 
   chunk_ranges = list(generate_chunks(vol, img, offset))
 
-  if vol.parallel == 1:
+  if parallel == 1:
     single_process_upload(vol, img, chunk_ranges)
     return
 
-  length = (len(chunk_ranges) // vol.parallel) or 1
+  length = (len(chunk_ranges) // parallel) or 1
   chunk_ranges_by_process = []
   for i in range(0, len(chunk_ranges), length):
     chunk_ranges_by_process.append(
       chunk_ranges[i:i+length]
     )
 
-  array_like, renderbuffer = shm.ndarray(shape=img.shape, dtype=img.dtype, 
-      location=vol.shared_memory_id, lock=fs_lock)
-  renderbuffer[:] = img
+  if manual_shared_memory_id:
+    shared_memory_id = manual_shared_memory_id
+  else:
+    shared_memory_id = vol.shared_memory_id
+    array_like, renderbuffer = shm.ndarray(shape=img.shape, dtype=img.dtype, 
+      location=shared_memory_id, lock=fs_lock)
+    renderbuffer[:] = img
 
-  pool = mp.Pool(vol.parallel)
+  pool = mp.Pool(parallel)
   provenance = vol.provenance 
   vol.provenance = None
-  mpu = partial(multi_process_upload, vol, img.shape, vol.cache.enabled)
+  mpu = partial(multi_process_upload, vol, img.shape, offset, shared_memory_id, manual_shared_memory_bbox, vol.cache.enabled)
   pool.map(mpu, chunk_ranges_by_process)
   pool.close()
   vol.provenance = provenance
 
-  array_like.close()
-  shm.unlink(vol.shared_memory_id)
+  # If manual mode is enabled, it's the 
+  # responsibilty of the user to clean up
+  if not manual_shared_memory_id:
+    array_like.close()
+    shm.unlink(vol.shared_memory_id)
 
-def multi_process_upload(vol, img_shape, caching, chunk_ranges):
+def multi_process_upload(vol, img_shape, offset, shared_memory_id, manual_shared_memory_bbox, caching, chunk_ranges):
   global fs_lock
   reset_connection_pools()
   vol.init_submodules(caching)
   array_like, renderbuffer = shm.ndarray(shape=img_shape, dtype=vol.dtype, 
-      location=vol.shared_memory_id, lock=fs_lock)
+      location=shared_memory_id, lock=fs_lock)
+
+  if manual_shared_memory_bbox:
+    cutout_bbox = Bbox( offset, offset + img_shape[:3] )
+    delta_box = cutout_bbox.clone() - manual_shared_memory_bbox.minpt
+    renderbuffer = renderbuffer[ delta_box.to_slices() ]
+
   single_process_upload(vol, renderbuffer, chunk_ranges)
   array_like.close()
 

--- a/cloudvolume/txrx.py
+++ b/cloudvolume/txrx.py
@@ -345,7 +345,7 @@ def multi_process_upload(vol, img_shape, offset, shared_memory_id, manual_shared
   reset_connection_pools()
   vol.init_submodules(caching)
   array_like, renderbuffer = shm.ndarray(shape=img_shape, dtype=vol.dtype, 
-      location=shared_memory_id, lock=fs_lock)
+      location=shared_memory_id, lock=fs_lock, readonly=True)
 
   if manual_shared_memory_bbox:
     cutout_bbox = Bbox( offset, offset + img_shape[:3] )

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -10,6 +10,7 @@ import json
 
 from cloudvolume import CloudVolume, chunks, Storage
 from cloudvolume.lib import mkdir, Bbox, Vec
+import cloudvolume.sharedmemory as shm
 from layer_harness import (
     TEST_NUMBER, create_image, 
     delete_layer, create_layer,
@@ -94,6 +95,31 @@ def test_parallel_write():
     del data
     cv.unlink_shared_memory()
 
+def test_parallel_shared_memory_write():
+    delete_layer()
+    cv, data = create_layer(size=(256,256,128,1), offset=(0,0,0))
+
+    shm_location = 'cloudvolume-test-shm-parallel-write'
+    mmapfh, shareddata = shm.ndarray(shape=(256,256,128), dtype=np.uint8, location=shm_location)
+    shareddata[:] = 1
+
+    cv.parallel = 1
+    cv.upload_from_shared_memory(shm_location, Bbox((0,0,0), (256,256,128)))
+    assert np.all(cv[:] == 1)
+
+    shareddata[:] = 2
+    cv.parallel = 2
+    cv.upload_from_shared_memory(shm_location, Bbox((0,0,0), (256,256,128)))
+    assert np.all(cv[:] == 2)
+
+    shareddata[:,:,:64] = 3
+    cv.upload_from_shared_memory(shm_location, bbox=Bbox((0,0,0), (256,256,128)), 
+        cutout_bbox=Bbox((0,0,0), (256,256,64)))
+    assert np.all(cv[:,:,:64] == 3)    
+    assert np.all(cv[:,:,64:128] == 2)    
+
+    mmapfh.close()
+    shm.unlink(shm_location)
 
 def test_non_aligned_read():
     delete_layer()

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -118,6 +118,14 @@ def test_parallel_shared_memory_write():
     assert np.all(cv[:,:,:64] == 3)    
     assert np.all(cv[:,:,64:128] == 2)    
 
+    shareddata[:,:,:69] = 4
+    cv.autocrop = True
+    cv.upload_from_shared_memory(shm_location, bbox=Bbox((-5,-5,-5), (251,251,123)), 
+        cutout_bbox=Bbox((-5,-5,-5), (128,128,64)))
+    assert np.all(cv[:128,:128,:63] == 4)    
+    assert np.all(cv[128:,128:,:64] == 3)    
+    assert np.all(cv[:,:,64:128] == 2)    
+
     mmapfh.close()
     shm.unlink(shm_location)
 

--- a/test/test_sharedmemory.py
+++ b/test/test_sharedmemory.py
@@ -26,6 +26,22 @@ def test_ndarray_fs():
 	assert shm.unlink_fs(location) == True
 	assert shm.unlink_fs(location) == False
 
+	try:
+		array_like, array = shm.ndarray_fs(shape=(2,2,2), dtype=np.uint8, location=location, lock=None, readonly=True)
+		assert False
+	except shm.SharedMemoryReadError:
+		pass
+
+	array_like, array = shm.ndarray_fs(shape=(2,2,2), dtype=np.uint8, location=location, lock=None)
+	try:
+		array_like, array = shm.ndarray_fs(shape=(200,200,200), dtype=np.uint8, location=location, lock=None, readonly=True)
+		assert False
+	except shm.SharedMemoryReadError:
+		pass
+
+	assert shm.unlink_fs(location) == True
+	assert shm.unlink_fs(location) == False
+
 	assert not os.path.exists(filename)
 
 def test_ndarray_sh():
@@ -59,7 +75,23 @@ def test_ndarray_sh():
 	try:
 		array_like, array = shm.ndarray_shm(shape=(available,2,2), dtype=np.uint8, location=location)
 		assert False
-	except shm.MemoryAllocationError:
+	except shm.SharedMemoryAllocationError:
+		pass
+
+	assert shm.unlink_shm(location) == True
+	assert shm.unlink_shm(location) == False
+
+	try:
+		array_like, array = shm.ndarray_shm(shape=(2,2,2), dtype=np.uint8, location=location, readonly=True)
+		assert False
+	except shm.SharedMemoryReadError:
+		pass
+
+	array_like, array = shm.ndarray_shm(shape=(2,2,2), dtype=np.uint8, location=location)
+	try:
+		array_like, array = shm.ndarray_shm(shape=(200,200,200), dtype=np.uint8, location=location, readonly=True)
+		assert False
+	except shm.SharedMemoryReadError:
 		pass
 
 	assert shm.unlink_shm(location) == True


### PR DESCRIPTION
Adds the ability to upload from shared memory. The comment says it best:

```  
def upload_from_shared_memory(self, location, bbox, cutout_bbox=None):
    """
    Upload from a shared memory array. 

    MEMORY LIFECYCLE WARNING: You are responsible for managing the lifecycle of the 
      shared memory. CloudVolume will merely read from it, it will not unlink the 
      memory automatically. To fully clear the shared memory you must unlink the 
      location and close any mmap file handles. You can use `cloudvolume.sharedmemory.unlink(...)`
      to help you unlink the shared memory file.

    EXPERT MODE WARNING: If you aren't sure you need this function (e.g. to relieve 
      memory pressure or improve performance in some way) you should use the ordinary 
      upload method of vol[:] = img. A typical use case it transferring arrays between 
      different processes without making copies. For reference, this feature was created
      for uploading a 62 GB array that originated in Julia.

    Required:
      location: (str) Shared memory location e.g. 'cloudvolume-shm-RANDOM-STRING'
        This typically corresponds to a file in `/dev/shm` or `/run/shm/`. It can 
        also be a file if you're using that for mmap.
      bbox: (Bbox or list of slices) the bounding box the shared array represents. For instance
        if you have a 1024x1024x128 volume and you're uploading only a 512x512x64 corner
        touching the origin, your Bbox would be `Bbox( (0,0,0), (512,512,64) )`.
    Optional:
      cutout_bbox: (bbox or list of slices) If you only want to upload a section of the
        array, give the bbox in volume coordinates (not image coordinates) that should 
        be cut out. For example, if you only want to upload 256x256x32 of the upper 
        rightmost corner of the above example but the entire 512x512x64 array is stored 
        in memory, you would provide: `Bbox( (256, 256, 32), (512, 512, 64) )`

        By default, just upload the entire image.

    Returns: void
    """```