### PR TITLE
Specifying mip level by voxel resolution

### DIFF
--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -462,13 +462,20 @@ class CloudVolume(object):
   def mip(self, mip):
     mip = list(mip) if isinstance(mip, collections.Iterable) else int(mip)
     try:
-      if isinstance(mip, list):
+      if isinstance(mip, list):  # mip specified by voxel resolution
         self._mip = next((i for (i,s) in enumerate(self.scales)
                           if s["resolution"] == mip))
-      else:
+      else:  # mip specified by index into downsampling hierarchy
         self._mip = self.available_mips[mip]
+
     except:
-      raise Exception("MIP {} has not been generated.".format(mip))
+      if isinstance(mip, list):
+        available = self.available_resolutions
+      else:
+        available = self.available_mips
+      available_str = ", ".join(map(str, available)) 
+      msg = "MIP {} not found. Available: {}".format(mip, available_str)
+      raise IndexError(msg)
 
   @property
   def scales(self):
@@ -530,6 +537,11 @@ class CloudVolume(object):
   def available_mips(self):
     """Returns a list of mip levels that are defined."""
     return range(len(self.info['scales']))
+
+  @property
+  def available_resolutions(self):
+    """Returns a list of defined resolutions."""
+    return (s["resolution"] for s in self.scales)
 
   @property
   def layer_type(self):

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -105,7 +105,7 @@ class CloudVolume(object):
     non_aligned_writes: (bool) Enable non-aligned writes. Not multiprocessing safe without careful design.
       When not enabled, a ValueError is thrown for non-aligned writes.
   """
-  def __init__(self, cloudpath, mip=0, bounded=True, autocrop=False, fill_missing=False, 
+  def __init__(self, cloudpath, mip=0, resolution=None, bounded=True, autocrop=False, fill_missing=False, 
       cache=False, compress_cache=None, cdn_cache=True, progress=INTERACTIVE, info=None, provenance=None, 
       compress=None, non_aligned_writes=False, parallel=1, output_to_shared_memory=False):
 
@@ -152,9 +152,15 @@ class CloudVolume(object):
       self.provenance = self._cast_provenance(provenance)
 
     try:
-      self.mip = self.available_mips[self.mip]
+      # Explicit voxel resolution takes priority
+      if resolution is not None:
+        self.mip = next((i for (i,s) in enumerate(self.scales)
+                         if s["resolution"] == list(resolution)))
+      else:
+        self.mip = self.available_mips[self.mip]
     except:
-      raise Exception("MIP {} has not been generated.".format(self.mip))
+      desc = resolution if resolution is not None else self.mip
+      raise Exception("MIP {} has not been generated.".format(desc))
 
     self.pid = os.getpid()
 


### PR DESCRIPTION
* Adds an argument to the cloud-volume initialization so that users can explicitly specify the desired voxel resolution instead of needing to coordinate with the info file. This performs a quick conversion to mip index within the `__init__` function, so the change should be otherwise invisible. 

All tests still pass aside from `test_boss_download` which I probably just haven't configured on my workstation. If there's an easy way to do this I can re-run the test, but it seems unrelated.