### PR TITLE
perf: 1x memory usage for parallel downloads

### DIFF
--- a/cloudvolume/txrx.py
+++ b/cloudvolume/txrx.py
@@ -100,11 +100,8 @@ def multi_process_cutout(vol, requested_bbox, cloudpaths, parallel,
 
   mmap_handle, renderbuffer = shm.bbox2array(vol, requested_bbox, lock=fs_lock, location=shared_memory_location)
   if not output_to_shared_memory:
-    renderbuffer = np.copy(renderbuffer)
-    mmap_handle.close()
     shm.unlink(vol.shared_memory_id)
-  else:
-    shm.track_mmap(mmap_handle)
+  shm.track_mmap(mmap_handle)
 
   return mmap_handle, renderbuffer
 


### PR DESCRIPTION
Previously, I was very conservative and wanted to ensure
that the usage of shared memory was completely invisible
to the end user of downloaded numpy arrays. However, this
required making a copy resulting in 2x memory usage.

I conducted some experiments showing that we can safely
avoid making this copy. Instead, we merely unlink the
shared memory. The memory region will remain accessible
so long as there is an open file descriptor to it. The FD
will be closed when the output VolumeCutout is garbage collected.

In all common use cases I have witnessed, this should result in
the transparent usage of shared memory without the concomitant
memory cost. In the case that a user fills an array with
thousands of VolumeCutouts, they have the option of making a
copy using np.copy and closing the file descriptors manually
or automatically.