### PR TITLE
feat: independent control of cache compression

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
 Jingpeng Wu <jingpeng.wu@gmail.com>
+Nico Kemnitz <nkemnitz@princeton.edu>
 Pat Gunn <pgunn01@gmail.com>
 Thomas Macrina <thomas.macrina@gmail.com>
 William Silversmith <william.silversmith@gmail.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,18 @@
 CHANGES
 =======
 
+0.27.1
+------
+
+* Version 0.27.1
+* chore(requirements.txt): replace deprecated google-cloud (#131)
+
+0.27.0
+------
+
+* Version 0.27.0
+* feat: bbox\_to\_mip (#127)
+
 0.26.3
 ------
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ vol.cache.num_bytes() # number of bytes taken up by files, size on disk can be b
 vol.cache.num_bytes(all_mips=True) # Return num bytes for each mip level in a list  
 
 vol.cache.enabled = True/False/Path # Turn the cache on/off 
+vol.cache.compress = None/True/False # None: Link to cloud setting, Boolean: Force cache to compressed (True) or uncompressed (False)
 
 # Deleting Cache
 vol.cache.flush() # Delete local cache for this layer at this mip level  

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ vol.cache.flush_provenance()
 ```python3
 CloudVolume(cloudpath, 
      mip=0, bounded=True, fill_missing=False, autocrop=False, 
-     cache=False, cdn_cache=False, progress=INTERACTIVE, info=None, 
+     cache=False, compress_cache=None, cdn_cache=False, progress=INTERACTIVE, info=None, 
      provenance=None, compress=None, non_aligned_writes=False, parallel=1)
 ```
 
@@ -219,6 +219,7 @@ CloudVolume(cloudpath,
 * bounded - Whether access is allowed outside the bounds defined in the info file
 * fill_missing - If a chunk is missing, should it be zero filled or throw an EmptyVolumeException? Note that under conditions of high load, it's possible for fill_missing to be activated for existing files. Set to false for extra safety.
 * cache - Save uploads/downloads to disk. You can also provide a string path instead of a boolean to specify a custom cache location.
+* compress_cache - Override default cache compression behavior if set to a boolean.
 * autocrop - If bounded is False, automatically crop requested uploads and downloads to the volume boundary.
 * cdn_cache - Set the HTTP Cache-Control header on uploaded image chunks.
 * progress - Show progress bars. Defaults to True if in python interactive mode else default False.

--- a/cloudvolume/__init__.py
+++ b/cloudvolume/__init__.py
@@ -10,4 +10,4 @@ from .volumecutout import VolumeCutout
 from . import secrets
 from . import txrx
 
-__version__ = '0.27.0'
+__version__ = '0.27.1'

--- a/cloudvolume/cacheservice.py
+++ b/cloudvolume/cacheservice.py
@@ -11,10 +11,11 @@ def warn(text):
   print(colorize('yellow', text))
 
 class CacheService(object):
-
+  
   def __init__(self, path_or_bool, vol):
     self.vol = vol
     self.enabled = path_or_bool # on/off or path (on)
+    self.compress = None # None = linked, bool = force
 
     self.initialize()
 

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -78,6 +78,7 @@ class CloudVolume(object):
         - falsey value: no caching will occur.
         - True: cache will be located in a standard location.
         - non-empty string: cache is located at this file path
+    compress_cache: (None or bool) If not None, override default compression behavior for the cache.
     cdn_cache: (int, bool, or str) Sets the Cache-Control HTTP header on uploaded image files.
       Most cloud providers perform some kind of caching. As of this writing, Google defaults to
       3600 seconds. Most of the time you'll want to go with the default. 
@@ -104,7 +105,7 @@ class CloudVolume(object):
       When not enabled, a ValueError is thrown for non-aligned writes.
   """
   def __init__(self, cloudpath, mip=0, bounded=True, autocrop=False, fill_missing=False, 
-      cache=False, cdn_cache=True, progress=INTERACTIVE, info=None, provenance=None, 
+      cache=False, compress_cache=None, cdn_cache=True, progress=INTERACTIVE, info=None, provenance=None, 
       compress=None, non_aligned_writes=False, parallel=1, output_to_shared_memory=False):
 
     self.autocrop = bool(autocrop)
@@ -133,6 +134,7 @@ class CloudVolume(object):
       raise ValueError('Number of processes must be >= 1. Got: ' + str(self.parallel))
 
     self.init_submodules(cache)
+    self.cache.compress = compress_cache
 
     if info is None:
       self.refresh_info()

--- a/cloudvolume/txrx.py
+++ b/cloudvolume/txrx.py
@@ -162,7 +162,7 @@ def download_single(vol, cloudpath, filename, cache):
         file_path=filename, 
         content=(content or b''), 
         content_type=content_type(vol), 
-        compress=should_compress(vol),
+        compress=should_compress(vol, iscache=True),
       )
 
   bbox = Bbox.from_filename(filename) # possible off by one error w/ exclusive bounds
@@ -241,7 +241,10 @@ def content_type(vol):
     return 'image/x.' + vol.encoding 
   return 'application/octet-stream'
 
-def should_compress(vol):
+def should_compress(vol, iscache=False):
+  if iscache and vol.cache.compress != None:
+    return vol.cache.compress
+
   if vol.compress is None:
     return 'gzip' if vol.encoding in ('raw', 'compressed_segmentation') else None
   elif vol.compress == True:
@@ -431,7 +434,7 @@ def single_process_upload(vol, img, chunk_ranges, n_threads=DEFAULT_THREADS):
         file_path=cloudpath,
         content=encoded, 
         content_type=content_type(vol), 
-        compress=should_compress(vol)
+        compress=should_compress(vol, iscache=True)
       )
 
   desc = 'Uploading' if vol.progress else None


### PR DESCRIPTION
@wongwill86 wanted faster cache access on disk which required
disabling cache compression independent of how we treat the
storage endpoint (where we'd like it compressed).

Resolves #130