### PR TITLE
chore(requirements.txt): replace deprecated google-cloud with google-cloud-storage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ backports-abc==0.5
 boto3>=1.4.7
 chardet==3.0.4
 google-auth>=1.0.2
-google-cloud==0.32.0
+google-cloud-storage>=1.10.0
 -e git+https://github.com/seung-lab/intern.git#egg=intern
 json5==0.5.1
 numpy>=1.13.3


### PR DESCRIPTION
See https://pypi.org/project/google-cloud/

Should get rid off all those related, confusing error messages:
>google-cloud-logging 1.4.0 has requirement google-api-core<0.2.0dev,>=0.1.1, but you'll have google-api-core 1.3.0 which is incompatible.
google-cloud-speech 0.30.0 has requirement google-api-core<0.2.0dev,>=0.1.1, but you'll have google-api-core 1.3.0 which is incompatible.
google-cloud-dns 0.28.0 has requirement google-api-core<0.2.0dev,>=0.1.1, but you'll have google-api-core 1.3.0 which is incompatible.
google-cloud-vision 0.29.0 has requirement google-api-core<0.2.0dev,>=0.1.0, but you'll have google-api-core 1.3.0 which is incompatible.
google-cloud-bigquery 0.28.0 has requirement google-api-core<0.2.0dev,>=0.1.1, but you'll have google-api-core 1.3.0 which is incompatible.
google-cloud-trace 0.17.0 has requirement google-api-core<0.2.0dev,>=0.1.1, but you'll have google-api-core 1.3.0 which is incompatible.
google-cloud-pubsub 0.30.1 has requirement google-api-core[grpc]<0.2.0dev,>=0.1.3, but you'll have google-api-core 1.3.0 which is incompatible.
google-cloud-bigtable 0.28.1 has requirement google-api-core<0.2.0dev,>=0.1.1, but you'll have google-api-core 1.3.0 which is incompatible.
google-cloud-datastore 1.4.0 has requirement google-api-core<0.2.0dev,>=0.1.1, but you'll have google-api-core 1.3.0 which is incompatible.
google-cloud-spanner 0.29.0 has requirement google-api-core<0.2.0dev,>=0.1.1, but you'll have google-api-core 1.3.0 which is incompatible.
google-cloud-error-reporting 0.28.0 has requirement google-api-core<0.2.0dev,>=0.1.1, but you'll have google-api-core 1.3.0 which is incompatible.
google-cloud-firestore 0.28.0 has requirement google-api-core<0.2.0dev,>=0.1.1, but you'll have google-api-core 1.3.0 which is incompatible.
google-cloud 0.32.0 has requirement google-api-core<0.2.0dev,>=0.1.2, but you'll have google-api-core 1.3.0 which is incompatible.
google-cloud 0.32.0 has requirement google-cloud-storage<1.7dev,>=1.6.0, but you'll have google-cloud-storage 1.10.0 which is incompatible.