### PR TITLE
fix: tqdm race condition "AttributeError: 'tqdm' object has no attrib…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ protobuf>=3.3.0
 requests>=2.18.4
 six==1.10.0
 tenacity==4.4.0
-tqdm>=4.19.4
+-e git+https://github.com/seung-lab/tqdm.git#egg=tqdm
 urllib3[secure]


### PR DESCRIPTION
…ute 'pos'"

Use forked tqdm until PR is accepted.
https://github.com/tqdm/tqdm/pull/544

This is blocking @davidbuniat  and possibly @macrintr 