### PR TITLE
fix: actually del cls

### DIFF
--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -183,7 +183,7 @@ class CloudVolume(object):
     if use_https:
       cloudpath = to_https_protocol(cloudpath)
 
-    kwargs = locals()
+    kwargs = dict(locals())
     del kwargs['cls']
 
     path = strict_extract(cloudpath)


### PR DESCRIPTION
this fixes an issue where the "del" command wasn't actually removing the object from the dictionary

i'm not entirely sure exactly what was going on, but my best guess is that it was related to some namespace issue where `kwargs` was already defined in locals

by passing it through "dict" i believe this does an object copy which then allows del to complete