### PR TITLE
sets ACL by default for s3 interface

### DIFF
--- a/cloudvolume/storage/storage_interfaces.py
+++ b/cloudvolume/storage/storage_interfaces.py
@@ -338,7 +338,7 @@ class S3Interface(StorageInterface):
     return posixpath.join(self._path.no_bucket_basepath, self._path.layer, file_path)
 
   @retry
-  def put_file(self, file_path, content, content_type, compress, cache_control=None):
+  def put_file(self, file_path, content, content_type, compress, cache_control=None, ACL="bucket-owner-full-control"):
     key = self.get_path_to_file(file_path)
 
     attrs = {
@@ -346,6 +346,7 @@ class S3Interface(StorageInterface):
       'Body': content,
       'Key': key,
       'ContentType': (content_type or 'application/octet-stream'),
+      'ACL': ACL,
     }
 
     if compress:


### PR DESCRIPTION
On S3 when a user from a separate account puts objects into a S3 bucket that they do not own, the default behavior is that the actual owner of that bucket has no privileges to those objects.  This is in my experience rarely desired behavior and can be quite tedious to fix after the fact.

This PR attempts to set a default ACL for objects created using cloud volume.

This is not generalized and might be necessary for other clouds as well.

Also, would need to be propagated through the code in order for a user to be able to supply a custom ACL, in the case that they actually want ACL to limit owner control.

Happy to to more work on this as needed but wanted to check in first to make sure it was something wanted or if you had some other idea how to tackle this.