### PR TITLE
feat: vol.skeleton for accessing Neuroglancer skeletons

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,16 @@ image = vol[:,:,:] # Download the entire image stack into a numpy array
 listing = vol.exists( np.s_[0:64, 0:128, 0:64] ) # get a report on which chunks actually exist
 listing = vol.delete( np.s_[0:64, 0:128, 0:64] ) # delete this region (bbox must be chunk aligned)
 vol[64:128, 64:128, 64:128] = image # Write a 64^3 image to the volume
+
+# Meshes
 vol.mesh.save(12345) # save 12345 as ./12345.obj
 vol.mesh.save([12345, 12346, 12347]) # merge three segments into one obj
 vol.mesh.get(12345) # return the mesh as vertices and faces instead of writing to disk
+
+# Skeletons
+skel = vol.skeleton.get(12345)
+vol.skeleton.upload(12345, skel.vertices, skel.edges) # upload neuroglancer visualization
+vol.get_point_cloud(12345) # download the object's point cloud
 
 # Parallel Operation
 vol = CloudVolume('gs://mybucket/retina/image', parallel=True) # Use all cores
@@ -223,6 +230,10 @@ Better documentation coming later, but for now, here's a summary of the most use
 * mesh - Access mesh operations
 	* get - Download an object. Can merge multiple segmentids
 	* save - Download an object and save it in `.obj` format. You can combine equivialences into a single object too.
+* skeleton - Access Skeletons
+  * get - Download an object.
+  * upload - Save a skeleton object to the cloud.
+  * get_point_cloud - Download the point cloud, a skeleton precursor, for an object. 
 * cache - Access cache operations
 	* enabled - Boolean switch to enable/disable cache. If true, on reading, check local disk cache before downloading, and save downloaded chunks to cache. When writing, write to the cloud then save the chunks you wrote to cache. If false, bypass cache completely. The cache is located at `$HOME/.cloudvolume/cache`.
 	* path - Property that shows the current filesystem path to the cache

--- a/cloudvolume/__init__.py
+++ b/cloudvolume/__init__.py
@@ -1,10 +1,11 @@
+from .connectionpools import ConnectionPool
 from .cloudvolume import CloudVolume
 from .provenance import DataLayerProvenance
-from .volumecutout import VolumeCutout
+from .skeletonservice import PrecomputedSkeleton
 from .storage import Storage
 from .threaded_queue import ThreadedQueue
-from .connectionpools import ConnectionPool
 from .txrx import EmptyVolumeException, EmptyRequestException, AlignmentError
+from .volumecutout import VolumeCutout
 
 from . import secrets
 from . import txrx

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -179,7 +179,11 @@ class CloudVolume(object):
       raise
       
   @classmethod
-  def create_new_info(cls, num_channels, layer_type, data_type, encoding, resolution, voxel_offset, volume_size, mesh=None, chunk_size=(64,64,64)):
+  def create_new_info(cls, 
+    num_channels, layer_type, data_type, encoding, 
+    resolution, voxel_offset, volume_size, 
+    mesh=None, skeletons=None, chunk_size=(64,64,64)
+  ):
     """
     Used for creating new neuroglancer info files.
 
@@ -194,6 +198,7 @@ class CloudVolume(object):
     
     Optional:
       mesh: (str) name of mesh directory, typically "mesh"
+      skeletons: (str) name of skeletons directory, typically "skeletons"
       chunk_size: int (x,y,z), dimensions of each downloadable 3D image chunk in voxels
 
     Returns: dict representing a single mip level that's JSON encodable
@@ -214,6 +219,9 @@ class CloudVolume(object):
 
     if mesh:
       info['mesh'] = 'mesh' if not isinstance(mesh, string_types) else mesh
+
+    if skeletons:
+      info['skeletons'] = 'skeletons' if not isinstance(mesh, string_types) else mesh      
 
     return info
 

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -29,6 +29,7 @@ from .lib import (
 )
 from .meshservice import PrecomputedMeshService
 from .provenance import DataLayerProvenance
+from .skeletonservice import PrecomputedSkeletonService
 from .storage import SimpleStorage, Storage
 from . import txrx
 from .volumecutout import VolumeCutout
@@ -154,7 +155,8 @@ class CloudVolume(object):
 
   def init_submodules(self, cache):
     self.cache = CacheService(cache, weakref.proxy(self)) 
-    self.mesh = PrecomputedMeshService(weakref.proxy(self)) 
+    self.mesh = PrecomputedMeshService(weakref.proxy(self))
+    self.skeleton = PrecomputedSkeletonService(weakref.proxy(self)) 
 
   def generate_shared_memory_location(self):
     return 'cloudvolume-shm-' + str(uuid.uuid4())

--- a/cloudvolume/lib.py
+++ b/cloudvolume/lib.py
@@ -372,6 +372,22 @@ class Bbox(object):
   def center(self):
     return (self.minpt + self.maxpt) / 2.0
 
+  def grow(self, amt):
+    assert amt >= 0
+    self.minpt -= amt
+    self.maxpt += amt
+    return self
+
+  def shrink(self, amt):
+    assert amt >= 0
+    self.minpt += amt
+    self.maxpt -= amt
+
+    if np.any(self.minpt > self.maxpt):
+      raise ValueError("Cannot shrink bbox below zero volume.")
+
+    return self
+
   def expand_to_chunk_size(self, chunk_size, offset=Vec(0,0,0, dtype=int)):
     """
     Align a potentially non-axis aligned bbox to the grid by growing it

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -58,7 +58,7 @@ class PrecomputedSkeleton(object):
     edgebuf = skelbuf[ estart : eend ]
 
     vertices = np.frombuffer(vertbuf, dtype='<f4').reshape( (num_vertices, 3) )
-    edges = np.frombuffer(vertbuf, dtype='<u4')
+    edges = np.frombuffer(vertbuf, dtype='<u4').reshape( (num_edges, 2) )
 
     return PrecomputedSkeleton(vertices, edges, segid=segid)
 

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -1,0 +1,88 @@
+import re
+import os
+
+try:
+  from StringIO import cStringIO as BytesIO
+except ImportError:
+  from io import BytesIO
+
+import numpy as np
+import struct
+
+from . import lib
+from .lib import red
+from .storage import Storage, SimpleStorage
+
+class PrecomputedSkeleton(object):
+  def __init__(self, vertices, edges, segid=None):
+    self.id = segid
+    self.vertices = vertices.astype(np.float32)
+    self.edges = edges.astype(np.uint32)
+
+  def encode(self):
+    edges = self.edges
+    vertices = self.vertices
+    
+    result = BytesIO()
+
+    # Write number of positions and edges as first two uint32s
+    result.write(struct.pack('<II', vertices.shape[0], edges.shape[0] // 2))
+    result.write(vertices.tobytes('C'))
+    result.write(edges.tobytes('C'))
+    return result.getvalue()
+
+  @classmethod
+  def decode(kls, skelbuf, segid=None):
+    num_vertices, num_edges = struct.unpack('<II', skelbuf[:8])
+
+    vstart = 2 * 4 # two uint32s in
+    vend = vstart + num_vertices * 3 * 4 # float32s
+    vertbuf = skelbuf[ vstart : vend ]
+
+    estart = vend + 1 
+    eend = estart + num_edges * 4 * 2 # 2x uint32s
+
+    edgebuf = skelbuf[ estart : eend ]
+
+    vertices = np.frombuffer(vertbuf, dtype='<f4').reshape( (num_vertices, 3) )
+    edges = np.frombuffer(vertbuf, dtype='<u4')
+
+    return PrecomputedSkeleton(vertices, edges, segid=segid)
+
+class PrecomputedSkeletonService(object):
+  def __init__(self, vol):
+    self.vol = vol
+
+  @property
+  def path(self):
+    path = 'skeletons'
+    if 'skeletons' in self.vol.info:
+      path = self.vol.info['skeletons']
+    return path
+
+  def get(self, segid):
+    with SimpleStorage(self.vol.layer_cloudpath) as stor:
+      path = os.path.join(self.path, str(segid))
+      skelbuf = stor.get_file(path)
+    return PrecomputedSkeleton.decode(skelbuf, segid=segid)
+
+  def save(self, segid, vertices, edges):
+    with SimpleStorage(self.vol.layer_cloudpath) as stor:
+      path = os.path.join(self.path, str(segid))
+      skel = PrecomputedSkeleton(vertices, edges, segid=segid).encode()
+      
+      stor.put_file(
+        file_path='{}/{}'.format(self.skeldir, segid),
+        content=skel,
+        compress='gzip',
+      )
+    
+  def point_cloud(self, segid):
+    with SimpleStorage(self.vol.layer_cloudpath) as stor:
+      path = os.path.join(self.path, '{}.ptc').format(segid)
+      buf = stor.get_file(path)
+    points = np.frombuffer(buf, dtype=np.int32) \
+      .reshape( (len(buf) // 3, 3) ) # xyz coordinate triplets
+    return points
+
+

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -29,7 +29,7 @@ class PrecomputedSkeleton(object):
     result = BytesIO()
 
     # Write number of positions and edges as first two uint32s
-    result.write(struct.pack('<II', vertices.shape[0], edges.shape[0] // 2))
+    result.write(struct.pack('<II', vertices.size // 3, edges.size // 2))
     result.write(vertices.tobytes('C'))
     result.write(edges.tobytes('C'))
     return result.getvalue()

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -40,7 +40,6 @@ class PrecomputedSkeleton(object):
       raise SkeletonDecodeError("{} bytes is fewer than needed to specify the number of verices and edges.".format(len(skelbuf)))
 
     num_vertices, num_edges = struct.unpack('<II', skelbuf[:8])
-
     format_length = 8 + 12 * num_vertices + 8 * num_edges
 
     if len(skelbuf) < format_length:
@@ -52,13 +51,13 @@ class PrecomputedSkeleton(object):
     vend = vstart + num_vertices * 3 * 4 # float32s
     vertbuf = skelbuf[ vstart : vend ]
 
-    estart = vend + 1 
+    estart = vend
     eend = estart + num_edges * 4 * 2 # 2x uint32s
 
     edgebuf = skelbuf[ estart : eend ]
 
     vertices = np.frombuffer(vertbuf, dtype='<f4').reshape( (num_vertices, 3) )
-    edges = np.frombuffer(vertbuf, dtype='<u4').reshape( (num_edges, 2) )
+    edges = np.frombuffer(edgebuf, dtype='<u4').reshape( (num_edges, 2) )
 
     return PrecomputedSkeleton(vertices, edges, segid=segid)
 
@@ -85,7 +84,7 @@ class PrecomputedSkeletonService(object):
       skel = PrecomputedSkeleton(vertices, edges, segid=segid).encode()
       
       stor.put_file(
-        file_path='{}/{}'.format(self.skeldir, segid),
+        file_path='{}/{}'.format(self.path, segid),
         content=skel,
         compress='gzip',
       )

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -19,9 +19,14 @@ class SkeletonDecodeError(Exception):
 class PrecomputedSkeleton(object):
   def __init__(self, vertices, edges, segid=None):
     self.id = segid
-    self.vertices = vertices.astype(np.float32)
-    self.edges = edges.astype(np.uint32)
 
+    self.vertices = vertices.astype(np.float32)
+
+    if edges is None:
+      self.edges = np.array([[]], dtype=np.uint32)
+    else:
+      self.edges = edges.astype(np.uint32)
+      
   def encode(self):
     edges = self.edges
     vertices = self.vertices

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -26,7 +26,7 @@ class PrecomputedSkeleton(object):
       self.edges = np.array([[]], dtype=np.uint32)
     else:
       self.edges = edges.astype(np.uint32)
-      
+
   def encode(self):
     edges = self.edges
     vertices = self.vertices
@@ -83,7 +83,7 @@ class PrecomputedSkeletonService(object):
       skelbuf = stor.get_file(path)
     return PrecomputedSkeleton.decode(skelbuf, segid=segid)
 
-  def save(self, segid, vertices, edges):
+  def upload(self, segid, vertices, edges):
     with SimpleStorage(self.vol.layer_cloudpath) as stor:
       path = os.path.join(self.path, str(segid))
       skel = PrecomputedSkeleton(vertices, edges, segid=segid).encode()
@@ -94,7 +94,7 @@ class PrecomputedSkeletonService(object):
         compress='gzip',
       )
     
-  def point_cloud(self, segid):
+  def get_point_cloud(self, segid):
     with SimpleStorage(self.vol.layer_cloudpath) as stor:
       path = os.path.join(self.path, '{}.ptc').format(segid)
       buf = stor.get_file(path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ python-jsonschema-objects==0.2.1
 Pillow>=4.2.1
 protobuf>=3.3.0
 requests>=2.18.4
-six==1.10.0
+six>=1.10.0
 tenacity==4.4.0
 -e git+https://github.com/seung-lab/tqdm.git#egg=tqdm
 urllib3[secure]

--- a/test/test_skeletons.py
+++ b/test/test_skeletons.py
@@ -60,7 +60,7 @@ def test_skeletons():
   ], dtype=np.uint32)
 
   vol = CloudVolume('file:///tmp/cloudvolume/test-skeletons', info=info)
-  vol.skeleton.save(segid=1, vertices=vertices, edges=edges)
+  vol.skeleton.upload(segid=1, vertices=vertices, edges=edges)
   skel = vol.skeleton.get(1)
 
   assert skel.id == 1
@@ -82,7 +82,7 @@ def test_no_edges():
 
   edges = None
   vol = CloudVolume('file:///tmp/cloudvolume/test-skeletons', info=info)
-  vol.skeleton.save(2, vertices, edges)
+  vol.skeleton.upload(2, vertices, edges)
   skel = vol.skeleton.get(2)
 
   assert skel.id == 2
@@ -100,14 +100,14 @@ def test_no_vertices():
 
   edges = None
   vol = CloudVolume('file:///tmp/cloudvolume/test-skeletons', info=info)
-  vol.skeleton.save(3, vertices, edges)
+  vol.skeleton.upload(3, vertices, edges)
   skel = vol.skeleton.get(3)
 
   assert skel.id == 3
   assert np.all(skel.vertices == vertices)
   assert np.all(skel.edges.shape == (0, 2))
   assert vol.skeleton.path == 'skeletons'
-  
+
   with SimpleStorage('file:///tmp/cloudvolume/test-skeletons/') as stor:
     rawskel = stor.get_file('skeletons/3')
     assert len(rawskel) == 8 + 0 * 12 + 0 * 8

--- a/test/test_skeletons.py
+++ b/test/test_skeletons.py
@@ -12,6 +12,18 @@ from cloudvolume import CloudVolume, chunks, Storage, PrecomputedSkeleton
 from cloudvolume.storage import SimpleStorage
 from cloudvolume.lib import mkdir, Bbox, Vec
 
+info = CloudVolume.create_new_info(
+  num_channels=1, # Increase this number when we add more tests for RGB
+  layer_type='segmentation', 
+  data_type='uint16', 
+  encoding='raw',
+  resolution=[1,1,1], 
+  voxel_offset=(0,0,0), 
+  skeletons=True,
+  volume_size=(100, 100, 100),
+  chunk_size=(64, 64, 64),
+)
+
 def test_skeletons():
   
   # Skeleton of my initials
@@ -47,20 +59,7 @@ def test_skeletons():
     [10, 11],
   ], dtype=np.uint32)
 
-  info = CloudVolume.create_new_info(
-    num_channels=1, # Increase this number when we add more tests for RGB
-    layer_type='segmentation', 
-    data_type='uint16', 
-    encoding='raw',
-    resolution=[1,1,1], 
-    voxel_offset=(0,0,0), 
-    skeletons=True,
-    volume_size=(100, 100, 100),
-    chunk_size=(64, 64, 64),
-  )
-
   vol = CloudVolume('file:///tmp/cloudvolume/test-skeletons', info=info)
-  vol.commit_info()
   vol.skeleton.save(segid=1, vertices=vertices, edges=edges)
   skel = vol.skeleton.get(1)
 
@@ -75,6 +74,41 @@ def test_skeletons():
     stor.delete_file('skeletons/1')
   
 
+def test_no_edges():
+  vertices = np.array([
+    [ 0, 1, 0 ],
+    [ 1, 0, 0 ],
+  ], np.float32)
+
+  edges = None
+  vol = CloudVolume('file:///tmp/cloudvolume/test-skeletons', info=info)
+  vol.skeleton.save(2, vertices, edges)
+  skel = vol.skeleton.get(2)
+
+  assert skel.id == 2
+  assert np.all(skel.vertices == vertices)
+  assert np.all(skel.edges.shape == (0, 2))
+  assert vol.skeleton.path == 'skeletons'
+
+  with SimpleStorage('file:///tmp/cloudvolume/test-skeletons/') as stor:
+    rawskel = stor.get_file('skeletons/2')
+    assert len(rawskel) == 8 + 2 * 12 + 0 * 8
+    stor.delete_file('skeletons/2')
+
+def test_no_vertices():
+  vertices = np.array([], np.float32).reshape(0,3)
+
+  edges = None
+  vol = CloudVolume('file:///tmp/cloudvolume/test-skeletons', info=info)
+  vol.skeleton.save(3, vertices, edges)
+  skel = vol.skeleton.get(3)
+
+  assert skel.id == 3
+  assert np.all(skel.vertices == vertices)
+  assert np.all(skel.edges.shape == (0, 2))
+  assert vol.skeleton.path == 'skeletons'
   
-
-
+  with SimpleStorage('file:///tmp/cloudvolume/test-skeletons/') as stor:
+    rawskel = stor.get_file('skeletons/3')
+    assert len(rawskel) == 8 + 0 * 12 + 0 * 8
+    stor.delete_file('skeletons/3')


### PR DESCRIPTION
**Neuroglancer Skeleton Format**

Filename: `$CLOUDPATH/skeletons/$SEGID`  

| Vertex Count (Nv) |  Edges Count (Ne)  |  Vertices           |  Edges         | 
|-------------------|--------------------|---------------------|----------------| 
| uint32            |  uint32            |  Nv x XYZ float32s  |  Ne x 2 uint32 | 
| 4 bytes          |  4 bytes          | Nv x 12 bytes          |  Ne x 8 bytes  |
