### PR TITLE
feat: joint preserving downsample

### DIFF
--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -484,31 +484,31 @@ class PrecomputedSkeleton(object):
     paths = []
 
     stack = [ terminal_nodes[0] ]
-    parents = [ -1 ]
     criticals = [ terminal_nodes[0] ]
-    path = []
+    path_stack = [ [] ]
+    
+    visited = defaultdict(bool)
 
     while stack:
       node = stack.pop()
       root = criticals.pop() # "root" is used v. loosely here
-      parent = parents.pop()
+      path = path_stack.pop()
 
-      path.append(parent)
+      path.append(node)
+      visited[node] = True
 
-      if node in critical_points and node != root:
-        paths.append(path + [ node ])
-        path = []
+      if node != root and node in critical_points:
+        paths.append(path)
+        path = [ node ]
         root = node
 
       for child in tree[node]:
-        if child != parent:
+        if not visited[child]:
           stack.append(child)
-          parents.append(node)
           criticals.append(root)
+          path_stack.append(list(path))
 
-    if len(paths):
-      paths[0] = paths[0][1:] # get rid of -1
-    return paths
+    return [ vertices[path] for path in paths ]
 
   def critical_paths(self):
     """
@@ -518,12 +518,8 @@ class PrecomputedSkeleton(object):
     """
     paths = []
     for tree in self.components():
-      paths.extend(
-        self._single_tree_critical_paths(tree)
-      )
-
-    for i, path in enumerate(paths):
-      paths[i] = self.vertices[ path ]
+      subpaths = self._single_tree_critical_paths(tree)
+      paths.extend(subpaths)
 
     return paths
 

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -365,7 +365,7 @@ class PrecomputedSkeleton(object):
     if int(factor) != factor or factor < 1:
       raise ValueError("Argument `factor` must be a positive integer greater than or equal to 1. Got: <{}>({})", type(factor), factor)
 
-    paths = self.critical_paths()
+    paths = self.interjoint_paths()
 
     for i, path in enumerate(paths):
       if preserve_endpoints:
@@ -454,7 +454,7 @@ class PrecomputedSkeleton(object):
       paths += self._single_tree_paths(tree)
     return paths
 
-  def _single_tree_critical_paths(self, skeleton):
+  def _single_tree_interjoint_paths(self, skeleton):
     vertices = skeleton.vertices
     edges = skeleton.edges
 
@@ -508,7 +508,7 @@ class PrecomputedSkeleton(object):
 
     return [ vertices[path] for path in paths ]
 
-  def critical_paths(self):
+  def interjoint_paths(self):
     """
     Returns paths between the adjacent critical points
     in the skeleton, where a critical point is the set of
@@ -516,7 +516,7 @@ class PrecomputedSkeleton(object):
     """
     paths = []
     for tree in self.components():
-      subpaths = self._single_tree_critical_paths(tree)
+      subpaths = self._single_tree_interjoint_paths(tree)
       paths.extend(subpaths)
 
     return paths

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -480,7 +480,10 @@ class PrecomputedSkeleton(object):
 
     stack = [ terminal_nodes[0] ]
     criticals = [ terminal_nodes[0] ]
-    path_stack = [ [] ]
+    # Saving the path stack is memory intensive
+    # There might be a way to do it more linearly
+    # via a DFS rather than BFS strategy.
+    path_stack = [ [] ] 
     
     visited = defaultdict(bool)
 

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -351,14 +351,12 @@ class PrecomputedSkeleton(object):
 
     return np.sum(dist)
 
-  def downsample(self, factor, preserve_endpoints=True):
+  def downsample(self, factor):
     """
     Compute a downsampled version of the skeleton by striding while 
     preserving endpoints.
 
     factor: stride length for downsampling the saved skeleton paths.
-    preserve_endpoints: ensure that regardless of the downsample factor, 
-      the final vertex and edge on each tree branch is preserved.
 
     Returns: downsampled PrecomputedSkeleton
     """
@@ -368,12 +366,9 @@ class PrecomputedSkeleton(object):
     paths = self.interjoint_paths()
 
     for i, path in enumerate(paths):
-      if preserve_endpoints:
-        paths[i] = np.concatenate(
-          (path[0::factor, :], path[-1:, :])
-        )
-      else:
-        paths[i] = path[0::factor, :]
+      paths[i] = np.concatenate(
+        (path[0::factor, :], path[-1:, :]) # preserve endpoints
+      )
 
     ds_skel = PrecomputedSkeleton.simple_merge(
       [ PrecomputedSkeleton.from_path(path) for path in paths ]

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -230,7 +230,6 @@ class PrecomputedSkeleton(object):
 
     vertex_match = np.all(np.abs(vertex1 - vertex2) < EPSILON)
     if not vertex_match:
-      print("vertex")
       return False
 
     remapping = {}
@@ -247,26 +246,22 @@ class PrecomputedSkeleton(object):
     edges_match = np.all(edges1 == edges2)
 
     if not edges_match:
-      print('edge')
       return False
 
-    radii_match = np.all(np.abs(first.radii - second.radii) < EPSILON)
-    if not radii_match:
-      print("radii")
-      return False   
+    second_verts = {}
+    for i, vert in enumerate(second.vertices):
+      second_verts[tuple(vert)] = i
+    
+    for i in range(len(first.radii)):
+      i2 = second_verts[tuple(first.vertices[i])]
 
-    print("vtypes")
+      if first.radii[i] != second.radii[i2]:
+        return False
 
-    return np.all(first.vertex_types == second.vertex_types)
-    # for i in range(len(first.radii)):
-    #   if first.radii[i] != second.radii[remapping[i]]:
-    #     print("false radii match")
-    #     return False
+      if first.vertex_types[i] != second.vertex_types[i2]:
+        return False
 
-    # for i in range(len(first.vertex_types)):
-    #   if first.vertex_types[i] != second.vertex_types[remapping[i]]:
-    #     print("false vert match")
-    #     return False
+    return True
 
   def crop(self, bbox):
     """

--- a/cloudvolume/skeletonservice.py
+++ b/cloudvolume/skeletonservice.py
@@ -225,26 +225,48 @@ class PrecomputedSkeleton(object):
 
     EPSILON = 1e-7
 
-    vertex_match = np.all(np.abs(first.vertices - second.vertices) < EPSILON)
+    vertex1, inv1 = np.unique(first.vertices, axis=0, return_inverse=True)
+    vertex2, inv2 = np.unique(second.vertices, axis=0, return_inverse=True)
+
+    vertex_match = np.all(np.abs(vertex1 - vertex2) < EPSILON)
     if not vertex_match:
+      print("vertex")
       return False
+
+    remapping = {}
+    for i in range(len(inv1)):
+      remapping[inv1[i]] = inv2[i]
+    remap = np.vectorize(lambda idx: remapping[idx])
 
     edges1 = np.sort(np.unique(first.edges, axis=0), axis=1)
     edges1 = edges1[np.lexsort(edges1[:,::-1].T)]
-    edges2 = np.sort(np.unique(second.edges, axis=0), axis=1)
+
+    edges2 = remap(second.edges)
+    edges2 = np.sort(np.unique(edges2, axis=0), axis=1)
     edges2 = edges2[np.lexsort(edges2[:,::-1].T)]
     edges_match = np.all(edges1 == edges2)
-    del edges1
-    del edges2
 
     if not edges_match:
+      print('edge')
       return False
 
     radii_match = np.all(np.abs(first.radii - second.radii) < EPSILON)
     if not radii_match:
+      print("radii")
       return False   
 
+    print("vtypes")
+
     return np.all(first.vertex_types == second.vertex_types)
+    # for i in range(len(first.radii)):
+    #   if first.radii[i] != second.radii[remapping[i]]:
+    #     print("false radii match")
+    #     return False
+
+    # for i in range(len(first.vertex_types)):
+    #   if first.vertex_types[i] != second.vertex_types[remapping[i]]:
+    #     print("false vert match")
+    #     return False
 
   def crop(self, bbox):
     """

--- a/test/test_skeletons.py
+++ b/test/test_skeletons.py
@@ -340,6 +340,8 @@ def test_downsample():
   )
   assert PrecomputedSkeleton.equivalent(dskel, dskel_gt)
 
+  print("OMG")
+
   skel = PrecomputedSkeleton([ 
       (0,0,0), (1,0,0), (1,1,0), (1,1,3), (2,1,3), (2,2,3)
     ], 
@@ -354,6 +356,60 @@ def test_downsample():
     radii=[1,3,4,6], vertex_types=[1,3,4,6] 
   )
   assert PrecomputedSkeleton.equivalent(dskel, dskel_gt)
+
+
+def test_downsample_joints():
+  skel = PrecomputedSkeleton([ 
+      
+                        (2, 3,0), # 0
+                        (2, 2,0), # 1
+                        (2, 1,0), # 2
+      (0,0,0), (1,0,0), (2, 0,0), (3,0,0), (4,0,0), # 3, 4, 5, 6, 7
+                        (2,-1,0), # 8
+                        (2,-2,0), # 9
+                        (2,-3,0), # 10
+
+    ], 
+    edges=[ 
+                  (0, 1),
+                  (1, 2),
+                  (2, 5),
+        (3,4), (4,5), (5, 6), (6,7),
+                  (5, 8),
+                  (8, 9),
+                  (9,10)
+    ],
+    radii=[ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
+    vertex_types=[ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
+    segid=1337,
+  )
+
+  ds_skel = skel.downsample(2)
+  ds_skel_gt = PrecomputedSkeleton([ 
+
+                        (2, 3,0), # 0
+                        
+                        (2, 2,0), # 1
+      (0,0,0),          (2, 0,0),     (4,0,0), # 2, 3, 4
+
+                        (2,-2,0), # 5                        
+                        (2,-3,0), # 6
+
+    ], 
+    edges=[ 
+                  (0,1),
+                  (1,3),
+              (2,3),  (3,4), 
+                  (3,5),
+                  (5,6)
+    ],
+    radii=[ 3, 10, 9, 5, 2, 0, 7 ],
+    vertex_types=[ 3, 10, 9, 5, 2, 0, 7 ],
+    segid=1337,
+  )
+
+  assert PrecomputedSkeleton.equivalent(ds_skel, ds_skel_gt)
+
 
 def test_read_swc():
 

--- a/test/test_skeletons.py
+++ b/test/test_skeletons.py
@@ -301,24 +301,12 @@ def test_downsample():
   should_error(.5)
   should_error(2.00000000000001)
 
-  dskel = skel.downsample(1, preserve_endpoints=False)
+  dskel = skel.downsample(1)
   assert PrecomputedSkeleton.equivalent(dskel, skel)
   assert dskel.id == skel.id
   assert dskel.id == 1337
 
-  dskel = skel.downsample(1, preserve_endpoints=True)
-  assert PrecomputedSkeleton.equivalent(dskel, skel)
-  assert dskel.id == skel.id
-  assert dskel.id == 1337
-
-  dskel = skel.downsample(2, preserve_endpoints=False)
-  dskel_gt = PrecomputedSkeleton(
-    [ (0,0,0), (1,1,0), (2,1,3) ], edges=[ (1,0), (1,2) ],
-    radii=[1,3,5], vertex_types=[1, 3, 5]
-  )
-  assert PrecomputedSkeleton.equivalent(dskel, dskel_gt)
-
-  dskel = skel.downsample(2, preserve_endpoints=True)
+  dskel = skel.downsample(2)
   dskel_gt = PrecomputedSkeleton(
     [ (0,0,0), (1,1,0), (2,1,3), (2,2,3) ], 
     edges=[ (1,0), (1,2), (2,3) ],
@@ -326,21 +314,12 @@ def test_downsample():
   )
   assert PrecomputedSkeleton.equivalent(dskel, dskel_gt)
 
-  dskel = skel.downsample(3, preserve_endpoints=False)
-  dskel_gt = PrecomputedSkeleton(
-    [ (0,0,0), (1,1,3) ], edges=[ (1,0) ],
-    radii=[1,4], vertex_types=[1,4] 
-  )
-  assert PrecomputedSkeleton.equivalent(dskel, dskel_gt)
-
-  dskel = skel.downsample(3, preserve_endpoints=True)
+  dskel = skel.downsample(3)
   dskel_gt = PrecomputedSkeleton(
     [ (0,0,0), (1,1,3), (2,2,3) ], edges=[ (1,0), (1,2) ],
     radii=[1,4,6], vertex_types=[1,4,6],
   )
   assert PrecomputedSkeleton.equivalent(dskel, dskel_gt)
-
-  print("OMG")
 
   skel = PrecomputedSkeleton([ 
       (0,0,0), (1,0,0), (1,1,0), (1,1,3), (2,1,3), (2,2,3)
@@ -349,7 +328,7 @@ def test_downsample():
     radii=[ 1, 2, 3, 4, 5, 6 ],
     vertex_types=[1, 2, 3, 4, 5, 6]
   )
-  dskel = skel.downsample(2, preserve_endpoints=True)
+  dskel = skel.downsample(2)
   dskel_gt = PrecomputedSkeleton(
     [ (0,0,0), (1,1,0), (1,1,3), (2,2,3) ], 
     edges=[ (1,0), (2,3) ],

--- a/test/test_skeletons.py
+++ b/test/test_skeletons.py
@@ -403,8 +403,8 @@ def test_downsample_joints():
                   (3,5),
                   (5,6)
     ],
-    radii=[ 3, 10, 9, 5, 2, 0, 7 ],
-    vertex_types=[ 3, 10, 9, 5, 2, 0, 7 ],
+    radii=[ 0, 1, 3, 5, 7, 9, 10 ],
+    vertex_types=[ 0, 1, 3, 5, 7, 9, 10 ],
     segid=1337,
   )
 


### PR DESCRIPTION
Downsampling currently relies on computing a set of paths then striding, however this often causes the destruction of key joints. 

What we'd prefer is if each segment between critical points (terminal and branch nodes) would be downsampled while preserving heads and tails then reunifying that set of paths.