### PR TITLE
Add allow_cropped flag to CloudVolume.download_point

### DIFF
--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -1033,7 +1033,7 @@ class CloudVolume(object):
 
     return self._boss_cutout(requested_bbox, steps, channel_slice)
 
-  def download_point(self, pt, size=256, mip=None, allow_cropped=False):
+  def download_point(self, pt, size=256, mip=None):
     """
     Download to the right of point given in mip 0 coords.
     Useful for quickly visualizing a neuroglancer coordinate
@@ -1056,18 +1056,15 @@ class CloudVolume(object):
 
     pt = self.point_to_mip(pt, mip=0, to_mip=mip)
     bbox = Bbox(pt - size2, pt + size2)
-
-    if allow_cropped:
-      bbox = Bbox.clamp(bbox, self.mip_bounds(mip))
     
     saved_mip = self.mip 
     self.mip = mip
     try:
       img = self[bbox]
-    except ValueError:
+    except exceptions.OutOfBoundsError:
       self.mip = saved_mip
       print(traceback.format_exc())
-      raise ValueError(
+      raise exceptions.OutOfBoundsError(
           'A border of bbox of size {} at point {} is out of bounds (see above trace)'.format(size, pt))
     self.mip = saved_mip
     return img

--- a/cloudvolume/exceptions.py
+++ b/cloudvolume/exceptions.py
@@ -31,6 +31,12 @@ class EncodingError(Exception):
   """Generic decoding error. Applies to content aware and unaware codecs."""
   pass
 
+class OutOfBoundsError(ValueError):
+  """
+  Raised upon trying to obtain or assign to a bbox of a volume outside
+  of the volume's bounds
+  """
+
 # Inheritance below done for backwards compatibility reasons.
 
 class DecompressionError(DecodingError):

--- a/cloudvolume/lib.py
+++ b/cloudvolume/lib.py
@@ -17,7 +17,7 @@ import numpy as np
 from PIL import Image
 from tqdm import tqdm
 
-from .exceptions import UnsupportedProtocolError
+from .exceptions import UnsupportedProtocolError, OutOfBoundsError
 
 if sys.version_info < (3,):
     integer_types = (int, long, np.integer)
@@ -265,7 +265,7 @@ def clamp(val, low, high):
 
 def check_bounds(val, low, high):
   if val > high or val < low:
-    raise ValueError('Value {} cannot be outside of inclusive range {} to {}'.format(val,low,high))
+    raise OutOfBoundsError('Value {} cannot be outside of inclusive range {} to {}'.format(val,low,high))
   return val
 
 class Vec(np.ndarray):


### PR DESCRIPTION
Download_point can raise a ValueError if the bbox is out of bounds. This PR adds a flag to allow a cropped bbox, and resets self.mip if a ValueError happens.