### PR TITLE
fix: treat 403 like 404 for HTTPS interface

### DIFF
--- a/cloudvolume/storage/storage_interfaces.py
+++ b/cloudvolume/storage/storage_interfaces.py
@@ -309,7 +309,7 @@ class HttpInterface(StorageInterface):
       resp = requests.get(key, headers=headers)
     else:
       resp = requests.get(key)
-    if resp.status_code == 404:
+    if resp.status_code in (404, 403):
       return None, None
     resp.raise_for_status()
     return resp.content, resp.encoding


### PR DESCRIPTION
Google Cloud Storage never returns 404s when using use_https, it
always returns 403 (to prevent you from learning that file names
exist).