### PR TITLE
chore: upgrade tenacity to 4.10.0 for python 3.7 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ Pillow>=4.2.1
 protobuf>=3.3.0
 requests>=2.18.4
 six>=1.10.0
-tenacity==4.4.0
+tenacity==4.10.0
 -e git+https://github.com/seung-lab/tqdm.git#egg=tqdm
 urllib3[secure]


### PR DESCRIPTION
Resolves #124