### PR TITLE
allow reestablishing viewer server in the same python session

### DIFF
--- a/cloudvolume/viewer.py
+++ b/cloudvolume/viewer.py
@@ -98,8 +98,10 @@ def run(cutouts, hostname="localhost", port=DEFAULT_PORT):
 
   myServer = HTTPServer(('localhost', port), handler)
   print("Viewer server listening to http://localhost:" + str(port))
-  myServer.serve_forever()
-  myServer.server_close()
+  try:
+    myServer.serve_forever()
+  finally:
+    myServer.server_close()
 
 class ViewerServerHandler(BaseHTTPRequestHandler):
   def __init__(self, cutouts, *args):

--- a/cloudvolume/viewer.py
+++ b/cloudvolume/viewer.py
@@ -97,7 +97,7 @@ def run(cutouts, hostname="localhost", port=DEFAULT_PORT):
     return ViewerServerHandler(cutouts, *args)
 
   myServer = HTTPServer((hostname, port), handler)
-  print("Viewer server listening to http://localhost:" + str(port))
+  print("Viewer server listening to http://{}:{}".format(hostname, port))
   try:
     myServer.serve_forever()
   except KeyboardInterrupt:

--- a/cloudvolume/viewer.py
+++ b/cloudvolume/viewer.py
@@ -100,6 +100,9 @@ def run(cutouts, hostname="localhost", port=DEFAULT_PORT):
   print("Viewer server listening to http://localhost:" + str(port))
   try:
     myServer.serve_forever()
+  except KeyboardInterrupt:
+    # extra \n to prevent display of "^CContinuing"
+    print("\nContinuing program execution...")
   finally:
     myServer.server_close()
 

--- a/cloudvolume/viewer.py
+++ b/cloudvolume/viewer.py
@@ -96,7 +96,7 @@ def run(cutouts, hostname="localhost", port=DEFAULT_PORT):
   def handler(*args):
     return ViewerServerHandler(cutouts, *args)
 
-  myServer = HTTPServer(('localhost', port), handler)
+  myServer = HTTPServer((hostname, port), handler)
   print("Viewer server listening to http://localhost:" + str(port))
   try:
     myServer.serve_forever()

--- a/cloudvolume/volumecutout.py
+++ b/cloudvolume/volumecutout.py
@@ -78,4 +78,4 @@ class VolumeCutout(np.ndarray):
 
   def view(self, port=8080):
     """Start a local web app on the given port that lets you explore this cutout."""
-    viewer.run([ self ], port)
+    viewer.run([ self ], port=port)


### PR DESCRIPTION
- Allows reusing the same port number after killing a script
- Allows continuation of the program and multiple uses of the viewer within the same script
- Ensures that the hostname argument actually works