### PR TITLE
fix: use concurrent.futures.ProcessPoolExecutor vs mp.Pool

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,12 @@
 CHANGES
 =======
 
+0.21.0
+------
+
+* Version 0.21.0
+* feat: Http(s) Storage interface
+
 0.20.2
 ------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 backports-abc==0.5
 boto3>=1.4.7
 chardet==3.0.4
+futures>=3.1.1
 google-auth>=1.0.2
 google-cloud==0.32.0
 -e git+https://github.com/seung-lab/intern.git#egg=intern


### PR DESCRIPTION
multiprocessing.Pool has a longstanding known bug where
childprocesses abruptly dying results in indefinite hanging.
This can happen e.g. if a child process exceeds the memory
limit and is killed by the OS violently.

As of Python 3.3, concurrent.futures.ProcessPoolExecutor should
raise a concurrent.futures.process.BrokenProcessPool under those
conditions.

https://docs.python.org/3/library/concurrent.futures.html