### PR TITLE
Feat: store draco_grid_size in info file

### DIFF
--- a/cloudvolume/datasource/graphene/mesh.py
+++ b/cloudvolume/datasource/graphene/mesh.py
@@ -111,27 +111,26 @@ class GrapheneMeshSource(UnshardedLegacyPrecomputedMeshSource):
 
       if remove_duplicate_vertices:
         mesh = mesh.consolidate()
-      else:
-        if is_draco:
-          if self.meta.uniform_draco_grid_size is not None or level == 2:
-            draco_grid_size = self.meta.get_draco_grid_size(level)
-            mesh = mesh.deduplicate_chunk_boundaries(
-              self.meta.mesh_chunk_size * resolution,
-              offset=offset * resolution,
-              is_draco=True,
-              draco_grid_size=draco_grid_size,
-            )
-          else:
-            # TODO: cyclic draco quantization to properly
-            # stitch and deduplicate draco meshes at variable
-            # levels (see github issue #299)
-            print('Warning: deduplication not currently supported for this layer\'s variable layered draco meshes')
-        else:
+      elif is_draco:
+        if self.meta.uniform_draco_grid_size is not None or level == 2:
+          draco_grid_size = self.meta.get_draco_grid_size(level)
           mesh = mesh.deduplicate_chunk_boundaries(
-              self.meta.mesh_chunk_size * resolution,
-              offset=offset * resolution,
-              is_draco=False,
-            )
+            self.meta.mesh_chunk_size * resolution,
+            offset=offset * resolution,
+            is_draco=True,
+            draco_grid_size=draco_grid_size,
+          )
+        else:
+          # TODO: cyclic draco quantization to properly
+          # stitch and deduplicate draco meshes at variable
+          # levels (see github issue #299)
+          print('Warning: deduplication not currently supported for this layer\'s variable layered draco meshes')
+      else:
+        mesh = mesh.deduplicate_chunk_boundaries(
+            self.meta.mesh_chunk_size * resolution,
+            offset=offset * resolution,
+            is_draco=False,
+          )
       
       meshes.append(mesh)
 

--- a/cloudvolume/datasource/graphene/mesh.py
+++ b/cloudvolume/datasource/graphene/mesh.py
@@ -112,7 +112,8 @@ class GrapheneMeshSource(UnshardedLegacyPrecomputedMeshSource):
       if remove_duplicate_vertices:
         mesh = mesh.consolidate()
       elif is_draco:
-        if self.meta.uniform_draco_grid_size is not None or level == 2:
+        if level == 2:
+          # Deduplicate at quantized lvl2 chunk borders
           draco_grid_size = self.meta.get_draco_grid_size(level)
           mesh = mesh.deduplicate_chunk_boundaries(
             self.meta.mesh_chunk_size * resolution,

--- a/cloudvolume/datasource/graphene/metadata.py
+++ b/cloudvolume/datasource/graphene/metadata.py
@@ -26,8 +26,6 @@ class GrapheneMetadata(PrecomputedMetadata):
       self.auth_header = {
         "Authorization": "Bearer %s" % token
       }
-    if custom_mesh_metadata is not None:
-      self.mesh_metadata = custom_mesh_metadata
     super(GrapheneMetadata, self).__init__(cloudpath, *args, **kwargs)
 
   def fetch_info(self):

--- a/cloudvolume/datasource/graphene/metadata.py
+++ b/cloudvolume/datasource/graphene/metadata.py
@@ -26,6 +26,8 @@ class GrapheneMetadata(PrecomputedMetadata):
       self.auth_header = {
         "Authorization": "Bearer %s" % token
       }
+    if custom_mesh_metadata is not None:
+      self.mesh_metadata = custom_mesh_metadata
     super(GrapheneMetadata, self).__init__(cloudpath, *args, **kwargs)
 
   def fetch_info(self):
@@ -66,6 +68,16 @@ class GrapheneMetadata(PrecomputedMetadata):
       url += pth.subdomain + '.' 
     url += pth.domain
     return url + '/' + posixpath.join('meshing', pth.version, pth.dataset, 'manifest')
+
+  @property
+  def chunks_start_at_voxel_offset(self):
+    """
+    Boolean property specifying whether ChunkedGraph chunks begin
+    at voxel offset or at origin.
+    """
+    if 'chunks_start_at_voxel_offset' in self.info:
+      return self.info["chunks_start_at_voxel_offset"]
+    return False
 
   @property
   def mesh_metadata(self):

--- a/cloudvolume/datasource/graphene/metadata.py
+++ b/cloudvolume/datasource/graphene/metadata.py
@@ -67,6 +67,39 @@ class GrapheneMetadata(PrecomputedMetadata):
     url += pth.domain
     return url + '/' + posixpath.join('meshing', pth.version, pth.dataset, 'manifest')
 
+  @property
+  def mesh_metadata(self):
+    if 'mesh_metadata' in self.info:
+      return self.info["mesh_metadata"]
+    return None
+
+  @property
+  def uniform_draco_grid_size(self):
+    if self.mesh_metadata and 'uniform_draco_grid_size' in self.mesh_metadata:
+      return self.mesh_metadata["uniform_draco_grid_size"]
+    return None
+
+  @property
+  def max_meshed_layer(self):
+    if self.mesh_metadata and 'max_meshed_layer' in self.mesh_metadata:
+      return self.mesh_metadata["max_meshed_layer"]
+    return None
+
+  def get_draco_grid_size(self, level):
+    if self.mesh_metadata is None:
+      raise ValueError('This layer is not draco meshed')
+    if self.uniform_draco_grid_size is not None:
+      return self.uniform_draco_grid_size
+    if self.mesh_metadata["max_meshed_layer"] < level:
+      raise ValueError(
+        "Request level",
+        level,
+        ". But the maximum meshed level is ",
+        self.mesh_metadata["max_meshed_layer"],
+      )
+    return self.mesh_metadata["draco_grid_sizes"][str(level)]
+
+
 GraphenePath = namedtuple('GraphenePath', ('scheme', 'subdomain', 'domain', 'modality', 'version', 'dataset'))
 EXTRACTION_RE = re.compile(r'/?(\w+)/([\d.]+)/([\w\d\.\_\-]+)/?')
 

--- a/cloudvolume/datasource/graphene/metadata.py
+++ b/cloudvolume/datasource/graphene/metadata.py
@@ -85,17 +85,26 @@ class GrapheneMetadata(PrecomputedMetadata):
 
   @property
   def uniform_draco_grid_size(self):
+    """
+    If not None, a number that specifies the draco_grid_size at every ChunkedGraph level.
+    """
     if self.mesh_metadata and 'uniform_draco_grid_size' in self.mesh_metadata:
       return self.mesh_metadata["uniform_draco_grid_size"]
     return None
 
   @property
   def max_meshed_layer(self):
+    """
+    The highest level in the ChunkedGraph that we create meshes for in this dataset.
+    """
     if self.mesh_metadata and 'max_meshed_layer' in self.mesh_metadata:
       return self.mesh_metadata["max_meshed_layer"]
     return None
 
   def get_draco_grid_size(self, level):
+    """
+    Returns the draco_grid_size for specified ChunkedGraph level.
+    """
     if self.mesh_metadata is None:
       raise ValueError('This layer is not draco meshed')
     if self.uniform_draco_grid_size is not None:

--- a/cloudvolume/datasource/precomputed/mesh/unsharded.py
+++ b/cloudvolume/datasource/precomputed/mesh/unsharded.py
@@ -10,6 +10,7 @@ import struct
 import numpy as np
 from tqdm import tqdm
 
+from .... import exceptions
 from ....lib import yellow, red, toiter
 from ....mesh import Mesh
 from ....storage import Storage

--- a/cloudvolume/mesh.py
+++ b/cloudvolume/mesh.py
@@ -324,16 +324,14 @@ end_header
       encoding_options=mesh_object.encoding_options
     )
 
-  def deduplicate_chunk_boundaries(
-    self, chunk_size, is_draco=False, 
-    draco_grid_size=21, offset=(0,0,0)
-  ):
+  def deduplicate_chunk_boundaries(self, chunk_size, is_draco=False, draco_grid_size=None, offset=(0,0,0)):
     offset = Vec(*offset)
     verts = self.vertices - offset
-
     # find all vertices that are exactly on chunk_size boundaries
     if is_draco:
-      is_chunk_aligned = is_draco_chunk_aligned(verts, chunk_size, draco_grid_size=draco_grid_size)
+      if draco_grid_size is None:
+        raise ValueError('Must specify draco grid size to dedup draco meshes')
+      is_chunk_aligned = is_draco_chunk_aligned(self.vertices, chunk_size, draco_grid_size=draco_grid_size)
     else:
       is_chunk_aligned = np.any(np.mod(verts, chunk_size) == 0, axis=1)
 

--- a/cloudvolume/mesh.py
+++ b/cloudvolume/mesh.py
@@ -328,7 +328,6 @@ end_header
 
   def deduplicate_chunk_boundaries(self, chunk_size, is_draco=False, draco_grid_size=None, offset=(0,0,0)):
     offset = Vec(*offset)
-    print('offset = ', offset)
     verts = self.vertices - offset
     # find all vertices that are exactly on chunk_size boundaries
     if is_draco:

--- a/cloudvolume/mesh.py
+++ b/cloudvolume/mesh.py
@@ -24,6 +24,10 @@ def deprecation_notice(key):
 
 
 def is_draco_chunk_aligned(verts, chunk_size, draco_grid_size):
+  """
+  Return a mask that for each vertex is true iff it is within
+  half a draco_grid_size from a chunk border.
+  """
   dist_to_chunk_behind = np.mod(verts, chunk_size)
   dist_to_chunk_ahead = chunk_size - dist_to_chunk_behind
   # Draco rounds up

--- a/test/test_graphene.py
+++ b/test/test_graphene.py
@@ -34,7 +34,7 @@ def cv_graphene_mesh_precomputed(requests_mock):
         128
         ]
         },
-        "chunks_start_at_voxel_offset": True,
+        "chunks_start_at_voxel_offset": False,
         "mesh": "mesh_mip_2_err_40_sv16",
         "num_channels": 1,
         "scales": [
@@ -104,7 +104,7 @@ def cv_graphene_mesh_draco(requests_mock):
         128
         ]
         },
-        "chunks_start_at_voxel_offset": True,
+        "chunks_start_at_voxel_offset": False,
         "mesh": "mesh_mip_2_draco_sv16",
         "mesh_metadata": {
             "max_meshed_layer": 6,

--- a/test/test_graphene.py
+++ b/test/test_graphene.py
@@ -34,6 +34,7 @@ def cv_graphene_mesh_precomputed(requests_mock):
         128
         ]
         },
+        "chunks_start_at_voxel_offset": True,
         "mesh": "mesh_mip_2_err_40_sv16",
         "num_channels": 1,
         "scales": [
@@ -103,7 +104,12 @@ def cv_graphene_mesh_draco(requests_mock):
         128
         ]
         },
+        "chunks_start_at_voxel_offset": True,
         "mesh": "mesh_mip_2_draco_sv16",
+        "mesh_metadata": {
+            "max_meshed_layer": 6,
+            "uniform_draco_grid_size": 21
+        },
         "num_channels": 1,
         "scales": [
         {


### PR DESCRIPTION
The draco_grid_size is necessary for mesh vertex deduplication and differs in each dataset