### PR TITLE
adding test for use_https and fixing replace call

### DIFF
--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -175,8 +175,8 @@ class CloudVolume(object):
         https paths hit a cached, read-only version of the data and may be faster.
     """
     if use_https:
-      cloudpath = cloudpath.replace("gs://", "https://storage.googleapis.com/", max=1)
-      cloudpath = cloudpath.replace("s3://", "https://s3.amazonaws.com/", max=1)
+      cloudpath = cloudpath.replace("gs://", "https://storage.googleapis.com/", 1)
+      cloudpath = cloudpath.replace("s3://", "https://s3.amazonaws.com/", 1)
 
     kwargs = locals()
     del kwargs['cls']

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -1188,9 +1188,9 @@ def test_slices_to_global_coords():
   result = Bbox.from_slices(slices)
   assert result == Bbox( (100, 100, 1), (500, 512, 2) )
 
-
-def test_mesh_fragment_download():
-  vol = CloudVolume('gs://seunglab-test/test_v0/segmentation')
+@pytest.mark.parametrize(("use_https"),[True, False])
+def test_mesh_fragment_download(use_https):
+  vol = CloudVolume('gs://seunglab-test/test_v0/segmentation', use_https=use_https)
   paths = vol.mesh._get_manifests(18)
   assert len(paths) == 1
   assert paths[18] == [ '18:0:0-512_0-512_0-100' ]
@@ -1198,6 +1198,7 @@ def test_mesh_fragment_download():
   paths = vol.mesh._get_manifests(147)
   assert len(paths) == 1
   assert paths[147] == [ '147:0:0-512_0-512_0-100' ]
+
 
 
 def test_get_mesh():


### PR DESCRIPTION
it seemed that the max= keyword is not correct for replace in python 3..  simply leaving it as a non keyword argument fixes this.  I added a parameterized test to exercise the function that reveals the bug.