### PR TITLE
fix: transfer_to retains Content-Type and respects existing info.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
+- '3.7-dev'
 before_install:
 - PYTHON_MAJOR_VERSION=`echo $TRAVIS_PYTHON_VERSION | head -c 1`
 - if [[ $PYTHON_MAJOR_VERSION == 3 ]]; then sudo apt-get install python3-pip; fi

--- a/cloudvolume/__init__.py
+++ b/cloudvolume/__init__.py
@@ -7,6 +7,7 @@ from .threaded_queue import ThreadedQueue
 from .exceptions import EmptyVolumeException, EmptyRequestException, AlignmentError
 from .volumecutout import VolumeCutout
 
+from . import exceptions
 from . import secrets
 from . import txrx
 

--- a/cloudvolume/__init__.py
+++ b/cloudvolume/__init__.py
@@ -4,7 +4,7 @@ from .provenance import DataLayerProvenance
 from .skeletonservice import PrecomputedSkeleton, SkeletonEncodeError, SkeletonDecodeError
 from .storage import Storage
 from .threaded_queue import ThreadedQueue
-from .txrx import EmptyVolumeException, EmptyRequestException, AlignmentError
+from .exceptions import EmptyVolumeException, EmptyRequestException, AlignmentError
 from .volumecutout import VolumeCutout
 
 from . import secrets

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -470,19 +470,19 @@ class CloudVolume(object):
                           if s["resolution"] == mip))
       else:  # mip specified by index into downsampling hierarchy
         self._mip = self.available_mips[mip]
-    except:
+    except Exception as err:
       if isinstance(mip, list):
         opening_text = "Scale <{}>".format(", ".join(map(str, mip)))
       else:
-        opening_text = "MIP {}".format(mip)
+        opening_text = "MIP {}".format(str(mip))
   
-      scales = [ ",".join(scale) for scale in self.available_resolutions ]
+      scales = [ ",".join(map(str, scale)) for scale in self.available_resolutions ]
       scales = [ "<{}>".format(scale) for scale in scales ]
       scales = ", ".join(scales)
       msg = "{} not found. {} available: {}".format(
         opening_text, len(self.available_mips), scales
       )
-      raise ScaleUnavailableError(msg)
+      raise exceptions.ScaleUnavailableError(msg)
 
   @property
   def scales(self):

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -23,7 +23,7 @@ from .secrets import boss_credentials, CLOUD_VOLUME_DIR
 
 from . import lib, chunks
 from .cacheservice import CacheService
-from .exceptions import AlignmentError, EmptyRequestException
+from . import exceptions 
 from .lib import ( 
   toabs, colorize, red, yellow, 
   mkdir, clamp, xyzrange, Vec, 
@@ -273,7 +273,9 @@ class CloudVolume(object):
       info = stor.get_json('info')
 
     if info is None:
-      raise ValueError(red('No info file was found: {}'.format(self.info_cloudpath)))
+      raise exceptions.InfoUnavailableError(
+        red('No info file was found: {}'.format(self.info_cloudpath))
+      )
     return info
 
   def refreshInfo(self):
@@ -468,15 +470,19 @@ class CloudVolume(object):
                           if s["resolution"] == mip))
       else:  # mip specified by index into downsampling hierarchy
         self._mip = self.available_mips[mip]
-
     except:
       if isinstance(mip, list):
-        available = self.available_resolutions
+        opening_text = "Scale <{}>".format(", ".join(map(str, mip)))
       else:
-        available = self.available_mips
-      available_str = ", ".join(map(str, available)) 
-      msg = "MIP {} not found. Available: {}".format(mip, available_str)
-      raise IndexError(msg)
+        opening_text = "MIP {}".format(mip)
+  
+      scales = [ ",".join(scale) for scale in self.available_resolutions ]
+      scales = [ "<{}>".format(scale) for scale in scales ]
+      scales = ", ".join(scales)
+      msg = "{} not found. {} available: {}".format(
+        opening_text, len(self.available_mips), scales
+      )
+      raise ScaleUnavailableError(msg)
 
   @property
   def scales(self):
@@ -820,7 +826,8 @@ class CloudVolume(object):
     realized_bbox = self.__realized_bbox(requested_bbox)
 
     if requested_bbox != realized_bbox:
-      raise ValueError("Unable to delete non-chunk aligned bounding boxes. Requested: {}, Realized: {}".format(
+      raise exceptions.AlignmentError(
+        "Unable to delete non-chunk aligned bounding boxes. Requested: {}, Realized: {}".format(
         requested_bbox, realized_bbox
       ))
 
@@ -854,9 +861,10 @@ class CloudVolume(object):
     realized_bbox = self.__realized_bbox(requested_bbox)
 
     if requested_bbox != realized_bbox:
-      raise ValueError("Unable to transfer non-chunk aligned bounding boxes. Requested: {}, Realized: {}".format(
-        requested_bbox, realized_bbox
-      ))
+      raise exceptions.AlignmentError(
+        "Unable to transfer non-chunk aligned bounding boxes. Requested: {}, Realized: {}".format(
+          requested_bbox, realized_bbox
+        ))
 
     default_block_size_MB = 50 # MB
     chunk_MB = self.underlying.rectVolume() * np.dtype(self.dtype).itemsize * self.num_channels
@@ -875,10 +883,17 @@ class CloudVolume(object):
 
     try:
       destvol = CloudVolume(cloudpath, mip=self.mip)
-      if destvol.scale != self.scale:
-        raise AlignmentError("Source and target scales must match. Source: {}, Target: {}", self.scale, destvol.scale)
-    except ValueError: # info file missing
+    except exceptions.InfoUnavailableError: 
       destvol = CloudVolume(cloudpath, mip=self.mip, info=self.info, provenance=self.provenance.serialize())
+      destvol.commit_info()
+      destvol.commit_provenance()
+    except exceptions.ScaleUnavailableError:
+      destvol = CloudVolume(cloudpath)
+      num_missing = len(self.scales) - len(destvol.scales)
+      for i in range(len(destvol.scales) + 1, len(self.scales)):
+        destvol.scales.append(
+          self.scales[i]
+        )
       destvol.commit_info()
       destvol.commit_provenance()
 
@@ -975,7 +990,7 @@ class CloudVolume(object):
     bounds = Bbox.clamp(requested_bbox, self.bounds)
     
     if bounds.volume() < 1:
-      raise ValueError('Requested less than one pixel of volume. {}'.format(bounds))
+      raise exceptions.EmptyRequestException('Requested less than one pixel of volume. {}'.format(bounds))
 
     x_rng = [ bounds.minpt.x, bounds.maxpt.x ]
     y_rng = [ bounds.minpt.y, bounds.maxpt.y ]
@@ -1025,7 +1040,7 @@ class CloudVolume(object):
     slice_shape = list(bbox.size3()) + [ slices[3].stop - slices[3].start ]
 
     if not np.array_equal(imgshape, slice_shape):
-      raise ValueError("Illegal slicing, Image shape: {} != {} Slice Shape".format(imgshape, slice_shape))
+      raise exceptions.AlignmentError("Illegal slicing, Image shape: {} != {} Slice Shape".format(imgshape, slice_shape))
 
     if self.autocrop:
       if not self.bounds.contains_bbox(bbox):
@@ -1090,7 +1105,7 @@ class CloudVolume(object):
     cutout_bbox = tobbox(cutout_bbox) if cutout_bbox else bbox.clone()
 
     if not bbox.contains_bbox(cutout_bbox):
-      raise IndexError("""
+      raise exceptions.AlignmentError("""
         The provided cutout is not wholly contained in the given array. 
         Bbox:        {}
         Cutout:      {}
@@ -1120,7 +1135,7 @@ class CloudVolume(object):
     bounds = Bbox(offset, shape + offset)
 
     if bounds.volume() < 1:
-      raise EmptyRequestException('Requested less than one pixel of volume. {}'.format(bounds))
+      raise exceptions.EmptyRequestException('Requested less than one pixel of volume. {}'.format(bounds))
 
     x_rng = [ bounds.minpt.x, bounds.maxpt.x ]
     y_rng = [ bounds.minpt.y, bounds.maxpt.y ]

--- a/cloudvolume/compression.py
+++ b/cloudvolume/compression.py
@@ -3,13 +3,8 @@ from six import StringIO, BytesIO
 import gzip
 import sys
 
+from .exceptions import DecompressionError, CompressionError
 from .lib import yellow
-
-class DecodingError(Exception):
-  pass
-
-class EncodingError(Exception):
-  pass
 
 def decompress(content, encoding, filename='N/A'):
   """
@@ -32,7 +27,7 @@ def decompress(content, encoding, filename='N/A'):
       return content
     elif encoding == 'gzip':
       return gunzip(content)
-  except DecodingError as err:
+  except DecompressionError as err:
     print("Filename: " + str(filename))
     raise
   
@@ -83,7 +78,7 @@ def gunzip(content):
   gzip_magic_numbers = [ 0x1f, 0x8b ]
   first_two_bytes = [ byte for byte in bytearray(content)[:2] ]
   if first_two_bytes != gzip_magic_numbers:
-    raise DecodingError('File is not in gzip format. Magic numbers {}, {} did not match {}, {}.'.format(
+    raise DecompressionError('File is not in gzip format. Magic numbers {}, {} did not match {}, {}.'.format(
       hex(first_two_bytes[0]), hex(first_two_bytes[1])), hex(gzip_magic_numbers[0]), hex(gzip_magic_numbers[1]))
 
   stringio = BytesIO(content)

--- a/cloudvolume/exceptions.py
+++ b/cloudvolume/exceptions.py
@@ -1,0 +1,18 @@
+
+
+class AlignmentError(Exception):
+  """Signals that an operation requiring chunk alignment was not aligned."""
+  pass 
+
+class EmptyVolumeException(Exception):
+  """Raised upon finding a missing chunk."""
+  pass
+
+class EmptyRequestException(Exception):
+  """
+  Requesting uploading or downloading 
+  a bounding box of less than one cubic voxel
+  is impossible.
+  """
+  pass
+

--- a/cloudvolume/exceptions.py
+++ b/cloudvolume/exceptions.py
@@ -1,3 +1,6 @@
+"""
+
+"""
 
 
 class AlignmentError(Exception):
@@ -16,3 +19,18 @@ class EmptyRequestException(Exception):
   """
   pass
 
+class DecompressionError(Exception):
+  """
+  Decompression failed. This exception is used for codecs 
+  that are naieve to data contents like gzip, lzma, etc. as opposed
+  to codecs that are aware of array shape like fpzip or compressed_segmentation.
+  """
+  pass
+
+class CompressionError(Exception):
+  """
+  Compression failed. This exception is used for codecs 
+  that are naieve to data contents like gzip, lzma, etc. as opposed
+  to codecs that are aware of array shape like fpzip or compressed_segmentation.
+  """
+  pass

--- a/cloudvolume/exceptions.py
+++ b/cloudvolume/exceptions.py
@@ -1,9 +1,13 @@
-"""
 
-"""
+class InfoUnavailableError(ValueError):
+  """CloudVolume was unable to access this layer's info file."""
+  pass
 
+class ScaleUnavailableError(IndexError):
+  """The info file is not configured to support this scale / mip level."""
+  pass
 
-class AlignmentError(Exception):
+class AlignmentError(ValueError):
   """Signals that an operation requiring chunk alignment was not aligned."""
   pass 
 
@@ -11,7 +15,7 @@ class EmptyVolumeException(Exception):
   """Raised upon finding a missing chunk."""
   pass
 
-class EmptyRequestException(Exception):
+class EmptyRequestException(ValueError):
   """
   Requesting uploading or downloading 
   a bounding box of less than one cubic voxel
@@ -19,7 +23,17 @@ class EmptyRequestException(Exception):
   """
   pass
 
-class DecompressionError(Exception):
+class DecodingError(Exception):
+  """Generic decoding error. Applies to content aware and unaware codecs."""
+  pass
+
+class EncodingError(Exception):
+  """Generic decoding error. Applies to content aware and unaware codecs."""
+  pass
+
+# Inheritance below done for backwards compatibility reasons.
+
+class DecompressionError(DecodingError):
   """
   Decompression failed. This exception is used for codecs 
   that are naieve to data contents like gzip, lzma, etc. as opposed
@@ -27,7 +41,7 @@ class DecompressionError(Exception):
   """
   pass
 
-class CompressionError(Exception):
+class CompressionError(EncodingError):
   """
   Compression failed. This exception is used for codecs 
   that are naieve to data contents like gzip, lzma, etc. as opposed

--- a/cloudvolume/txrx.py
+++ b/cloudvolume/txrx.py
@@ -436,7 +436,7 @@ def generate_chunks(vol, img, offset):
   alignment_check = bounds.round_to_chunk_size(vol.underlying, vol.voxel_offset)
 
   if not np.all(alignment_check.minpt == bounds.minpt):
-    raise ValueError('Only chunk aligned writes are currently supported. Got: {}, Volume Offset: {}, Alignment Check: {}'.format(
+    raise AlignmentError('Only chunk aligned writes are currently supported. Got: {}, Volume Offset: {}, Alignment Check: {}'.format(
       bounds, vol.voxel_offset, alignment_check)
     )
 

--- a/cloudvolume/txrx.py
+++ b/cloudvolume/txrx.py
@@ -10,6 +10,7 @@ from six.moves import range
 from tqdm import tqdm
 
 from . import lib, chunks
+from .exceptions import AlignmentError, EmptyVolumeException
 from .cacheservice import CacheService
 from .lib import ( 
   toabs, colorize, red, yellow, 
@@ -21,22 +22,6 @@ from .storage import Storage, SimpleStorage, DEFAULT_THREADS, reset_connection_p
 from .threaded_queue import ThreadedQueue
 from .volumecutout import VolumeCutout
 from . import sharedmemory as shm
-
-class EmptyVolumeException(Exception):
-  """Raised upon finding a missing chunk."""
-  pass
-
-class EmptyRequestException(Exception):
-  """
-  Requesting uploading or downloading 
-  a bounding box of less than one cubic voxel
-  is impossible.
-  """
-  pass
-
-class AlignmentError(Exception):
-  """Signals that an operation requiring chunk alignment was not aligned."""
-  pass 
 
 NON_ALIGNED_WRITE = yellow(
   """

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -905,15 +905,6 @@ def test_transfer():
 
   assert 'dont_touch_me_bro' in dcv.info
 
-  dcv.scale['voxel_offset'] = [1,1,1]
-  dcv.commit_info()
-
-  try:
-    cv.transfer_to('file:///tmp/removeme/transfer/', cv.bounds)
-    assert False
-  except AlignmentError:
-    pass
-
 def test_cdn_cache_control():
   delete_layer()
   cv, data = create_layer(size=(128,10,10,1), offset=(0,0,0))


### PR DESCRIPTION
Relevant to #156 

Also refactors CloudVolumes exceptions into a single exceptions module so they can be more easily referenced.