### PR TITLE
perf: 1.5-2x faster CloudVolume on Google Cloud Storage

### DIFF
--- a/cloudvolume/storage.py
+++ b/cloudvolume/storage.py
@@ -578,12 +578,13 @@ class GoogleCloudStorageInterface(object):
   @retry
   def get_file(self, file_path):
     key = self.get_path_to_file(file_path)
-    blob = self._bucket.get_blob( key )
-    if not blob:
-      return None, None # content, encoding
+    blob = self._bucket.blob( key )
 
-    # blob handles the decompression so the encoding is None
-    return blob.download_as_string(), None # content, encoding
+    try:
+      # blob handles the decompression so the encoding is None
+      return blob.download_as_string(), None # content, encoding
+    except google.cloud.exceptions.NotFound as err:
+      return None, None
 
   def exists(self, file_path):
     key = self.get_path_to_file(file_path)


### PR DESCRIPTION
We omit a metadata request. This results in 2x less API calls.