### PR TITLE
feat: cable_length, downsample, improved Consolidation, SWC file support, connected components

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,26 @@ vol.mesh.get(12345) # return the mesh as vertices and faces instead of writing t
 
 # Skeletons
 skel = vol.skeleton.get(12345)
-vol.skeleton.upload(12345, skel.vertices, skel.edges) # upload neuroglancer visualization
-vol.get_point_cloud(12345) # download the object's point cloud
+vol.skeleton.upload(segid, skel.vertices, skel.edges, skel.radii, skel.vertex_types) 
+vol.skeleton.upload_multiple([ ... skeletons ... ])
+
+skel.empty() # boolean
+
+bytes = skel.encode() # encode to Precomputed format (bytes)
+skel = PrecomputedSkeleton.decode(bytes) # decode from PrecomputedFormat
+
+skel = skel.crop(slices or bbox) # eliminate vertices and edges outside bbox
+skel = skel.consolidate() # eliminate duplicate vertices and edges
+skel3 = skel.merge(skel2) # merge two skeletons into one
+skel = skel.clone() # create copy
+skel = PrecomputedSkeleton.from_swc(swcstr) # decode an SWC file
+skel_str = skel.to_swc() # convert to SWC file in string representation
+
+skel.cable_length() # sum of all edge lengths
+skel = skel.downsample(2, preserve_endpoints=True) # reduce size of skeleton by factor of 2 while ensuring the endpoints aren't stripped
+
+skel1 == skel2 # check if contents of internal arrays match
+PrecomputedSkeleton.equivalent(skel1, skel2) # ...even if there are differences like differently numbered edges
 
 # Parallel Operation
 vol = CloudVolume('gs://mybucket/retina/image', parallel=True) # Use all cores

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -93,9 +93,9 @@ class CloudVolume(object):
             This is useful when creating new datasets.
     parallel (int: 1, bool): number of extra processes to launch, 1 means only use the main process. If parallel is True
       use the number of CPUs returned by multiprocessing.cpu_count()
-    output_to_shared_memory (bool: False, str): Write results to shared memory. Don't make copies from this buffer
+    output_to_shared_memory (deprecated, bool: False, str): Write results to shared memory. Don't make copies from this buffer
       and don't automatically unlink it. If a string is provided, use that shared memory location rather than
-      the default.
+      the default. Please use vol.download_to_shared_memory(slices_or_bbox) instead.
     provenance: (string, dict, or object) in lieu of fetching a neuroglancer provenance file, use this provided one.
             This is useful when doing multiprocessing.
     progress: (bool) Show tqdm progress bars. 

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -17,6 +17,8 @@ from .lib import red, Bbox
 from .txrx import cdn_cache_control
 from .storage import Storage, SimpleStorage
 
+class UnassignedEdgeError(Exception):
+  pass
 
 class SkeletonDecodeError(Exception):
   pass
@@ -329,7 +331,14 @@ class PrecomputedSkeleton(object):
     """
     dist = 0
     for e1, e2 in self.edges:
-      v1, v2 = self.vertices[e1], self.vertices[e2]
+      try:
+        v1, v2 = self.vertices[e1], self.vertices[e2]
+      except IndexError:
+        raise UnassignedEdgeError(
+          "Edge ({},{}) points to an index outside the number of vertices ({}).".format(
+            e1, e2, self.vertices.shape[0]
+          )
+        )
       dist += np.linalg.norm(v2 - v1)
 
     return dist

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -370,6 +370,9 @@ class PrecomputedSkeleton(object):
 
       root = np.argmax([ len(_) for _ in paths ])
       root = paths[root][-1]
+    else:
+      match = np.abs(self.vertices - np.array(root, dtype=np.float32)) < 1e-7
+      root = np.where(match.all(axis=1))[0][0]
 
     paths = dfs([ root ], defaultdict(bool), [])
     

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -17,7 +17,7 @@ from .lib import red, Bbox
 from .txrx import cdn_cache_control
 from .storage import Storage, SimpleStorage
 
-class UnassignedEdgeError(Exception):
+class SkeletonUnassignedEdgeError(Exception):
   pass
 
 class SkeletonDecodeError(Exception):
@@ -334,7 +334,7 @@ class PrecomputedSkeleton(object):
       try:
         v1, v2 = self.vertices[e1], self.vertices[e2]
       except IndexError:
-        raise UnassignedEdgeError(
+        raise SkeletonUnassignedEdgeError(
           "Edge ({},{}) points to an index outside the number of vertices ({}).".format(
             e1, e2, self.vertices.shape[0]
           )

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -370,6 +370,7 @@ class PrecomputedSkeleton(object):
     ds_skel = PrecomputedSkeleton.simple_merge(
       [ PrecomputedSkeleton.from_path(path) for path in paths ]
     ).consolidate()
+    ds_skel.id = self.id
 
     # TODO: I'm sure this could be sped up if need be.
     index = {}

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -304,6 +304,7 @@ class PrecomputedSkeleton(object):
     eff_edges = np.sort(eff_edges, axis=1) # sort each edge [2,1] => [1,2]
     eff_edges = eff_edges[np.lexsort(eff_edges[:,::-1].T)] # Sort rows 
     eff_edges = np.unique(eff_edges, axis=0)
+    eff_edges = eff_edges[ eff_edges[:,0] != eff_edges[:,1] ] # remove trivial loops
 
     radii_vector_map = np.vectorize(lambda idx: radii[idx])
     eff_radii = radii_vector_map(uniq_idx)

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -333,7 +333,7 @@ class PrecomputedSkeleton(object):
 
     return dist
 
-  def paths(self):
+  def paths(self, root=None):
     """
     Assuming the skeleton is structured as a single tree, return a 
     list of all traversal paths. We start from the first 
@@ -364,12 +364,14 @@ class PrecomputedSkeleton(object):
 
       return paths
 
-    root = skel.edges[0,0]
-    paths = dfs([root], defaultdict(bool), [])
+    if root is None:
+      root = skel.edges[0,0]
+      paths = dfs([root], defaultdict(bool), [])
 
-    new_root = np.argmax([ len(_) for _ in paths ])
-    new_root = paths[new_root][-1]
-    paths = dfs([ new_root ], defaultdict(bool), [])
+      root = np.argmax([ len(_) for _ in paths ])
+      root = paths[root][-1]
+
+    paths = dfs([ root ], defaultdict(bool), [])
     
     return [ skel.vertices[path] for path in paths ]
 

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -365,7 +365,11 @@ class PrecomputedSkeleton(object):
   def paths(self, root=None):
     """
     Assuming the skeleton is structured as a single tree, return a 
-    list of all traversal paths. We start from the first 
+    list of all traversal paths. By default, start from the first
+    vertex, find the most distant vertex by hops and set that as
+    the root. Then use depth first traversal to produce paths.
+
+    Returns: [ [(x,y,z), (x,y,z), ...], path_2, path_3, ... ]
     """
     skel = self.consolidate()
 

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -326,11 +326,10 @@ class PrecomputedSkeleton(object):
     Returns cable length of connected skeleton vertices in the same
     metric that this volume uses (typically nanometers).
     """
-    dist = 0 
-    for path in self.paths():
-      for i in range(len(path) - 2):
-        v1, v2 = path[i], path[i+1]
-        dist += np.linalg.norm(v2 - v1)
+    dist = 0
+    for e1, e2 in self.edges:
+      v1, v2 = self.vertices[e1], self.vertices[e2]
+      dist += np.linalg.norm(v2 - v1)
 
     return dist
 

--- a/test/test_skeletons.py
+++ b/test/test_skeletons.py
@@ -249,3 +249,59 @@ def test_equivalent():
   double1 = PrecomputedSkeleton([ (0,0,0), (1,0,0), (1,1,0), (1,1,3) ], edges=[ (1,0), (1,2), (1,3) ])
   double2 = PrecomputedSkeleton([ (0,0,0), (1,0,0), (1,1,0), (1,1,3) ], edges=[ (3,1), (2,1), (0,1) ])
   assert PrecomputedSkeleton.equivalent(double1, double2)
+
+
+def test_downsample():
+  skel = PrecomputedSkeleton([ 
+      (0,0,0), (1,0,0), (1,1,0), (1,1,3), (2,1,3), (2,2,3)
+    ], 
+    edges=[ (1,0), (1,2), (2,3), (3,4), (5,4) ],
+    radii=[ 1, 2, 3, 4, 5, 6 ],
+    vertex_types=[1, 2, 3, 4, 5, 6]
+  )
+
+  def should_error(x):
+    try:
+      skel.downsample(x)
+      assert False
+    except ValueError:
+      pass
+
+  should_error(-1)
+  should_error(0)
+  should_error(.5)
+  should_error(2.00000000000001)
+
+  dskel = skel.downsample(2, preserve_endpoints=False)
+  dskel_gt = PrecomputedSkeleton(
+    [ (0,0,0), (1,1,0), (2,1,3) ], edges=[ (1,0), (1,2) ],
+    radii=[1,3,5], vertex_types=[1, 3, 5]
+  )
+  assert PrecomputedSkeleton.equivalent(dskel, dskel_gt)
+
+  dskel = skel.downsample(2, preserve_endpoints=True)
+  dskel_gt = PrecomputedSkeleton(
+    [ (0,0,0), (1,1,0), (2,1,3), (2,2,3) ], 
+    edges=[ (1,0), (1,2), (2,3) ],
+    radii=[1,3,5,6], vertex_types=[1,3,5,6] 
+  )
+  assert PrecomputedSkeleton.equivalent(dskel, dskel_gt)
+
+  dskel = skel.downsample(3, preserve_endpoints=False)
+  dskel_gt = PrecomputedSkeleton(
+    [ (0,0,0), (1,1,3) ], edges=[ (1,0) ],
+    radii=[1,4], vertex_types=[1,4] 
+  )
+  assert PrecomputedSkeleton.equivalent(dskel, dskel_gt)
+
+  dskel = skel.downsample(3, preserve_endpoints=True)
+  dskel_gt = PrecomputedSkeleton(
+    [ (0,0,0), (1,1,3), (2,2,3) ], edges=[ (1,0), (1,2) ],
+    radii=[1,4,6], vertex_types=[1,4,6],
+  )
+  assert PrecomputedSkeleton.equivalent(dskel, dskel_gt)
+
+
+
+
+

--- a/test/test_skeletons.py
+++ b/test/test_skeletons.py
@@ -388,3 +388,29 @@ def test_read_swc():
   )
 
   assert PrecomputedSkeleton.equivalent(skel, skel_gt)
+
+def test_components():
+  skel = PrecomputedSkeleton(
+    [ 
+      (0,0,0), (1,0,0), (2,0,0),
+      (0,1,0), (0,2,0), (0,3,0),
+    ], 
+    edges=[ 
+      (0,1), (1,2), 
+      (3,4), (4,5), (3,5)
+    ],
+    segid=666,
+  )
+
+  components = skel.components()
+  assert len(components) == 2
+  assert components[0].vertices.shape[0] == 3
+  assert components[1].vertices.shape[0] == 3
+  assert components[0].edges.shape[0] == 2
+  assert components[1].edges.shape[0] == 3
+
+  skel1_gt = PrecomputedSkeleton([(0,0,0), (1,0,0), (2,0,0)], [(0,1), (1,2)])
+  skel2_gt = PrecomputedSkeleton([(0,1,0), (0,2,0), (0,3,0)], [(0,1), (0,2), (1,2)])
+
+  assert PrecomputedSkeleton.equivalent(components[0], skel1_gt)
+  assert PrecomputedSkeleton.equivalent(components[1], skel2_gt)

--- a/test/test_skeletons.py
+++ b/test/test_skeletons.py
@@ -285,7 +285,8 @@ def test_downsample():
     ], 
     edges=[ (1,0), (1,2), (2,3), (3,4), (5,4) ],
     radii=[ 1, 2, 3, 4, 5, 6 ],
-    vertex_types=[1, 2, 3, 4, 5, 6]
+    vertex_types=[1, 2, 3, 4, 5, 6],
+    segid=1337,
   )
 
   def should_error(x):
@@ -302,9 +303,13 @@ def test_downsample():
 
   dskel = skel.downsample(1, preserve_endpoints=False)
   assert PrecomputedSkeleton.equivalent(dskel, skel)
+  assert dskel.id == skel.id
+  assert dskel.id == 1337
 
   dskel = skel.downsample(1, preserve_endpoints=True)
   assert PrecomputedSkeleton.equivalent(dskel, skel)
+  assert dskel.id == skel.id
+  assert dskel.id == 1337
 
   dskel = skel.downsample(2, preserve_endpoints=False)
   dskel_gt = PrecomputedSkeleton(

--- a/test/test_skeletons.py
+++ b/test/test_skeletons.py
@@ -336,6 +336,55 @@ def test_downsample():
   assert PrecomputedSkeleton.equivalent(dskel, dskel_gt)
 
 
+def test_read_swc():
 
+  # From http://research.mssm.edu/cnic/swc.html
+  test_file = """# ORIGINAL_SOURCE NeuronStudio 0.8.80
+# CREATURE
+# REGION
+# FIELD/LAYER
+# TYPE
+# CONTRIBUTOR
+# REFERENCE
+# RAW
+# EXTRAS
+# SOMA_AREA
+# SHINKAGE_CORRECTION 1.0 1.0 1.0
+# VERSION_NUMBER 1.0
+# VERSION_DATE 2007-07-24
+# SCALE 1.0 1.0 1.0
+1 1 14.566132 34.873772 7.857000 0.717830 -1
+2 0 16.022520 33.760513 7.047000 0.463378 1
+3 5 17.542000 32.604973 6.885001 0.638007 2
+4 0 19.163984 32.022469 5.913000 0.602284 3
+5 0 20.448090 30.822802 4.860000 0.436025 4
+6 6 21.897903 28.881084 3.402000 0.471886 5
+7 0 18.461960 30.289471 8.586000 0.447463 3
+8 6 19.420759 28.730757 9.558000 0.496217 7"""
 
+  skel = PrecomputedSkeleton.from_swc(test_file)
+  assert skel.vertices.shape[0] == 8
+  assert skel.edges.shape[0] == 7
 
+  skel_gt = PrecomputedSkeleton(
+    vertices=[
+      [14.566132, 34.873772, 7.857000],
+      [16.022520, 33.760513, 7.047000],
+      [17.542000, 32.604973, 6.885001],
+      [19.163984, 32.022469, 5.913000],
+      [20.448090, 30.822802, 4.860000],
+      [21.897903, 28.881084, 3.402000],
+      [18.461960, 30.289471, 8.586000],
+      [19.420759, 28.730757, 9.558000]
+    ],
+    edges=[ (0,1), (1,2), (2,3), (3,4), (4,5), (2,6), (7,6) ],
+    radii=[ 
+      0.717830, 0.463378, 0.638007, 0.602284, 
+      0.436025, 0.471886, 0.447463, 0.496217
+    ],
+    vertex_types=[
+      1, 0, 5, 0, 0, 6, 0, 6
+    ],
+  )
+
+  assert PrecomputedSkeleton.equivalent(skel, skel_gt)

--- a/test/test_skeletons.py
+++ b/test/test_skeletons.py
@@ -1,12 +1,12 @@
 import pytest
 
 import copy
-import json
-import os
-import numpy as np
-import shutil
 import gzip
 import json
+import math
+import numpy as np
+import os
+import shutil
 
 from cloudvolume import CloudVolume, chunks, Storage, PrecomputedSkeleton
 from cloudvolume.storage import SimpleStorage
@@ -250,6 +250,34 @@ def test_equivalent():
   double2 = PrecomputedSkeleton([ (0,0,0), (1,0,0), (1,1,0), (1,1,3) ], edges=[ (3,1), (2,1), (0,1) ])
   assert PrecomputedSkeleton.equivalent(double1, double2)
 
+def test_cable_length():
+  skel = PrecomputedSkeleton([ 
+      (0,0,0), (1,0,0), (2,0,0), (3,0,0), (4,0,0), (5,0,0)
+    ], 
+    edges=[ (1,0), (1,2), (2,3), (3,4), (5,4) ],
+    radii=[ 1, 2, 3, 4, 5, 6 ],
+    vertex_types=[1, 2, 3, 4, 5, 6]
+  )
+
+  assert skel.cable_length() == (skel.vertices.shape[0] - 1)
+
+  skel = PrecomputedSkeleton([ 
+      (2,0,0), (1,0,0), (0,0,0), (0,5,0), (0,6,0), (0,7,0)
+    ], 
+    edges=[ (1,0), (1,2), (2,3), (3,4), (5,4) ],
+    radii=[ 1, 2, 3, 4, 5, 6 ],
+    vertex_types=[1, 2, 3, 4, 5, 6]
+  )
+  assert skel.cable_length() == 9
+
+  skel = PrecomputedSkeleton([ 
+      (1,1,1), (0,0,0), (1,0,0)
+    ], 
+    edges=[ (1,0), (1,2) ],
+    radii=[ 1, 2, 3],
+    vertex_types=[1, 2, 3]
+  )
+  assert abs(skel.cable_length() - (math.sqrt(3) + 1)) < 1e-6
 
 def test_downsample():
   skel = PrecomputedSkeleton([ 

--- a/test/test_skeletons.py
+++ b/test/test_skeletons.py
@@ -335,6 +335,20 @@ def test_downsample():
   )
   assert PrecomputedSkeleton.equivalent(dskel, dskel_gt)
 
+  skel = PrecomputedSkeleton([ 
+      (0,0,0), (1,0,0), (1,1,0), (1,1,3), (2,1,3), (2,2,3)
+    ], 
+    edges=[ (1,0), (1,2), (3,4), (5,4) ],
+    radii=[ 1, 2, 3, 4, 5, 6 ],
+    vertex_types=[1, 2, 3, 4, 5, 6]
+  )
+  dskel = skel.downsample(2, preserve_endpoints=True)
+  dskel_gt = PrecomputedSkeleton(
+    [ (0,0,0), (1,1,0), (1,1,3), (2,2,3) ], 
+    edges=[ (1,0), (2,3) ],
+    radii=[1,3,4,6], vertex_types=[1,3,4,6] 
+  )
+  assert PrecomputedSkeleton.equivalent(dskel, dskel_gt)
 
 def test_read_swc():
 

--- a/test/test_skeletons.py
+++ b/test/test_skeletons.py
@@ -272,6 +272,12 @@ def test_downsample():
   should_error(.5)
   should_error(2.00000000000001)
 
+  dskel = skel.downsample(1, preserve_endpoints=False)
+  assert PrecomputedSkeleton.equivalent(dskel, skel)
+
+  dskel = skel.downsample(1, preserve_endpoints=True)
+  assert PrecomputedSkeleton.equivalent(dskel, skel)
+
   dskel = skel.downsample(2, preserve_endpoints=False)
   dskel_gt = PrecomputedSkeleton(
     [ (0,0,0), (1,1,0), (2,1,3) ], edges=[ (1,0), (1,2) ],


### PR DESCRIPTION
This PR adds:

- [x] cable_length returns the physical distance the skeleton runs for.
- [x] paths returns all the traversals of all components in the edge list.
- [x] components extracts the connected components and returns them as sub-PrecomputedSkeletons
- [x] downsample strides the points along all traversal paths of all components
- [x] SWC file decoder
- [x] tests for these items
- [x] consolidate eliminates trivial edges (e.g. [1,1])

We'll need to handle getting a path from a specified root, but how that works exactly will depend on the use case. It gets weird when multiple components are present.
