### PR TITLE
install: requests/urllib supports brotli

### DIFF
--- a/cloudvolume/storage/storage_interfaces.py
+++ b/cloudvolume/storage/storage_interfaces.py
@@ -12,7 +12,6 @@ import google.cloud.exceptions
 from google.cloud.storage import Batch, Client
 import requests
 import tenacity
-import brotli
 
 from cloudvolume.connectionpools import S3ConnectionPool, GCloudBucketPool
 from cloudvolume.lib import mkdir
@@ -324,10 +323,6 @@ class HttpInterface(StorageInterface):
       resp = requests.get(key, headers=headers)
     else:
       resp = requests.get(key)
-      if resp.headers.get('Content-Encoding') == 'br':
-        # needed until requests natively supports brotli
-        # https://github.com/psf/requests/issues/4525
-        resp._content = brotli.decompress(resp.content)
     if resp.status_code in (404, 403):
       return None, None
     resp.raise_for_status()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,8 @@ numpy>=1.13.3
 python-jsonschema-objects>=0.3.3
 Pillow>=4.2.1
 protobuf>=3.3.0
-requests>=2.18.4
+requests>=2.22.0
 six>=1.10.0
 tenacity>=4.10.0
 tqdm
-urllib3[secure]==1.24.2
-brotli>=1.0.7
+urllib3[secure,brotli]>=1.25.7


### PR DESCRIPTION
Somehow I missed that `urllib3/requests` does now support `brotli`, through the optional install parameter in urllib3 (and by using latest releases from both).  Discovered this yesterday when I had a different version of requests installed in a different virtual environment and was running into problem decoding brotli encoded data (because it was trying to decode an already decoded response, and I had brotli installed in that environment).

A few things to keep an eye out for w/ this PR:

1. This "unpins" and upgrades `urlib3`.  Also upgrades requests, but that wasn't unpinned, so don't think it's a big deal.  Not sure if pinning urlib3 was important, can repin if necessary.  Brotli was added in 1.25 of urlib3.  I tested on 1.25.7.  Requests added support in latest release, 2.22.0.

2. I'm not sure what this does for people who install from source.  I think it will be fine though, as long as they reinstall from requirements.txt

3. I didn't/can't run the entire test suite