### PR TITLE
feat: neuroglancer compatible link with vol.view()

### DIFF
--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -591,8 +591,16 @@ class CloudVolume(object):
     return self.info['scales'][mip]
 
   @property
+  def basepath(self):
+    return os.path.join(self.path.bucket, self.path.intermediate_path, self.dataset_name)
+
+  @property 
+  def layerpath(self):
+    return os.path.join(self.basepath, self.layer)
+
+  @property
   def base_cloudpath(self):
-    return self.path.protocol + "://" + os.path.join(self.path.bucket, self.path.intermediate_path, self.dataset_name)
+    return self.path.protocol + "://" + self.basepath
 
   @property 
   def cloudpath(self):
@@ -1285,4 +1293,12 @@ class CloudVolume(object):
   def save_mesh(self, *args, **kwargs):
     warn("WARNING: vol.save_mesh is deprecated. Please use vol.mesh.save(...) instead.")
     self.mesh.save(*args, **kwargs)
+
+  def view(self, port=1337):
+    import cloudvolume.server
+
+    if self.path.protocol != "file":
+      raise NotImplementedError("Only the file protocol is currently supported.")
+
+    cloudvolume.server.view(self.base_cloudpath, port=port)
 

--- a/cloudvolume/server.py
+++ b/cloudvolume/server.py
@@ -1,0 +1,62 @@
+import os
+
+try: 
+  from http.server import BaseHTTPRequestHandler, HTTPServer
+except ImportError:
+  from SocketServer import TCPServer as HTTPServer
+  from BaseHTTPServer import BaseHTTPRequestHandler
+
+import json
+from six.moves import range
+
+import numpy as np
+from tqdm import tqdm
+
+from cloudvolume.storage import Storage
+from cloudvolume.lib import Vec, Bbox, mkdir, save_images, ExtractedPath, yellow
+
+DEFAULT_PORT = 8080
+
+def view(cloudpath, hostname="localhost", port=DEFAULT_PORT):
+  """Start a local web app on the given port that lets you explore this cutout."""
+  def handler(*args):
+    return ViewerServerHandler(cloudpath, *args)
+
+  myServer = HTTPServer((hostname, port), handler)
+  print("Neuroglancer server listening to http://{}:{}".format(hostname, port))
+  try:
+    myServer.serve_forever()
+  except KeyboardInterrupt:
+    # extra \n to prevent display of "^CContinuing"
+    print("\nContinuing program execution...")
+  finally:
+    myServer.server_close()
+
+class ViewerServerHandler(BaseHTTPRequestHandler):
+  def __init__(self, cloudpath, *args):
+    self.storage = Storage(cloudpath)
+    BaseHTTPRequestHandler.__init__(self, *args)
+
+  def __del__(self):
+    self.storage.kill_threads()
+
+  def do_GET(self):  
+    if self.path.find('..') != -1:
+      raise ValueError("Relative paths are not allowed.")
+
+    path = self.path[1:]
+    data = self.storage.get_file(path)
+
+    if data is None:
+      self.send_response(404)
+      return 
+
+    self.send_response(200)
+    self.serve_data(data)
+
+  def serve_data(self, data):
+    self.send_header('Content-type', 'application/octet-stream')
+    self.send_header('Access-Control-Allow-Origin', '*')
+    self.send_header('Content-length', str(len(data)))
+    self.end_headers()
+    self.wfile.write(data)


### PR DESCRIPTION
Potential uses:

1. Compatibility with compressed files on local disk. This especially helps CloudVolume newbies get started really easily (they often write HDF5 to Precomputed on their local disk because they haven't set up cloud storage yet).
2. Allow access to a non-public dataset by handing out cloudvolume keys.
3. Enable aggressive client-side caching of downloaded data.
4. Use C++/Python codecs to translate unviewable formats to neuroglancer readable formats (e.g. kempressed) (superset of 1)

Workflow:

1.

```python
vol = CloudVolume('file:///tmp/removeme/subvol')
vol.view()

>>> Neuroglancer server listening to http://localhost:1337
```

2. `precomputed://http://localhost:1337/subvol`
