### PR TITLE
feat: transfer_to implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ data = vol.download_to_shared_memory(np.s_[:], location='some-example')
 vol.unlink_shared_memory() # delete the shared memory associated with this cloudvolume
 vol.shared_memory_id # get/set the default shared memory location for this instance
 
+# Transfer w/o Excess Memory Allocation
+
+vol = CloudVolume(...)
+# single core, send all of vol to destination, no painting memory
+vol.transfer_to('gs://bucket/dataset/layer', vol.bounds) 
+
 # Shared Memory Upload
 vol = CloudVolume(...)
 vol.upload_from_shared_memory('my-shared-memory-id', # do not prefix with /dev/shm
@@ -265,6 +271,7 @@ Better documentation coming later, but for now, here's a summary of the most use
 	* flush_region - Delete a spatial region at this mip level
 * exists - Generate a report on which chunks within a bounding box exist.
 * delete - Delete the chunks within this bounding box.
+* transfer_to - Transfer data from a bounding box to another data storage location. Does not allocate memory and transfers in blocks, so can transfer large volumes of data. May be less efficient than a dedicated tool like `gsutil` or `aws s3`.
 * unlink_shared_memory - Delete shared memory associated with this instance (`vol.shared_memory_id`)
 * generate_shared_memory_location - Create a new unique shared memory identifier string. No side effects.
 * download_to_shared_memory - Instead of using ordinary numpy memory allocations, download to shared memory.

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -761,8 +761,9 @@ class CloudVolume(object):
     may be more appropriate. This method is provided for convenience. It
     may be optimized for better performance over time as demand requires.
 
-    
-
+    cloudpath (str): path to storage layer
+    bbox (Bbox object): ROI to transfer
+    block_size (int): number of file chunks to transfer per I/O batch.
     """
     if type(bbox) is Bbox:
       requested_bbox = bbox

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -802,7 +802,7 @@ class CloudVolume(object):
     num_blocks = int(np.ceil(num_blocks))
 
     cloudpaths = txrx.chunknames(realized_bbox, self.bounds, self.key, self.underlying)
-    
+
     pbar = tqdm(
       desc='Transferring Blocks of {} Chunks'.format(step), 
       unit='blocks', 
@@ -813,11 +813,12 @@ class CloudVolume(object):
     with pbar:
       with Storage(self.layer_cloudpath) as src_stor:
         with Storage(cloudpath) as dest_stor:
-          srcpaths = list(itertools.islice(cloudpaths, step))
-          files = src_stor.get_files(srcpaths)
-          files = [ (f['filename'], f['content']) for f in files ]
-          dest_stor.put_files(files)
-          pbar.update()
+          for _ in range(num_blocks, 0, -1):
+            srcpaths = list(itertools.islice(cloudpaths, step))
+            files = src_stor.get_files(srcpaths)
+            files = [ (f['filename'], f['content']) for f in files ]
+            dest_stor.put_files(files)
+            pbar.update()
 
 
   def __getitem__(self, slices):

--- a/cloudvolume/txrx.py
+++ b/cloudvolume/txrx.py
@@ -129,7 +129,7 @@ def cutout(vol, requested_bbox, steps, channel_slice=slice(None), parallel=1,
 
   cloudpath_bbox = requested_bbox.expand_to_chunk_size(vol.underlying, offset=vol.voxel_offset)
   cloudpath_bbox = Bbox.clamp(cloudpath_bbox, vol.bounds)
-  cloudpaths = chunknames(cloudpath_bbox, vol.bounds, vol.key, vol.underlying)
+  cloudpaths = list(chunknames(cloudpath_bbox, vol.bounds, vol.key, vol.underlying))
   shape = list(requested_bbox.size3()) + [ vol.num_channels ]
 
   handle = None
@@ -473,8 +473,6 @@ def generate_chunks(vol, img, offset):
     yield (startpt, endpt, spt, ept)
 
 def chunknames(bbox, volume_bbox, key, chunk_size):
-  paths = []
-
   for x,y,z in xyzrange( bbox.minpt, bbox.maxpt, chunk_size ):
     highpt = min2(Vec(x,y,z) + chunk_size, volume_bbox.maxpt)
     filename = "{}-{}_{}-{}_{}-{}".format(
@@ -482,6 +480,6 @@ def chunknames(bbox, volume_bbox, key, chunk_size):
       y, highpt.y, 
       z, highpt.z
     )
-    paths.append( os.path.join(key, filename) )
+    yield os.path.join(key, filename)
 
-  return paths
+

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -854,8 +854,6 @@ def test_transfer():
     assert os.path.exists('/tmp/removeme/transfer/provenance')
 
 
-
-
 def test_cdn_cache_control():
     delete_layer()
     cv, data = create_layer(size=(128,10,10,1), offset=(0,0,0))

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -838,6 +838,24 @@ def test_delete():
     else:
         assert False
 
+def test_transfer():
+    # Bbox version
+    delete_layer()
+    cv, data = create_layer(size=(128,64,64,1), offset=(0,0,0))
+
+    cv.transfer_to('file:///tmp/removeme/transfer/', cv.bounds)
+
+    ls = os.listdir('/tmp/removeme/transfer/1_1_1/')
+
+    assert '0-64_0-64_0-64' in ls
+    assert len(ls) == 2
+
+    assert os.path.exists('/tmp/removeme/transfer/info')
+    assert os.path.exists('/tmp/removeme/transfer/provenance')
+
+
+
+
 def test_cdn_cache_control():
     delete_layer()
     cv, data = create_layer(size=(128,10,10,1), offset=(0,0,0))


### PR DESCRIPTION
Transfer files from one storage to another while bypassing the
memory intensive painting process. This potentially allows for
the transmission of arbitrary sized volumes given an optimized
implementation of this concept.

TODO: don't decompress/recompress, parallel, don't generate all
  filenames up front.