### PR TITLE
feat: add brotli compression option

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ CloudVolume(cloudpath,
 * progress - Show progress bars. Defaults to True if in python interactive mode else default False.
 * info - Use this info object rather than pulling from the cloud (useful for creating new layers).
 * provenance - Use this object as the provenance file.
-* compress - None or 'gzip', force this compression algorithm to be used for upload
+* compress - None, 'gzip' or 'br', force this compression algorithm to be used for upload
 * non_aligned_writes - True/False. If False, non-chunk-aligned writes will trigger an error with a helpful message. If True,
     Non-aligned writes will proceed. Be careful, non-aligned writes are wasteful in memory and bandwidth, and in a mulitprocessing environment, are subject to an ugly race condition. (c.f. https://github.com/seung-lab/cloud-volume/wiki/Advanced-Topic:-Non-Aligned-Writes)
 * parallel - True/False/(int > 0), If False or 1, use a single process. If > 1, use that number of processes for downloading 

--- a/cloudvolume/cacheservice.py
+++ b/cloudvolume/cacheservice.py
@@ -314,7 +314,7 @@ class CacheService(object):
     kwargs['progress'] = False
     return self.upload( [(filename, content)], *args, **kwargs )
 
-  def upload(self, files, subdir, compress, cache_control, content_type=None, progress=None):
+  def upload(self, files, subdir, compress, cache_control, compress_level=None, content_type=None, progress=None):
     files = list(files)
 
     progress = progress if progress is not None else self.config.progress
@@ -324,6 +324,7 @@ class CacheService(object):
       remote_fragments = stor.put_files(
         files=files,
         compress=compress,
+        compress_level=compress_level,
         cache_control=cache_control,
         content_type=content_type,
       )
@@ -412,7 +413,7 @@ class CacheService(object):
     kwargs['progress'] = False
     return self.put([ (path, content) ], *args, **kwargs)
 
-  def put(self, files, progress=None, compress=None):
+  def put(self, files, progress=None, compress=None, compress_level=None):
     if progress is None:
       progress = self.config.progress
 
@@ -429,6 +430,7 @@ class CacheService(object):
       stor.put_files(
         [ (name, content) for name, content in files ],
         compress=compress,
+        compress_level=compress_level,
       )
 
   def compute_data_locations(self, cloudpaths):

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -125,7 +125,7 @@ class CloudVolume(object):
         - int: number of seconds for cache to be considered fresh (max-age)
         - bool: True: max-age=3600, False: no-cache
         - str: set the header manually
-      compress: (bool, str, None) pick which compression method to use. 
+      compress: (bool, str, None) pick which compression method to use.
           None: (default) gzip for raw arrays and no additional compression
             for compressed_segmentation and fpzip.
           bool: 
@@ -134,10 +134,12 @@ class CloudVolume(object):
           str: 
             'gzip': Extension so that we can add additional methods in the future 
                     like lz4 or zstd. 
-            'br': Brotli compression
+            'br': Brotli compression, better compression rate than gzip
             '': no compression (same as False).
-      compress_level: (int, None) level for brotli compression. Ignored for other compression types.
-        Defaults to 6 for brotli if not specified or None.
+      compress_level: (int, None) level for compression. Higher number results
+          in better compression but takes longer.
+        Defaults to 9 for gzip (ranges from 0 to 9).
+        Defaults to 5 for brotli (ranges from 0 to 11).
       compress_cache: (None or bool) If not None, override default compression 
           behavior for the cache.
       delete_black_uploads: (bool) If True, on uploading an entirely black chunk,

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -135,6 +135,8 @@ class CloudVolume(object):
                     like lz4 or zstd. 
             'br': Brotli compression
             '': no compression (same as False).
+      compress_level: (int, None) level for brotli compression. Ignored for other compression types.
+        Defaults to 6 for brotli if not specified or None.
       compress_cache: (None or bool) If not None, override default compression 
           behavior for the cache.
       delete_black_uploads: (bool) If True, on uploading an entirely black chunk,

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -30,7 +30,7 @@ class SharedConfiguration(object):
   synchronize them.
   """
   def __init__(
-    self, cdn_cache, compress, green,
+    self, cdn_cache, compress, compress_level, green,
     mip, parallel, progress,
     *args, **kwargs
   ):
@@ -43,6 +43,7 @@ class SharedConfiguration(object):
 
     self.cdn_cache = cdn_cache
     self.compress = compress
+    self.compress_level = compress_level
     self.green = bool(green)
     self.mip = mip
     self.parallel = parallel 
@@ -55,7 +56,7 @@ class CloudVolume(object):
     cloudpath, mip=0, bounded=True, autocrop=False,
     fill_missing=False, cache=False, compress_cache=None,
     cdn_cache=True, progress=INTERACTIVE, info=None, provenance=None,
-    compress=None, non_aligned_writes=False, parallel=1,
+    compress=None, compress_level=None, non_aligned_writes=False, parallel=1,
     delete_black_uploads=False, background_color=0,
     green_threads=False, use_https=False,
     max_redirects=10

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -133,6 +133,7 @@ class CloudVolume(object):
           str: 
             'gzip': Extension so that we can add additional methods in the future 
                     like lz4 or zstd. 
+            'br': Brotli compression
             '': no compression (same as False).
       compress_cache: (None or bool) If not None, override default compression 
           behavior for the cache.

--- a/cloudvolume/compression.py
+++ b/cloudvolume/compression.py
@@ -60,14 +60,17 @@ def compress(content, method='gzip', compress_level=None):
   if method == '':
     return content
   elif method == 'gzip': 
-    return gzip_compress(content)
+    return gzip_compress(content, compresslevel=compress_level)
   elif method == 'br':
     return brotli_compress(content, quality=compress_level)
   raise NotImplementedError(str(method) + ' is not currently supported. Supported Options: None, gzip')
 
-def gzip_compress(content):
+def gzip_compress(content, compresslevel=None):
+  if compresslevel is None:
+    compresslevel = 9
+  
   stringio = BytesIO()
-  gzip_obj = gzip.GzipFile(mode='wb', fileobj=stringio)
+  gzip_obj = gzip.GzipFile(mode='wb', fileobj=stringio, compresslevel=compresslevel)
 
   if sys.version_info < (3,):
     content = str(content)
@@ -95,7 +98,8 @@ def gunzip(content):
 
 def brotli_compress(content, quality=None):
   if quality is None:
-    quality = 6  # 5/6 are good balance between compression speed and compression rate
+    # 5/6 are good balance between compression speed and compression rate
+    quality = 5
   return brotli.compress(content, quality=quality)
 
 def brotli_decompress(content):

--- a/cloudvolume/compression.py
+++ b/cloudvolume/compression.py
@@ -3,10 +3,12 @@ from six import StringIO, BytesIO
 import gzip
 import sys
 
+import brotli
+
 from .exceptions import DecompressionError, CompressionError
 from .lib import yellow
 
-COMPRESSION_TYPES = [ None, False, True, '', 'gzip' ]
+COMPRESSION_TYPES = [ None, False, True, '', 'gzip', 'br' ]
 
 def decompress(content, encoding, filename='N/A'):
   """
@@ -14,7 +16,7 @@ def decompress(content, encoding, filename='N/A'):
 
   Required: 
     content (bytes): a file to be compressed
-    encoding: None (no compression) or 'gzip'
+    encoding: None (no compression) or 'gzip' or 'br'
   Optional:   
     filename (str:default:'N/A'): Used for debugging messages
   Raises: 
@@ -29,6 +31,8 @@ def decompress(content, encoding, filename='N/A'):
       return content
     elif encoding == 'gzip':
       return gunzip(content)
+    elif encoding == 'br':
+      return brotli_decompress(content)
   except DecompressionError as err:
     print("Filename: " + str(filename))
     raise
@@ -57,6 +61,8 @@ def compress(content, method='gzip'):
     return content
   elif method == 'gzip': 
     return gzip_compress(content)
+  elif method == 'br':
+    return brotli_compress(content)
   raise NotImplementedError(str(method) + ' is not currently supported. Supported Options: None, gzip')
 
 def gzip_compress(content):
@@ -87,4 +93,8 @@ def gunzip(content):
   with gzip.GzipFile(mode='rb', fileobj=stringio) as gfile:
     return gfile.read()
 
+def brotli_compress(content, quality=6):
+  return brotli.compress(content, quality=quality)
 
+def brotli_decompress(content):
+  return brotli.decompress(content)

--- a/cloudvolume/compression.py
+++ b/cloudvolume/compression.py
@@ -39,7 +39,7 @@ def decompress(content, encoding, filename='N/A'):
   
   raise NotImplementedError(str(encoding) + ' is not currently supported. Supported Options: None, gzip')
 
-def compress(content, method='gzip'):
+def compress(content, method='gzip', compress_level=None):
   """
   Compresses file content.
 
@@ -62,7 +62,7 @@ def compress(content, method='gzip'):
   elif method == 'gzip': 
     return gzip_compress(content)
   elif method == 'br':
-    return brotli_compress(content)
+    return brotli_compress(content, quality=compress_level)
   raise NotImplementedError(str(method) + ' is not currently supported. Supported Options: None, gzip')
 
 def gzip_compress(content):
@@ -93,7 +93,9 @@ def gunzip(content):
   with gzip.GzipFile(mode='rb', fileobj=stringio) as gfile:
     return gfile.read()
 
-def brotli_compress(content, quality=6):
+def brotli_compress(content, quality=None):
+  if quality is None:
+    quality = 6  # 5/6 are good balance between compression speed and compression rate
   return brotli.compress(content, quality=quality)
 
 def brotli_decompress(content):

--- a/cloudvolume/datasource/boss/__init__.py
+++ b/cloudvolume/datasource/boss/__init__.py
@@ -18,6 +18,7 @@ def create_boss(
     config = SharedConfiguration(
       cdn_cache=cdn_cache,
       compress=compress,
+      compress_level=None,
       green=green_threads,
       mip=mip,
       parallel=parallel,

--- a/cloudvolume/datasource/graphene/__init__.py
+++ b/cloudvolume/datasource/graphene/__init__.py
@@ -24,6 +24,7 @@ def create_graphene(
     config = SharedConfiguration(
       cdn_cache=cdn_cache,
       compress=compress,
+      compress_level=None,
       green=green_threads,
       mip=mip,
       parallel=parallel,

--- a/cloudvolume/datasource/precomputed/__init__.py
+++ b/cloudvolume/datasource/precomputed/__init__.py
@@ -13,7 +13,7 @@ def create_precomputed(
     cloudpath, mip=0, bounded=True, autocrop=False,
     fill_missing=False, cache=False, compress_cache=None,
     cdn_cache=True, progress=False, info=None, provenance=None,
-    compress=None, non_aligned_writes=False, parallel=1,
+    compress=None, compress_level=None, non_aligned_writes=False, parallel=1,
     delete_black_uploads=False, background_color=0, 
     green_threads=False, use_https=False,
     max_redirects=10
@@ -22,6 +22,7 @@ def create_precomputed(
     config = SharedConfiguration(
       cdn_cache=cdn_cache,
       compress=compress,
+      compress_level=compress_level,
       green=green_threads,
       mip=mip,
       parallel=parallel,

--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -163,6 +163,7 @@ class PrecomputedImageSource(ImageSourceInterface):
       self.meta, self.cache,
       image, offset, mip,
       compress=self.config.compress,
+      compress_level=self.config.compress_level,
       cdn_cache=self.config.cdn_cache,
       parallel=parallel, 
       progress=self.config.progress,

--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -228,7 +228,7 @@ class PrecomputedImageSource(ImageSourceInterface):
         storage.delete_files(cloudpaths)
 
 
-  def transfer_to(self, cloudpath, bbox, mip, block_size=None, compress=True):
+  def transfer_to(self, cloudpath, bbox, mip, block_size=None, compress=True, compress_level=None):
     """
     Transfer files from one storage location to another, bypassing
     volume painting. This enables using a single CloudVolume instance
@@ -315,6 +315,7 @@ class PrecomputedImageSource(ImageSourceInterface):
             dest_stor.put_files(
               files=files, 
               compress=compress, 
+              compress_level=compress_level,
               content_type=tx.content_type(destvol),
             )
             pbar.update()

--- a/cloudvolume/datasource/precomputed/image/tx.py
+++ b/cloudvolume/datasource/precomputed/image/tx.py
@@ -33,6 +33,7 @@ def upload(
     meta, cache,
     image, offset, mip,
     compress=None,
+    compress_level=None,
     cdn_cache=None,
     parallel=1,
     progress=False,
@@ -65,6 +66,7 @@ def upload(
 
   options = {
     "compress": compress,
+    "compress_level": compress_level,
     "cdn_cache": cdn_cache,
     "parallel": parallel, 
     "progress": progress,
@@ -132,6 +134,7 @@ def upload_aligned(
     meta, cache,
     img, offset, mip,
     compress=None,
+    compress_level=None,
     cdn_cache=None,
     progress=False,
     parallel=1, 
@@ -156,7 +159,7 @@ def upload_aligned(
       compress=compress, cdn_cache=cdn_cache,
       delete_black_uploads=delete_black_uploads,
       background_color=background_color,
-      green=green,
+      green=green, compress_level=compress_level,
     )
     return
 
@@ -184,7 +187,7 @@ def upload_aligned(
     compress, cdn_cache, progress,
     location, location_bbox, location_order, 
     delete_black_uploads, background_color, 
-    green,
+    green, compress_level=compress_level
   )
 
   parallel_execution(cup, chunk_ranges_by_process, parallel, cleanup_shm=location)
@@ -201,7 +204,7 @@ def child_upload_process(
     compress, cdn_cache, progress,
     location, location_bbox, location_order, 
     delete_black_uploads, background_color,
-    green, chunk_ranges
+    green, chunk_ranges, compress_level=None,
   ):
   global fs_lock
   reset_connection_pools()
@@ -230,7 +233,7 @@ def child_upload_process(
     compress=compress, cdn_cache=cdn_cache, progress=progress,
     delete_black_uploads=delete_black_uploads, 
     background_color=background_color,
-    green=green,
+    green=green, compress_level=compress_level,
   )
   array_like.close()
 

--- a/cloudvolume/datasource/precomputed/image/tx.py
+++ b/cloudvolume/datasource/precomputed/image/tx.py
@@ -242,6 +242,7 @@ def threaded_upload_chunks(
     delete_black_uploads=False,
     background_color=0,
     green=False,
+    compress_level=None,
   ):
   
   if cache.enabled:
@@ -262,6 +263,7 @@ def threaded_upload_chunks(
         content=encoded,
         content_type=content_type(meta.encoding(mip)), 
         compress=should_compress(meta.encoding(mip), compress, cache),
+        compress_level=compress_level,
         cache_control=cdn_cache_control(cdn_cache),
       )
 

--- a/cloudvolume/datasource/precomputed/skeleton/__init__.py
+++ b/cloudvolume/datasource/precomputed/skeleton/__init__.py
@@ -23,6 +23,7 @@ class PrecomputedSkeletonSource(object):
     config = SharedConfiguration(
       cdn_cache=False,
       compress=True,
+      compress_level=None,
       green=False,
       mip=0,
       parallel=1,

--- a/cloudvolume/exceptions.py
+++ b/cloudvolume/exceptions.py
@@ -55,6 +55,12 @@ class OutOfBoundsError(ValueError):
   of the volume's bounds
   """
 
+class UnsupportedCompressionType(ValueError):
+  """
+  Raised when attempting to use a compression type which is unsupported
+  by the storage interface.
+  """
+
 # Inheritance below done for backwards compatibility reasons.
 
 class DecompressionError(DecodingError):

--- a/cloudvolume/lib.py
+++ b/cloudvolume/lib.py
@@ -242,7 +242,7 @@ Vec.a = Vec.w
 def floating(lst):
   return any(( isinstance(x, float) for x in lst ))
 
-FILENAME_RE = re.compile(r'(-?\d+)-(-?\d+)_(-?\d+)-(-?\d+)_(-?\d+)-(-?\d+)(?:\.gz)?$')
+FILENAME_RE = re.compile(r'(-?\d+)-(-?\d+)_(-?\d+)-(-?\d+)_(-?\d+)-(-?\d+)(?:\.gz|\.br)?$')
 
 class Bbox(object):
   __slots__ = [ 'minpt', 'maxpt', '_dtype' ]
@@ -344,6 +344,9 @@ class Bbox(object):
   @classmethod
   def from_filename(cls, filename, dtype=int):
     match = FILENAME_RE.search(os.path.basename(filename))
+
+    if match is None:
+      raise FileNotFoundError
 
     (xmin, xmax,
      ymin, ymax,

--- a/cloudvolume/storage/storage_interfaces.py
+++ b/cloudvolume/storage/storage_interfaces.py
@@ -190,10 +190,8 @@ class GoogleCloudStorageInterface(StorageInterface):
     key = self.get_path_to_file(file_path)
     blob = self._bucket.blob( key )
 
-    # keep default gzip
-    if compress == "br":
-      blob.content_encoding = "br"
-    elif compress:
+    # gcloud disable brotli until content-encoding works
+    if compress:
       blob.content_encoding = "gzip"
     if cache_control:
       blob.cache_control = cache_control

--- a/cloudvolume/storage/storage_interfaces.py
+++ b/cloudvolume/storage/storage_interfaces.py
@@ -191,7 +191,9 @@ class GoogleCloudStorageInterface(StorageInterface):
     blob = self._bucket.blob( key )
 
     # gcloud disable brotli until content-encoding works
-    if compress:
+    if compress == "br":
+      raise TypeError("Brotli unsupported on google cloud storage")
+    elif compress:
       blob.content_encoding = "gzip"
     if cache_control:
       blob.cache_control = cache_control

--- a/cloudvolume/storage/storage_interfaces.py
+++ b/cloudvolume/storage/storage_interfaces.py
@@ -319,6 +319,8 @@ class HttpInterface(StorageInterface):
     else:
       resp = requests.get(key)
       if resp.headers.get('Content-Encoding') == 'br':
+        # needed until requests natively supports brotli
+        # https://github.com/psf/requests/issues/4525
         resp._content = brotli.decompress(resp.content)
     if resp.status_code in (404, 403):
       return None, None

--- a/cloudvolume/storage/storage_interfaces.py
+++ b/cloudvolume/storage/storage_interfaces.py
@@ -67,7 +67,10 @@ class FileInterface(StorageInterface):
     path = self.get_path_to_file(file_path)
     mkdir(os.path.dirname(path))
 
-    if compress:
+    # keep default as gzip
+    if compress == "br":
+      path += ".br"
+    elif compress:
       path += '.gz'
 
     if content \
@@ -87,13 +90,15 @@ class FileInterface(StorageInterface):
   def get_file(self, file_path, start=None, end=None):
     path = self.get_path_to_file(file_path)
 
-    compressed = os.path.exists(path + '.gz')
-      
-    if compressed:
+    if os.path.exists(path + '.gz'):
+      encoding = "gzip"
       path += '.gz'
+    elif os.path.exists(path + '.br'):
+      encoding = "br"
+      path += ".br"
+    else:
+      encoding = None
 
-    encoding = 'gzip' if compressed else None
-    
     try:
       with open(path, 'rb') as f:
         if start is not None:
@@ -184,7 +189,11 @@ class GoogleCloudStorageInterface(StorageInterface):
   def put_file(self, file_path, content, content_type, compress, cache_control=None):
     key = self.get_path_to_file(file_path)
     blob = self._bucket.blob( key )
-    if compress:
+
+    # keep default gzip
+    if compress == "br":
+      blob.content_encoding = "br"
+    elif compress:
       blob.content_encoding = "gzip"
     if cache_control:
       blob.cache_control = cache_control
@@ -349,7 +358,10 @@ class S3Interface(StorageInterface):
       'ACL': ACL,
     }
 
-    if compress:
+    # keep gzip as default
+    if compress == "br":
+      attrs['ContentEncoding'] = 'br'
+    elif compress:
       attrs['ContentEncoding'] = 'gzip'
     if cache_control:
       attrs['CacheControl'] = cache_control

--- a/cloudvolume/storage/storage_interfaces.py
+++ b/cloudvolume/storage/storage_interfaces.py
@@ -318,6 +318,8 @@ class HttpInterface(StorageInterface):
       resp = requests.get(key, headers=headers)
     else:
       resp = requests.get(key)
+      if resp.headers.get('Content-Encoding') == 'br':
+        resp._content = brotli.decompress(resp.content)
     if resp.status_code in (404, 403):
       return None, None
     resp.raise_for_status()

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ six>=1.10.0
 tenacity>=4.10.0
 tqdm
 urllib3[secure]==1.24.2
+brotli>=1.0.7

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -1375,7 +1375,7 @@ def test_redirects():
   
 @pytest.mark.parametrize("compress_method", ('', None, True, False, 'gzip', 'br'))
 def test_compression_methods(compress_method):
-  path = "file:///tmp/removeme/test/" + '-' + str(TEST_NUMBER)
+  path = "file:///tmp/cloudvolume/test" + '-' + str(TEST_NUMBER)
 
 
   # create a NG volume
@@ -1398,7 +1398,7 @@ def test_compression_methods(compress_method):
 
   image_test = vol[0:512, 0:512, 0:16]
   
-  delete_layer('/tmp/cloudvolume/redirects_' + '-' + str(TEST_NUMBER))
+  delete_layer('/tmp/cloudvolume/test' + '-' + str(TEST_NUMBER))
 
   assert vol.compress == compress_method
   assert np.array_equal(image_test, image)

--- a/test/test_compression.py
+++ b/test/test_compression.py
@@ -6,12 +6,11 @@ import numpy as np
 
 from cloudvolume.compression import compress, decompress
 
-def test_gzip():
+@pytest.mark.parametrize("compression_method", ("gzip", "br"))
+def test_compression(compression_method):
   for N in range(100):
     flts = np.array(range(N), dtype=np.float32).reshape( (N,1,1,1) ).tostring()
-    compressed = compress(flts, 'gzip')
+    compressed = compress(flts, compression_method)
     assert compressed != flts
-    decompressed = decompress(compressed, 'gzip')
+    decompressed = decompress(compressed, compression_method)
     assert decompressed == flts
-
-  

--- a/test/test_compression.py
+++ b/test/test_compression.py
@@ -14,3 +14,25 @@ def test_compression(compression_method):
     assert compressed != flts
     decompressed = decompress(compressed, compression_method)
     assert decompressed == flts
+
+def test_br_compress_level():
+  N=10000
+  x = np.array(range(N), dtype=np.float32).reshape( (N,1,1,1) )
+  content = np.ascontiguousarray(x, dtype=np.float32).tostring()
+
+  compr_rate = []
+  compress_levels = range(1, 7, 2)
+  for compress_level in compress_levels:
+    compressed = compress(content, "br", compress_level=compress_level)
+    
+    assert compressed != content
+    decompressed = decompress(compressed, "br")
+    assert decompressed == content
+
+    compr_rate.append(len(compressed) / len(content))
+
+  # make sure we get better compression at highest level than lowest level
+  assert compr_rate[-1] < compr_rate[0]
+
+  # make sure we dont get worse compr rates with each level
+  assert all(x >= y for x, y in zip(compr_rate, compr_rate[1:]))

--- a/test/test_compression.py
+++ b/test/test_compression.py
@@ -14,7 +14,7 @@ def test_compression(compression_method):
     assert decompressed == flts
 
 @pytest.mark.parametrize("compression_method", ("gzip", "br"))
-def test_br_compress_level(compression_method):
+def test_compress_level(compression_method):
   N = 10000
   x = np.array(range(N), dtype=np.float32).reshape( (N, 1, 1, 1) )
   content = np.ascontiguousarray(x, dtype=np.float32).tostring()

--- a/test/test_compression.py
+++ b/test/test_compression.py
@@ -1,7 +1,5 @@
 import pytest
 
-import sys
-
 import numpy as np
 
 from cloudvolume.compression import compress, decompress
@@ -15,24 +13,22 @@ def test_compression(compression_method):
     decompressed = decompress(compressed, compression_method)
     assert decompressed == flts
 
-def test_br_compress_level():
-  N=10000
-  x = np.array(range(N), dtype=np.float32).reshape( (N,1,1,1) )
+@pytest.mark.parametrize("compression_method", ("gzip", "br"))
+def test_br_compress_level(compression_method):
+  N = 10000
+  x = np.array(range(N), dtype=np.float32).reshape( (N, 1, 1, 1) )
   content = np.ascontiguousarray(x, dtype=np.float32).tostring()
 
   compr_rate = []
-  compress_levels = range(1, 7, 2)
+  compress_levels = (1, 8)
   for compress_level in compress_levels:
-    compressed = compress(content, "br", compress_level=compress_level)
+    compressed = compress(content, compression_method, compress_level=compress_level)
     
     assert compressed != content
-    decompressed = decompress(compressed, "br")
+    decompressed = decompress(compressed, compression_method)
     assert decompressed == content
 
     compr_rate.append(len(compressed) / len(content))
 
   # make sure we get better compression at highest level than lowest level
   assert compr_rate[-1] < compr_rate[0]
-
-  # make sure we dont get worse compr rates with each level
-  assert all(x >= y for x, y in zip(compr_rate, compr_rate[1:]))

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -132,3 +132,29 @@ def test_jsonify():
 
   assert lib.jsonify(obj, sort_keys=True) == r"""{"w": "1 2 34 5", "x": [[1, 2, 3, 4, 5]], "y": [{}, {}], "z": 5}"""
 
+
+def test_bbox_from_filename():
+  filenames = [
+    "0-512_0-512_0-16",
+    "0-512_0-512_0-16.gz",
+    "0-512_0-512_0-16.br",
+  ]
+
+  for fn in filenames:
+    bbox = Bbox.from_filename(fn)
+    assert np.array_equal(bbox.minpt, [0, 0, 0])
+    assert np.array_equal(bbox.maxpt, [512, 512, 16])
+
+  filenames = [
+    "gibberish",
+    "0-512_0-512_0-16.lol",
+    "0-512_0-512_0-16.gzip",
+    "0-512_0-512_0-16.brotli",
+    "0-512_0-512_0-16.na",
+    "0-512_0-512_0-abc",
+    "0-512_0-abc_0-16",
+    "0-abc_0-512_0-16",
+  ]
+  for fn in filenames:
+    with pytest.raises(FileNotFoundError):
+      bbox = Bbox.from_filename(fn)

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -140,8 +140,15 @@ def test_compression():
         content = b'some_string'
         s.put_file('info', content, compress=method)
         s.wait()
-        retrieved = s.get_file('info')
-        assert content == retrieved
+
+        # remove when GCS enables "br"
+        if method == "br" and "gs://" in url:
+          with pytest.raises(TypeError, match="Brotli unsupported on google cloud storage"):
+            retrieved = s.get_file('info')
+        else:
+          retrieved = s.get_file('info')
+          assert content == retrieved
+
         assert s.get_file('nonexistentfile') is None
 
     with Storage(url, n_threads=5) as s:

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -153,28 +153,30 @@ def test_compression():
         pass
 
     if "file://" in url:
-      delete_layer("/tmp/removeme/compress" + '-' + str(TEST_NUMBER))
+      delete_layer("/tmp/removeme/compress-" + str(TEST_NUMBER))
 
 @pytest.mark.parametrize("compression_method", ("gzip", "br"))
-def test_br_compress_level(compression_method):
-  url = "file:///tmp/removeme/compress_level" + '-' + str(TEST_NUMBER)
+def test_compress_level(compression_method):
+  filepath = "/tmp/removeme/compress_level-" + str(TEST_NUMBER)
+  url = "file://" + filepath
 
   content = b'some_string' * 1000
 
-  compr_rate = []
   compress_levels = range(1, 9, 2)
   for compress_level in compress_levels:
     with Storage(url, n_threads=5) as s:
       s.put_file('info', content, compress=compression_method, compress_level=compress_level)
       s.wait()
+
       retrieved = s.get_file('info')
       assert content == retrieved
-      assert s.get_file('nonexistentfile') is None
 
-      c, e = s._interface.get_file("info")
+      _, e = s._interface.get_file("info")
       assert e == compression_method
 
-  delete_layer(url)
+      assert s.get_file('nonexistentfile') is None
+
+    delete_layer(filepath)
 
 
 def test_list():  

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -155,7 +155,8 @@ def test_compression():
     if "file://" in url:
       delete_layer("/tmp/removeme/compress" + '-' + str(TEST_NUMBER))
 
-def test_br_compress_level():
+@pytest.mark.parametrize("compression_method", ("gzip", "br"))
+def test_br_compress_level(compression_method):
   url = "file:///tmp/removeme/compress_level" + '-' + str(TEST_NUMBER)
 
   content = b'some_string' * 1000
@@ -164,16 +165,17 @@ def test_br_compress_level():
   compress_levels = range(1, 9, 2)
   for compress_level in compress_levels:
     with Storage(url, n_threads=5) as s:
-      s.put_file('info', content, compress="br", compress_level=compress_level)
+      s.put_file('info', content, compress=compression_method, compress_level=compress_level)
       s.wait()
       retrieved = s.get_file('info')
       assert content == retrieved
       assert s.get_file('nonexistentfile') is None
 
       c, e = s._interface.get_file("info")
-      assert e == "br"
+      assert e == compression_method
 
   delete_layer(url)
+
 
 def test_list():  
   urls = [

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -130,6 +130,7 @@ def test_compression():
     True,
     False,
     'gzip',
+    'br',
   ]
 
   for url in urls:
@@ -151,7 +152,8 @@ def test_compression():
       except NotImplementedError:
         pass
 
-  delete_layer("/tmp/removeme/compression")
+    if "file://" in url:
+      delete_layer("/tmp/removeme/compress" + '-' + str(TEST_NUMBER))
 
 def test_list():  
   urls = [

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -155,6 +155,26 @@ def test_compression():
     if "file://" in url:
       delete_layer("/tmp/removeme/compress" + '-' + str(TEST_NUMBER))
 
+def test_br_compress_level():
+  url = "file:///tmp/removeme/compress_level" + '-' + str(TEST_NUMBER)
+
+  content = b'some_string' * 1000
+
+  compr_rate = []
+  compress_levels = range(1, 9, 2)
+  for compress_level in compress_levels:
+    with Storage(url, n_threads=5) as s:
+      s.put_file('info', content, compress="br", compress_level=compress_level)
+      s.wait()
+      retrieved = s.get_file('info')
+      assert content == retrieved
+      assert s.get_file('nonexistentfile') is None
+
+      c, e = s._interface.get_file("info")
+      assert e == "br"
+
+  delete_layer(url)
+
 def test_list():  
   urls = [
     "file:///tmp/removeme/list",


### PR DESCRIPTION
This adds brotli compression with a default compression level of 6.

My [testing](https://nbviewer.jupyter.org/github/neurodata/boss-export/blob/lambda/scripts/bench_compress.ipynb) has shown that there's a nice 10% compression rate advantage, with a small cost in compression/decompression speed.

I added tests for brotli with localfile volumes, but wasn't able to run the s3/gcs specific tests.

I did test "pulling" one of our brotli compressed datasets from a public precomputed test volume we have which you should be able to test as well.  See below:

```python3
import os

import boto3
import numpy as np
from PIL import Image

from cloudvolume import CloudVolume

path = "s3://open-neurodata-test/ZBrain/ZBrain/ZBB_y385-Cre"
vol = CloudVolume(path)

image = vol[0:512, 0:512, 0:16]

img = Image.fromarray(image[:,:,0,0])
img.save("/tmp/removeme/img.tif")
```