### PR TITLE
feat: add redirection feature to info files

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,8 @@ CloudVolume(cloudpath,
      cache=False, compress_cache=None, cdn_cache=False, progress=INTERACTIVE, info=None, provenance=None, 
      compress=None, non_aligned_writes=False, parallel=1,
      delete_black_uploads=False, background_color=0, 
-     green_threads=False)
+     green_threads=False, use_https=False,
+     max_redirects=10)
 ```
 
 * mip - Which mip level to access
@@ -359,6 +360,8 @@ CloudVolume(cloudpath,
 * delete_black_uploads - True/False. If True, issue a DELETE http request instead of a PUT when an individual uploaded chunk is all background (usually all zeros). This is useful for avoiding creating many tiny files, which some storage system designs do not handle well.
 * background_color - Number. Determines the background color that `delete_black_uploads` will scan for (typically zero).
 * green_threads - True/False. If True, use the gevent cooperative threading library instead of preemptive threads. This requires monkey patching your program which may be undesirable. However, for certain workloads this can be a significant performance improvement on multi-core devices.
+* use_https - True/False. If True, use the same read-only access urls that neuroglancer does that may be cached vs the secured read/write strongly consistent API. Use this when you do not have credentials.  
+* max_redirects - Integer. If > 0, allow info files containing a 'redirect' field to forward the CloudVolume instance across this many hops before raising an error. If set to <= 0, then do not allow redirection, but also do not raise an error (which allows for easy editing of info files with a redirect in them).  
 
 ### CloudVolume Methods
 

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -57,7 +57,8 @@ class CloudVolume(object):
     cdn_cache=True, progress=INTERACTIVE, info=None, provenance=None,
     compress=None, non_aligned_writes=False, parallel=1,
     delete_black_uploads=False, background_color=0,
-    green_threads=False, use_https=False
+    green_threads=False, use_https=False,
+    max_redirects=10
   ):
     """
     A "serverless" Python client for reading and writing arbitrarily large 

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -156,15 +156,18 @@ class CloudVolume(object):
       info: (dict) In lieu of fetching a neuroglancer info file, use this one.
           This is useful when creating new datasets and for repeatedly initializing
           a new cloudvolume instance.
+      max_redirects: (int) if > 0, allow up to this many redirects via info file 'redirect'
+          data fields. If <= 0, allow no redirections and access the current info file directly
+          without raising an error.
+      mip: (int or iterable) Which level of downsampling to read and write from.
+          0 is the highest resolution. You can also specify the voxel resolution
+          like mip=[6,6,30] which will search for the appropriate mip level.
       non_aligned_writes: (bool) Enable non-aligned writes. Not multiprocessing 
           safe without careful design. When not enabled, a 
           cloudvolume.exceptions.AlignmentError is thrown for non-aligned writes. 
           
           https://github.com/seung-lab/cloud-volume/wiki/Advanced-Topic:-Non-Aligned-Writes
 
-      mip: (int or iterable) Which level of downsampling to read and write from.
-          0 is the highest resolution. You can also specify the voxel resolution
-          like mip=[6,6,30] which will search for the appropriate mip level.
       parallel (int: 1, bool): Number of extra processes to launch, 1 means only 
           use the main process. If parallel is True use the number of CPUs 
           returned by multiprocessing.cpu_count(). When parallel > 1, shared

--- a/cloudvolume/datasource/__init__.py
+++ b/cloudvolume/datasource/__init__.py
@@ -43,6 +43,13 @@ class ImageSourceInterface(object):
   def transfer_to(self, cloudpath, bbox, mip):
     raise NotImplementedError()
 
+def readonlyguard(fn):
+  def guardfn(self, *args, **kwargs):
+    if self.readonly:
+      raise exceptions.ReadOnlyException(self.meta.cloudpath)
+    return fn(self, *args, **kwargs)
+  return guardfn
+
 def check_grid_aligned(meta, img, bounds, mip, throw_error=False):
   """Raise a cloudvolume.exceptions.AlignmentError if the provided image is not grid aligned."""
   shape = Vec(*img.shape)[:3]

--- a/cloudvolume/datasource/precomputed/__init__.py
+++ b/cloudvolume/datasource/precomputed/__init__.py
@@ -6,6 +6,7 @@ from .skeleton import PrecomputedSkeletonSource
 from ...cloudvolume import register_plugin, SharedConfiguration
 from ...cacheservice import CacheService
 from ...frontends import CloudVolumePrecomputed
+from ...lib import yellow
 from ...paths import strict_extract
 
 def create_precomputed(
@@ -41,6 +42,28 @@ def create_precomputed(
     )
 
     readonly = bool(meta.redirected_from)
+
+    if readonly:
+      print(yellow("""
+        Redirected 
+
+        From: {} 
+        To:   {}
+        Hops: {}
+
+        Volume set to readonly to mitigate accidental
+        redirection resulting in writing data to the wrong 
+        location.
+
+        To set the data to writable, access the destination
+        location directly or set:
+
+        vol.image.readonly = False
+        vol.mesh.readonly = False 
+        vol.skeleton.readonly = False
+      """.format(
+        cloudpath, meta.cloudpath, len(meta.redirected_from)
+      )))
 
     image = PrecomputedImageSource(
       config, meta, cache,

--- a/cloudvolume/datasource/precomputed/__init__.py
+++ b/cloudvolume/datasource/precomputed/__init__.py
@@ -14,7 +14,8 @@ def create_precomputed(
     cdn_cache=True, progress=False, info=None, provenance=None,
     compress=None, non_aligned_writes=False, parallel=1,
     delete_black_uploads=False, background_color=0, 
-    green_threads=False, use_https=False
+    green_threads=False, use_https=False,
+    max_redirects=10
   ):
     path = strict_extract(cloudpath)
     config = SharedConfiguration(
@@ -36,6 +37,7 @@ def create_precomputed(
     meta = PrecomputedMetadata(
       cloudpath, cache=cache,
       info=info, provenance=provenance,
+      max_redirects=max_redirects
     )
 
     readonly = bool(meta.redirected_from)

--- a/cloudvolume/datasource/precomputed/__init__.py
+++ b/cloudvolume/datasource/precomputed/__init__.py
@@ -38,6 +38,8 @@ def create_precomputed(
       info=info, provenance=provenance,
     )
 
+    readonly = bool(meta.redirected_from)
+
     image = PrecomputedImageSource(
       config, meta, cache,
       autocrop=bool(autocrop),
@@ -46,10 +48,11 @@ def create_precomputed(
       fill_missing=bool(fill_missing),
       delete_black_uploads=bool(delete_black_uploads),
       background_color=background_color,
+      readonly=readonly,
     )
 
-    mesh = PrecomputedMeshSource(meta, cache, config)
-    skeleton = PrecomputedSkeletonSource(meta, cache, config)
+    mesh = PrecomputedMeshSource(meta, cache, config, readonly)
+    skeleton = PrecomputedSkeletonSource(meta, cache, config, readonly)
 
     return CloudVolumePrecomputed(
       meta, cache, config, 

--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -18,7 +18,7 @@ from ....lib import Bbox, Vec
 from .... import sharedmemory
 from ....storage import Storage
 
-from ... import autocropfn, ImageSourceInterface
+from ... import autocropfn, readonlyguard, ImageSourceInterface
 from .. import sharding
 from .common import chunknames
 from . import tx, rx
@@ -31,6 +31,7 @@ class PrecomputedImageSource(ImageSourceInterface):
     fill_missing=False, 
     delete_black_uploads=False,
     background_color=0,
+    readonly=False,
   ):
     self.config = config
     self.meta = meta 
@@ -40,6 +41,7 @@ class PrecomputedImageSource(ImageSourceInterface):
     self.bounded = bool(bounded)
     self.fill_missing = bool(fill_missing)
     self.non_aligned_writes = bool(non_aligned_writes)
+    self.readonly = bool(readonly)
     
     self.delete_black_uploads = bool(delete_black_uploads)
     self.background_color = background_color
@@ -136,6 +138,7 @@ class PrecomputedImageSource(ImageSourceInterface):
         green=self.config.green,
       )
 
+  @readonlyguard
   def upload(
       self, 
       image, offset, mip, 
@@ -194,6 +197,7 @@ class PrecomputedImageSource(ImageSourceInterface):
       existence_report = storage.files_exist(cloudpaths)
     return existence_report
 
+  @readonlyguard
   def delete(self, bbox, mip=None):
     if mip is None:
       mip = self.config.mip

--- a/cloudvolume/datasource/precomputed/mesh.py
+++ b/cloudvolume/datasource/precomputed/mesh.py
@@ -25,10 +25,12 @@ def filename_to_segid(filename):
   return int(segid)
 
 class PrecomputedMeshSource(object):
-  def __init__(self, meta, cache, config):
+  def __init__(self, meta, cache, config, readonly=False):
     self.meta = meta
     self.cache = cache
     self.config = config
+
+    self.readonly = bool(readonly)
 
   @property
   def path(self):

--- a/cloudvolume/datasource/precomputed/metadata.py
+++ b/cloudvolume/datasource/precomputed/metadata.py
@@ -35,7 +35,11 @@ class PrecomputedMetadata(object):
   This class is a building block for building a class that can
   read and write Precomputed data types.
   """
-  def __init__(self, cloudpath, cache=None, info=None, provenance=None):
+  def __init__(
+    self, cloudpath, cache=None, 
+    info=None, provenance=None, 
+    max_redirects=10
+  ):
     self.path = strict_extract(cloudpath)
     self.cache = cache
     if self.cache:
@@ -45,7 +49,7 @@ class PrecomputedMetadata(object):
     self.redirected_from = []
 
     if info is None:
-      self.refresh_info()
+      self.refresh_info(max_redirects=max_redirects)
       if self.cache and self.cache.enabled:
         self.cache.check_info_validity()
     else:

--- a/cloudvolume/datasource/precomputed/metadata.py
+++ b/cloudvolume/datasource/precomputed/metadata.py
@@ -218,12 +218,12 @@ class PrecomputedMetadata(object):
     """
     visited = []
 
-    if max_redirects == 0:
+    if max_redirects <= 0:
       return self.fetch_info()
 
     for _ in range(max_redirects):
       info = self.fetch_info()
-      
+
       if 'redirect' not in info or not info['redirect']:
         break
 

--- a/cloudvolume/datasource/precomputed/metadata.py
+++ b/cloudvolume/datasource/precomputed/metadata.py
@@ -225,7 +225,10 @@ class PrecomputedMetadata(object):
     if max_redirects <= 0:
       return self.fetch_info()
 
-    start = self.cloudpath
+    if self.path.format == 'graphene':
+      start = self.server_url
+    else:
+      start = self.cloudpath
 
     for _ in range(max_redirects):
       info = self.fetch_info()

--- a/cloudvolume/datasource/precomputed/metadata.py
+++ b/cloudvolume/datasource/precomputed/metadata.py
@@ -238,7 +238,7 @@ class PrecomputedMetadata(object):
     else:
       raise exceptions.TooManyRedirects()
 
-    self.redirected_from = visited
+    self.redirected_from = visited[:-1]
 
     return info
 

--- a/cloudvolume/datasource/precomputed/skeleton/__init__.py
+++ b/cloudvolume/datasource/precomputed/skeleton/__init__.py
@@ -10,13 +10,13 @@ from ....paths import strict_extract
 from ....cloudvolume import SharedConfiguration
 
 class PrecomputedSkeletonSource(object):
-  def __new__(cls, meta, cache, config):
+  def __new__(cls, meta, cache, config, readonly=False):
     skel_meta = PrecomputedSkeletonMetadata(meta, cache)
 
     if skel_meta.is_sharded():
-      return ShardedPrecomputedSkeletonSource(skel_meta, cache, config)      
+      return ShardedPrecomputedSkeletonSource(skel_meta, cache, config, readonly) 
 
-    return UnshardedPrecomputedSkeletonSource(skel_meta, cache, config)
+    return UnshardedPrecomputedSkeletonSource(skel_meta, cache, config, readonly)
 
   @classmethod
   def from_cloudpath(cls, cloudpath, cache=False, progress=False):

--- a/cloudvolume/datasource/precomputed/skeleton/sharded.py
+++ b/cloudvolume/datasource/precomputed/skeleton/sharded.py
@@ -3,10 +3,11 @@ from ....skeleton import Skeleton
 
 
 class ShardedPrecomputedSkeletonSource(object):
-  def __init__(self, meta, cache, config):
+  def __init__(self, meta, cache, config, readonly=False):
     self.meta = meta
     self.cache = cache
     self.config = config
+    self.readonly = bool(readonly)
 
     spec = ShardingSpecification.from_dict(self.meta.info['sharding'])
     self.reader = ShardReader(meta, cache, spec)

--- a/cloudvolume/datasource/precomputed/skeleton/unsharded.py
+++ b/cloudvolume/datasource/precomputed/skeleton/unsharded.py
@@ -14,14 +14,17 @@ from cloudvolume.lib import red, Bbox
 from cloudvolume.storage import Storage, SimpleStorage
 
 from ..common import cdn_cache_control
+from ... import readonlyguard
 
 from ....skeleton import Skeleton
 
 class UnshardedPrecomputedSkeletonSource(object):
-  def __init__(self, meta, cache, config):
+  def __init__(self, meta, cache, config, readonly=False):
     self.meta = meta
     self.cache = cache
     self.config = config
+
+    self.readonly = bool(readonly)
 
   @property
   def path(self):
@@ -84,6 +87,7 @@ class UnshardedPrecomputedSkeletonSource(object):
 
     return None
 
+  @readonlyguard
   def upload_raw(self, segid, vertices, edges, radii=None, vertex_types=None):
     skel = Skeleton(
       vertices, edges, radii, 
@@ -91,6 +95,7 @@ class UnshardedPrecomputedSkeletonSource(object):
     )
     return self.upload(skel)
     
+  @readonlyguard
   def upload(self, skeletons):
     if type(skeletons) == Skeleton:
       skeletons = [ skeletons ]

--- a/cloudvolume/exceptions.py
+++ b/cloudvolume/exceptions.py
@@ -1,6 +1,20 @@
 
-class InfoUnavailableError(ValueError):
+class InfoError(Exception):
+  pass
+
+class InfoUnavailableError(InfoError):
   """CloudVolume was unable to access this layer's info file."""
+  pass
+
+class RedirectError(InfoError):
+  pass
+
+class TooManyRedirects(RedirectError):
+  """The chain of redirects became unconvincingly long."""
+  pass
+
+class CyclicRedirect(RedirectError):
+  """Unable to resolve redirects due to cycle."""
   pass
 
 class ScaleUnavailableError(IndexError):

--- a/cloudvolume/exceptions.py
+++ b/cloudvolume/exceptions.py
@@ -21,6 +21,10 @@ class ScaleUnavailableError(IndexError):
   """The info file is not configured to support this scale / mip level."""
   pass
 
+class ReadOnlyException(Exception):
+  """Attempted to write to a readonly data source."""
+  pass
+
 class AlignmentError(ValueError):
   """Signals that an operation requiring chunk alignment was not aligned."""
   pass 

--- a/cloudvolume/frontends/precomputed.py
+++ b/cloudvolume/frontends/precomputed.py
@@ -202,7 +202,8 @@ class CloudVolumePrecomputed(object):
     resolution, voxel_offset, volume_size, 
     mesh=None, skeletons=None, chunk_size=(64,64,64),
     compressed_segmentation_block_size=(8,8,8),
-    max_mip=0, factor=Vec(2,2,1), *args, **kwargs
+    max_mip=0, factor=Vec(2,2,1), redirect=None, 
+    *args, **kwargs
   ):
     """
     Create a new neuroglancer Precomputed info file.
@@ -224,6 +225,8 @@ class CloudVolumePrecomputed(object):
         (only used when encoding is 'compressed_segmentation')
       max_mip: (int), the maximum mip level id.
       factor: (Vec), the downsampling factor for each mip level
+      redirect: If this volume has moved, you can set an automatic redirect
+        by specifying a cloudpath here.
 
     Returns: dict representing a single mip level that's JSON encodable
     """

--- a/cloudvolume/paths.py
+++ b/cloudvolume/paths.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 import os
+import posixpath
 import re
 import sys
 
@@ -27,6 +28,12 @@ Cloud Path Recieved: {}
 """).format(
   ", ".join(ALLOWED_FORMATS), ", ".join(ALLOWED_PROTOCOLS), '{}' # curry first two
 )
+
+def ascloudpath(epath):
+  return "{}://{}://{}".format(
+    epath.format, epath.protocol, 
+    posixpath.join(epath.basepath, epath.dataset, epath.layer)
+  )
 
 def pop_protocol(cloudpath):
   protocol_re = re.compile(r'(\w+)://')


### PR DESCRIPTION
We were discussing a problem we are having where some of our collaborators have spreadsheets of neuroglancer links, but we are moving the layer they point to into cheaper storage. We are thinking of instrumenting Neuroglancer and CloudVolume with a redirect capability. 

I looked around for HTTP 301 support on GCS, but it didn't seem to exist, so we are proposing to handle redirects like so:

info:
```json
{
    ... may contain additional keys ... 
    "redirect": "precomputed://gs://new/location/"
}
```
The redirect process would abort with an error once a cycle is detected. 

This adds the `max_redirects` flag to CloudVolume so that you can specify how many redirects are allowed. 0 for direct access, 10 by default.

If a redirect occurs, a readonly flag is set on image upload automatically, but can be disabled.

```python
# fixing a broken redirect
vol = CloudVolume(..., max_redirects=0)
del vol.info['redirect']
vol.commit_info()

# setting images to writable 
vol = CloudVolume(...) # redirected 1 or more times
vol.image.readonly = False
```

