### PR TITLE
Delay creating metadata in dask.to_cloudvolume 

### DIFF
--- a/cloudvolume/dask.py
+++ b/cloudvolume/dask.py
@@ -63,6 +63,7 @@ def to_cloudvolume(arr,
   -------
   See notes on `compute` and `return_stored` parameters.
   """
+  import dask
   import dask.array as da
   if not da.core._check_regular_chunks(arr.chunks):
     raise ValueError('Attempt to save array to cloudvolume with irregular '
@@ -94,11 +95,25 @@ def to_cloudvolume(arr,
                                      arr.shape[:3],
                                      chunk_size=chunk_size,
                                      max_mip=max_mip)
+
+  # If not doing an immediate computation, also delay writing any metadata:
+  #   - the caller may never do the full computation
+  #   - the filesystem may be slow
+  if compute:
+    vol = _create_cloudvolume(cloudpath, info, **kwargs)
+  else:
+    vol = dask.delayed(_create_cloudvolume)(cloudpath, info, **kwargs)
+
+  return arr.store(vol, lock=False, compute=compute, return_stored=return_stored)
+
+
+def _create_cloudvolume(cloudpath, info, **kwargs):
+  """Create cloudvolume and commit metadata."""
   vol = CloudVolume(cloudpath, info=info, progress=False, **kwargs)
   vol.commit_info()
-  vol.provenance.processing = [{'method': 'dask_to_cloudvolume'}]
+  vol.provenance.processing = [{'method': 'cloudvolume.dask.to_cloudvolume'}]
   vol.commit_provenance()
-  return arr.store(vol, lock=False, compute=compute, return_stored=return_stored)
+  return vol
 
 
 def from_cloudvolume(cloudpath, chunks=None, name=None, **kwargs):

--- a/cloudvolume/dask.py
+++ b/cloudvolume/dask.py
@@ -96,14 +96,11 @@ def to_cloudvolume(arr,
                                      chunk_size=chunk_size,
                                      max_mip=max_mip)
 
-  # If not doing an immediate computation, also delay writing any metadata:
+  # Delay writing any metadata until computation time.
   #   - the caller may never do the full computation
-  #   - the filesystem may be slow
-  if compute:
-    vol = _create_cloudvolume(cloudpath, info, **kwargs)
-  else:
-    vol = dask.delayed(_create_cloudvolume)(cloudpath, info, **kwargs)
-
+  #   - the filesystem may be slow, and there is a desire to open files
+  #     in parallel on worker machines.
+  vol = dask.delayed(_create_cloudvolume)(cloudpath, info, **kwargs)
   return arr.store(vol, lock=False, compute=compute, return_stored=return_stored)
 
 


### PR DESCRIPTION
I was finding a huge slowdown when opening many volumes for writing on a cloud filesystem.  All the metadata files were being written from my machine -- instead of being sharded to workers.  

In addition, when compute=False, it may not be the intention of the caller to ever write out data.  The PR delays the writing of `info` or `provenance` until compute time.

For these reasons, I think we can delay writing the metadata.  It's an open question to me if we should always wrap in `dask.delayed`, regardless of the value of compute.  I believe this may be better, and am trying to open a discussion with the dask maintainers on a similar PR in their repo - dask/dask#5797