### PR TITLE
feat: support for chunked graph server authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,17 @@ You can create the `google-secret.json` file [here](https://console.cloud.google
 }
 ```
 
+#### `chunkedgraph-secret.json`
+
+If you have a token from Graphene/Chunkedgraph server, create the `chunkedgraph-secret.json` file as shown in the example below.
+You may also pass the token to `GrapheneMetadata` class `auth_token="<your_token>"`, this will override the token from `json` file.
+
+```json
+{
+  "token": "<your_token>"
+}
+```
+
 ## Usage
 
 CloudVolume supports reading and writing to Neuroglancer data layers on Amazon S3, Google Storage, The BOSS, and the local file system.

--- a/cloudvolume/datasource/graphene/mesh.py
+++ b/cloudvolume/datasource/graphene/mesh.py
@@ -35,10 +35,11 @@ class GrapheneMeshSource(PrecomputedMeshSource):
       res = requests.get(
         url,
         data=json.dumps({ "start_layer": level }),
-        params=query_d
+        params=query_d,
+        headers=self.meta.auth_headers
       )
     else:
-      res = requests.get(url, params=query_d)
+      res = requests.get(url, params=query_d, headers=self.meta.auth_headers)
 
     res.raise_for_status()
 

--- a/cloudvolume/datasource/graphene/mesh.py
+++ b/cloudvolume/datasource/graphene/mesh.py
@@ -36,10 +36,10 @@ class GrapheneMeshSource(PrecomputedMeshSource):
         url,
         data=json.dumps({ "start_layer": level }),
         params=query_d,
-        headers=self.meta.auth_headers
+        headers=self.meta.auth_header
       )
     else:
-      res = requests.get(url, params=query_d, headers=self.meta.auth_headers)
+      res = requests.get(url, params=query_d, headers=self.meta.auth_header)
 
     res.raise_for_status()
 

--- a/cloudvolume/datasource/graphene/metadata.py
+++ b/cloudvolume/datasource/graphene/metadata.py
@@ -11,14 +11,19 @@ from ...secrets import chunkedgraph_credentials
 from ..precomputed import PrecomputedMetadata
 
 class GrapheneMetadata(PrecomputedMetadata):
-  def __init__(self, cloudpath, use_https=False, *args, **kwargs):
+  def __init__(self, cloudpath, use_https=False, use_auth=True, auth_token=None, *args, **kwargs):
     self.server_url = cloudpath.replace('graphene://', '')
     self.server_path = extract_graphene_path(self.server_url)
     self.use_https = use_https
     self.auth_header = None
-    if chunkedgraph_credentials:
+    if use_auth:
+      token = None
+      if chunkedgraph_credentials:
+        token = chunkedgraph_credentials["token"]
+      if auth_token:
+        token = auth_token
       self.auth_header = {
-        "Authorization": "Bearer %s" % chunkedgraph_credentials["token"]
+        "Authorization": "Bearer %s" % token
       }
     super(GrapheneMetadata, self).__init__(cloudpath, *args, **kwargs)
 

--- a/cloudvolume/datasource/graphene/metadata.py
+++ b/cloudvolume/datasource/graphene/metadata.py
@@ -15,9 +15,10 @@ class GrapheneMetadata(PrecomputedMetadata):
     self.server_url = cloudpath.replace('graphene://', '')
     self.server_path = extract_graphene_path(self.server_url)
     self.use_https = use_https
+    self.auth_header = None
     if chunkedgraph_credentials:
       self.auth_header = {
-        "Authorization": f"Bearer {chunkedgraph_credentials["token"]}"
+        "Authorization": "Bearer %s" % chunkedgraph_credentials["token"]
       }
     super(GrapheneMetadata, self).__init__(cloudpath, *args, **kwargs)
 

--- a/cloudvolume/datasource/graphene/metadata.py
+++ b/cloudvolume/datasource/graphene/metadata.py
@@ -7,6 +7,7 @@ from six.moves import urllib
 
 from ... import exceptions
 from ... import paths
+from ...secrets import chunkedgraph_credentials
 from ..precomputed import PrecomputedMetadata
 
 class GrapheneMetadata(PrecomputedMetadata):
@@ -14,13 +15,17 @@ class GrapheneMetadata(PrecomputedMetadata):
     self.server_url = cloudpath.replace('graphene://', '')
     self.server_path = extract_graphene_path(self.server_url)
     self.use_https = use_https
+    if chunkedgraph_credentials:
+      self.auth_header = {
+        "Authorization": f"Bearer {chunkedgraph_credentials["token"]}"
+      }
     super(GrapheneMetadata, self).__init__(cloudpath, *args, **kwargs)
 
   def fetch_info(self):
     """
     Reads info from chunkedgraph endpoint and extracts relevant information
     """
-    r = requests.get(posixpath.join(self.server_url, "info"))
+    r = requests.get(posixpath.join(self.server_url, "info"), headers=self.auth_header)
     r.raise_for_status()
     return json.loads(r.content)
 

--- a/cloudvolume/frontends/graphene.py
+++ b/cloudvolume/frontends/graphene.py
@@ -121,7 +121,7 @@ class CloudVolumeGraphene(CloudVolumePrecomputed):
 
     response = requests.post(url, json=[ root_id ], params={
       'bounds': bbox.to_filename(),
-    }, headers=self.meta.auth_headers)
+    }, headers=self.meta.auth_header)
     response.raise_for_status()
 
     return np.frombuffer(response.content, dtype=np.uint64)

--- a/cloudvolume/frontends/graphene.py
+++ b/cloudvolume/frontends/graphene.py
@@ -121,7 +121,7 @@ class CloudVolumeGraphene(CloudVolumePrecomputed):
 
     response = requests.post(url, json=[ root_id ], params={
       'bounds': bbox.to_filename(),
-    })
+    }, headers=self.meta.auth_headers)
     response.raise_for_status()
 
     return np.frombuffer(response.content, dtype=np.uint64)

--- a/cloudvolume/secrets.py
+++ b/cloudvolume/secrets.py
@@ -136,3 +136,11 @@ if os.path.exists(boss_credentials_path):
     boss_credentials = json.loads(f.read())
 else:
   boss_credentials = ''
+
+
+chunkedgraph_credentials_path = secretpath('secrets/chunkedgraph-secret.json')
+if os.path.exists(chunkedgraph_credentials_path):
+  with open(chunkedgraph_credentials_path, 'r') as f:
+    chunkedgraph_credentials = json.loads(f.read())
+else:
+  chunkedgraph_credentials = None


### PR DESCRIPTION
* store credentials in file named `chunkedgraph-secret.json`, eg: `{"token":"<auth_token>"}`
* token will be in `auth_header` dictionary in meta class