### PR TITLE
fix: added use_https to graphene metadata service

### DIFF
--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -180,7 +180,6 @@ class CloudVolume(object):
 
     kwargs = locals()
     del kwargs['cls']
-    del kwargs['use_https']
 
     path = strict_extract(cloudpath)
     if path.format in REGISTERED_PLUGINS:

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from .exceptions import UnsupportedFormatError
 from .lib import generate_random_string
-from .paths import strict_extract
+from .paths import strict_extract, to_https_protocol
 
 # NOTE: Plugins are registered in __init__.py
 
@@ -174,9 +174,7 @@ class CloudVolume(object):
         https paths hit a cached, read-only version of the data and may be faster.
     """
     if use_https:
-      cloudpath = cloudpath.replace("gs://", "https://storage.googleapis.com/", 1)
-      cloudpath = cloudpath.replace("s3://", "https://s3.amazonaws.com/", 1)
-      cloudpath = cloudpath.replace("matrix://", "https://s3-hpcrc.rc.princeton.edu/", 1)
+      cloudpath = to_https_protocol(cloudpath)
 
     kwargs = locals()
     del kwargs['cls']

--- a/cloudvolume/datasource/graphene/__init__.py
+++ b/cloudvolume/datasource/graphene/__init__.py
@@ -14,7 +14,7 @@ def create_graphene(
     fill_missing=False, cache=False, compress_cache=None,
     cdn_cache=True, progress=False, info=None, provenance=None,
     compress=None, parallel=1,
-    delete_black_uploads=False, green_threads=False, 
+    delete_black_uploads=False, green_threads=False, use_https=False,
     **kwargs
   ):
     
@@ -36,7 +36,7 @@ def create_graphene(
 
     meta = GrapheneMetadata(
       cloudpath, cache=cache,
-      info=info, provenance=provenance,
+      info=info, provenance=provenance, use_https=use_https
     )
 
     image = PrecomputedImageSource(

--- a/cloudvolume/datasource/graphene/metadata.py
+++ b/cloudvolume/datasource/graphene/metadata.py
@@ -28,9 +28,7 @@ class GrapheneMetadata(PrecomputedMetadata):
   def cloudpath(self):
     data_dir = self.info['data_dir']
     if self.use_https:
-      data_dir = data_dir.replace("gs://", "https://storage.googleapis.com/", 1)
-      data_dir = data_dir.replace("s3://", "https://s3.amazonaws.com/", 1)
-      data_dir = data_dir.replace("matrix://", "https://s3-hpcrc.rc.princeton.edu/", 1)
+      data_dir = paths.use_https_protocol(data_dir)
     return data_dir
 
   @property

--- a/cloudvolume/datasource/graphene/metadata.py
+++ b/cloudvolume/datasource/graphene/metadata.py
@@ -10,9 +10,10 @@ from ... import paths
 from ..precomputed import PrecomputedMetadata
 
 class GrapheneMetadata(PrecomputedMetadata):
-  def __init__(self, cloudpath, *args, **kwargs):
+  def __init__(self, cloudpath, use_https=False, *args, **kwargs):
     self.server_url = cloudpath.replace('graphene://', '')
     self.server_path = extract_graphene_path(self.server_url)
+    self.use_https = use_https
     super(GrapheneMetadata, self).__init__(cloudpath, *args, **kwargs)
 
   def fetch_info(self):
@@ -25,7 +26,12 @@ class GrapheneMetadata(PrecomputedMetadata):
 
   @property
   def cloudpath(self):
-    return self.info['data_dir']
+    data_dir = self.info['data_dir']
+    if self.use_https:
+      data_dir = data_dir.replace("gs://", "https://storage.googleapis.com/", 1)
+      data_dir = data_dir.replace("s3://", "https://s3.amazonaws.com/", 1)
+      data_dir = data_dir.replace("matrix://", "https://s3-hpcrc.rc.princeton.edu/", 1)
+    return data_dir
 
   @property
   def graph_chunk_size(self):

--- a/cloudvolume/datasource/precomputed/__init__.py
+++ b/cloudvolume/datasource/precomputed/__init__.py
@@ -13,7 +13,8 @@ def create_precomputed(
     fill_missing=False, cache=False, compress_cache=None,
     cdn_cache=True, progress=False, info=None, provenance=None,
     compress=None, non_aligned_writes=False, parallel=1,
-    delete_black_uploads=False, green_threads=False
+    delete_black_uploads=False, green_threads=False,
+    use_https=False
   ):
     path = strict_extract(cloudpath)
     config = SharedConfiguration(

--- a/cloudvolume/paths.py
+++ b/cloudvolume/paths.py
@@ -149,3 +149,9 @@ def extract(cloudpath, windows=None, disable_toabs=False):
     fmt, protocol, bucket, 
     cloudpath, intermediate_path, dataset, layer
   )
+
+def to_https_protocol(cloudpath):
+  cloudpath = cloudpath.replace("gs://", "https://storage.googleapis.com/", 1)
+  cloudpath = cloudpath.replace("s3://", "https://s3.amazonaws.com/", 1)
+  cloudpath = cloudpath.replace("matrix://", "https://s3-hpcrc.rc.princeton.edu/", 1)
+  return cloudpath


### PR DESCRIPTION
I think i found the bug related to #247 , the GrapheneMetaDataService needed to allow remapping of https on the data_dir.  Please let me know if this is the correct way to fix this within the plugin architecture. 