### PR TITLE
feat: supporting bucket specific secrets for aws and google

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,14 @@
 CHANGES
 =======
 
+0.19.1
+------
+
+* Version 0.19.1
+* fix: tqdm race condition "AttributeError: 'tqdm' object has no attribute 'pos'" (#104)
+* docs: updated benchmarks for test\_v0, mip 0, parallel 1
+* docs: fixed misspelling in comment
+
 0.19.0
 ------
 

--- a/cloudvolume/storage.py
+++ b/cloudvolume/storage.py
@@ -33,7 +33,7 @@ GC_POOL = None
 def reset_connection_pools():
     global S3_POOL
     global GC_POOL
-    S3_POOL = S3ConnectionPool()
+    S3_POOL = keydefaultdict(lambda bucket_name: S3ConnectionPool(bucket_name))
     GC_POOL = keydefaultdict(lambda bucket_name: GCloudBucketPool(bucket_name))
 
 reset_connection_pools()
@@ -596,7 +596,7 @@ class S3Interface(object):
     def __init__(self, path):
         global S3_POOL
         self._path = path
-        self._conn = S3_POOL.get_connection()
+        self._conn = S3_POOL[path.bucket].get_connection()
 
     def get_path_to_file(self, file_path):
         clean = filter(None,[self._path.intermediate_path,
@@ -715,7 +715,7 @@ class S3Interface(object):
 
     def release_connection(self):
         global S3_POOL
-        S3_POOL.release_connection(self._conn)
+        S3_POOL[self._path.bucket].release_connection(self._conn)
 
 def _radix_sort(L, i=0):
     """

--- a/test/test_connectionpools.py
+++ b/test/test_connectionpools.py
@@ -8,7 +8,7 @@ from cloudvolume.connectionpools import S3ConnectionPool, GCloudBucketPool
 from cloudvolume.threaded_queue import ThreadedQueue
 from cloudvolume.storage import Storage
 
-S3_POOL = S3ConnectionPool()
+S3_POOL = S3ConnectionPool('seunglab-test')
 GC_POOL = GCloudBucketPool('seunglab-test')
 
 retry = tenacity.retry(


### PR DESCRIPTION
To use, add a secret prefixed with the name of the bucket and a hyphen.
E.g. if your bucket is mybucket, your secret name would be
`mybucket-google-secret.json` or `mybucket-aws-secret.json`.

The logic will default to `google-secret.json` or `aws-secret.json`
if there is no specific bucket secret.

NEW: If no secret is provided at all, use default application credentials
for Google.

Resolves #105 and partially #35

It's easy to implement for AWS, but I'm not set up to test it.