### PR TITLE
fix: multiprocess upload crashes on thin non-aligned images

### DIFF
--- a/cloudvolume/txrx.py
+++ b/cloudvolume/txrx.py
@@ -292,10 +292,12 @@ def upload_image(vol, img, offset, parallel=1,
   # Upload the aligned core
   retracted = bounds.shrink_to_chunk_size(vol.underlying, vol.voxel_offset)
   core_bbox = retracted.clone() - bounds.minpt
-  core_img = img[ core_bbox.to_slices() ] 
-  upload_aligned(vol, core_img, retracted.minpt, parallel=parallel, 
-    manual_shared_memory_id=manual_shared_memory_id, manual_shared_memory_bbox=manual_shared_memory_bbox,
-    manual_shared_memory_order=manual_shared_memory_order)
+
+  if core_bbox.volume() > 0:
+    core_img = img[ core_bbox.to_slices() ] 
+    upload_aligned(vol, core_img, retracted.minpt, parallel=parallel, 
+      manual_shared_memory_id=manual_shared_memory_id, manual_shared_memory_bbox=manual_shared_memory_bbox,
+      manual_shared_memory_order=manual_shared_memory_order)
 
   # Download the shell, paint, and upload
   all_chunks = set(chunknames(expanded, vol.bounds, vol.key, vol.underlying))

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -98,12 +98,26 @@ def test_parallel_write():
   delete_layer()
   cv, data = create_layer(size=(512,512,128,1), offset=(0,0,0))
   
+  # aligned write
   cv.parallel = 2
   cv[:] = np.zeros(shape=(512,512,128,1), dtype=cv.dtype) + 5
   data = cv[:]
   assert np.all(data == 5)
-  del data
-  cv.unlink_shared_memory()
+
+  # non-aligned-write
+  cv.parallel = 2
+  cv.non_aligned_writes = True
+  cv[1:,1:,1:] = np.zeros(shape=(511,511,127,1), dtype=cv.dtype) + 7
+  data = cv[1:,1:,1:]
+  assert np.all(data == 7)
+
+  # thin non-aligned-write so that there's no aligned core
+  cv.parallel = 2
+  cv.non_aligned_writes = True
+  cv[25:75,25:75,25:75] = np.zeros(shape=(50,50,50,1), dtype=cv.dtype) + 8
+  data = cv[25:75,25:75,25:75]
+  assert np.all(data == 8)
+
 
 def test_parallel_shared_memory_write():
   delete_layer()


### PR DESCRIPTION
Shared memory attempts to mmap a zero size buffer and crashes
if there is no aligned core to the image.

Resolves #164 