### PR TITLE
feat: agglomerating entire blocks of proofreading

### DIFF
--- a/cloudvolume/datasource/graphene/__init__.py
+++ b/cloudvolume/datasource/graphene/__init__.py
@@ -7,7 +7,6 @@ from ...cacheservice import CacheService
 from ...cloudvolume import SharedConfiguration, register_plugin
 from ...paths import strict_extract
 
-from ...frontends import CloudVolumeGraphene
 from requests import HTTPError
 
 def create_graphene(
@@ -19,6 +18,7 @@ def create_graphene(
     green_threads=False, use_https=False,
     **kwargs
   ):
+    from ...frontends import CloudVolumeGraphene
     
     path = strict_extract(cloudpath)
     config = SharedConfiguration(

--- a/cloudvolume/datasource/graphene/mesh.py
+++ b/cloudvolume/datasource/graphene/mesh.py
@@ -19,7 +19,6 @@ from ...storage import Storage, GreenStorage
 from ..precomputed.mesh import UnshardedLegacyPrecomputedMeshSource, PrecomputedMeshMetadata
 
 
-
 class GrapheneMeshSource(UnshardedLegacyPrecomputedMeshSource):
 
   def _get_fragment_filenames(self, seg_id, lod=0, level=2, bbox=None):

--- a/cloudvolume/datasource/graphene/metadata.py
+++ b/cloudvolume/datasource/graphene/metadata.py
@@ -99,6 +99,8 @@ class GrapheneMetadata(PrecomputedMetadata):
   @property
   def base_path(self):
     path = self.server_path
+    if path.subdomain is None:
+      return path.scheme + '://' + path.domain + '/'   
     return path.scheme + '://' + path.subdomain + '.' + path.domain + '/' 
 
   @property
@@ -143,11 +145,13 @@ class GrapheneMetadata(PrecomputedMetadata):
   @property
   def manifest_endpoint(self):
     pth = self.server_path
-    url = pth.scheme + '://'
-    if pth.subdomain is not None:
-      url += pth.subdomain + '.' 
-    url += pth.domain
-    return url + '/' + posixpath.join('meshing', pth.version, pth.dataset, 'manifest')
+    pth = GraphenePath(
+      pth.scheme, pth.subdomain, pth.domain, 
+      'meshing', pth.version, pth.dataset
+    )
+
+    url = self.api_version.path(pth)
+    return posixpath.join(self.base_path, url, 'manifest')
 
   @property
   def chunks_start_at_voxel_offset(self):

--- a/cloudvolume/datasource/graphene/metadata.py
+++ b/cloudvolume/datasource/graphene/metadata.py
@@ -74,11 +74,18 @@ class GrapheneMetadata(PrecomputedMetadata):
       }
     super(GrapheneMetadata, self).__init__(cloudpath, *args, **kwargs)
 
+  def info_path(self):
+    """e.g. https://SUBDOMAIN.dynamicannotationframework.com/segmentation/table/DATASET/info"""
+    path = self.server_path
+    return path.scheme + '://' + path.subdomain + '.' + path.domain + '/' \
+      + posixpath.join(path.modality, 'table', path.dataset, 'info')
+
   def fetch_info(self):
     """
     Reads info from chunkedgraph endpoint and extracts relevant information
     """
-    r = requests.get(posixpath.join(self.server_url, "info"), headers=self.auth_header)
+    info_path = self.info_path()
+    r = requests.get(info_path, headers=self.auth_header)
     r.raise_for_status()
     return r.json()
 

--- a/cloudvolume/datasource/graphene/metadata.py
+++ b/cloudvolume/datasource/graphene/metadata.py
@@ -62,7 +62,7 @@ class GrapheneApiVersion():
     As of Feb. 2020, these were the latest paths.
     """
     return posixpath.join( 
-      graphene_path.modality, 'api', self.version, graphene_path.dataset
+      graphene_path.modality, 'api', self.version, 'table', graphene_path.dataset
     )
 
 class GrapheneMetadata(PrecomputedMetadata):

--- a/cloudvolume/datasource/graphene/metadata.py
+++ b/cloudvolume/datasource/graphene/metadata.py
@@ -85,7 +85,7 @@ class GrapheneMetadata(PrecomputedMetadata):
     super(GrapheneMetadata, self).__init__(cloudpath, *args, **kwargs)
 
   def supports_api(self, version):
-    return GrapheneApiVersion(version) >= self.supported_api_versions[-1]
+    return GrapheneApiVersion(version) in self.supported_api_versions
 
   @property  
   def supported_api_versions(self):

--- a/cloudvolume/datasource/graphene/metadata.py
+++ b/cloudvolume/datasource/graphene/metadata.py
@@ -210,13 +210,11 @@ API_VX_EXTRACTION_RE = re.compile(r'/?(\w+)/api/(v[\d\.]+)/([\w\d\.\_\-]+)/?')
 
 def extract_graphene_path(url):
   """
-  segmentation/fly_v31/info
-  segmentation/fly_v26/info <-- sandbox
   Examples:
   Legacy endpoint:
-    graphene://https://fafbv2.dynamicannotationframework.com/segmentation/1.0/fly_v31
+    graphene://https://SUBDOMAIN.dynamicannotationframework.com/segmentation/1.0/DATASET
   Newer endpoint:
-    graphene://https://fafbv2.dynamicannotationframework.com/segmentation/api/v1/fly_v31 
+    graphene://https://SUBDOMAIN.dynamicannotationframework.com/segmentation/api/v1/DATASET
   """
   parse = urllib.parse.urlparse(url)
   subdomain = parse.netloc.split('.')[0]

--- a/cloudvolume/exceptions.py
+++ b/cloudvolume/exceptions.py
@@ -114,6 +114,10 @@ class UnsupportedProtocolError(ValueError):
   """Unknown protocol extension."""
   pass
 
+class UnsupportedGrapheneAPIVersionError(Exception):
+  """This dataset does not support the specified api version."""
+  pass
+
 class SpecViolation(Exception):
   """The values held by this object violate its written specification."""
   pass

--- a/cloudvolume/frontends/graphene.py
+++ b/cloudvolume/frontends/graphene.py
@@ -235,10 +235,12 @@ class CloudVolumeGraphene(CloudVolumePrecomputed):
     response = requests.post(url, data=data, headers=headers)
     response.raise_for_status()
 
+    roots = json.loads(response.content)['root_ids']
+
     if binary:
-      return np.frombuffer(response.content, dtype=np.uint64)
-    else:
-      return json.loads(response.content)
+      return np.frombuffer(roots, dtype=np.uint64)
+    
+    return roots
 
   def _get_roots_legacy(self, segids, timestamp):
     args = {}

--- a/cloudvolume/frontends/graphene.py
+++ b/cloudvolume/frontends/graphene.py
@@ -184,7 +184,7 @@ class CloudVolumeGraphene(CloudVolumePrecomputed):
     """Deprecated. Get a single root id for a single segid."""
     return get_roots(segid, *args, **kwargs)[0]
 
-  def get_roots(self, segids, timestamp=None):
+  def get_roots(self, segids, timestamp=None, binary=False):
     """
     Get the root ids for these labels.
     """
@@ -193,7 +193,7 @@ class CloudVolumeGraphene(CloudVolumePrecomputed):
       segids = segids.tolist()
 
     if self.meta.supports_api('v1'):
-      roots = self._get_roots_v1(segids, timestamp)
+      roots = self._get_roots_v1(segids, timestamp, binary)
     elif self.meta.supports_api('1.0'):
       roots = self._get_roots_legacy(segids, timestamp)
     else:

--- a/cloudvolume/frontends/graphene.py
+++ b/cloudvolume/frontends/graphene.py
@@ -165,11 +165,11 @@ class CloudVolumeGraphene(CloudVolumePrecomputed):
     return VolumeCutout.from_volume(
       self.meta, mip, img, bbox 
     )
-
+  
   def agglomerate_cutout(self, img, timestamp=None):
     """Remap a graphene volume to its latest root ids. This creates a flat segmentation."""
     labels = fastremap.unique(img)
-    roots = self.get_roots(labels, timestamp=timestamp)
+    roots = self.get_roots(labels, timestamp=timestamp, binary=True)
     mapping = { segid: root for segid, root in zip(labels, roots) }
     return fastremap.remap(img, mapping, preserve_missing_labels=True, in_place=True)
 

--- a/cloudvolume/frontends/graphene.py
+++ b/cloudvolume/frontends/graphene.py
@@ -202,7 +202,7 @@ class CloudVolumeGraphene(CloudVolumePrecomputed):
         + ", ".join([ str(_) for _ in self.meta.supported_api_versions ])
       )
 
-    return np.array(roots, dtype=np.uint64)
+    return np.array(roots, dtype=self.meta.dtype)
 
   def _get_roots_v1(self, segids, timestamp, binary=False):
     args = {}

--- a/cloudvolume/frontends/graphene.py
+++ b/cloudvolume/frontends/graphene.py
@@ -204,7 +204,7 @@ class CloudVolumeGraphene(CloudVolumePrecomputed):
 
     return np.array(roots, dtype=np.uint64)
 
-  def _get_roots_v1(self, segids, timestamp, binary=True):
+  def _get_roots_v1(self, segids, timestamp, binary=False):
     args = {}
     if timestamp is not None:
       args['timestamp'] = timestamp

--- a/cloudvolume/frontends/precomputed.py
+++ b/cloudvolume/frontends/precomputed.py
@@ -530,7 +530,8 @@ class CloudVolumePrecomputed(object):
 
   def download(
       self, bbox, mip=None, parallel=None,
-      segids=None, preserve_zeros=False
+      segids=None, preserve_zeros=False,
+      agglomerate=False, timestamp=None
     ):
     """
     Downloads segmentation from the indicated cutout
@@ -546,6 +547,9 @@ class CloudVolumePrecomputed(object):
       False: mask other segids with zero
       True: mask other segids with the largest integer value
         contained by the image data type and leave zero as is.
+
+    agglomerate & timestamp are just there to absorb arguments
+    to what could be a graphene frontend.
 
     Returns: img
     """  

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ backports-abc==0.5
 boto3>=1.4.7
 chardet==3.0.4
 compressed-segmentation>=1.0.0
-fastremap>=1.6.2
+fastremap>=1.9.2
 fpzip>=1.1.3
 gevent
 google-auth>=1.10.0

--- a/test/test_graphene.py
+++ b/test/test_graphene.py
@@ -145,7 +145,7 @@ def cv_graphene_mesh_draco(requests_mock):
         }],
         "type": "segmentation"
     }
-    infourl = posixpath.join(PCG_LOCATION, 'mesh/table', TEST_DATASET_NAME, "info")
+    infourl = posixpath.join(PCG_LOCATION, 'meshing/table', DRACO_MESH_TEST_DATASET_NAME, "info")
     requests_mock.get(infourl, json=info_d)
   
     frag_files = os.listdir(os.path.join(graphene_test_cv_dir, info_d['mesh']))
@@ -160,7 +160,7 @@ def cv_graphene_mesh_draco(requests_mock):
     requests_mock.get(mock_url, json=frag_d)
     
     cloudpath = posixpath.join(PCG_LOCATION, 'meshing/api/v1', DRACO_MESH_TEST_DATASET_NAME)
-    yield cloudvolume.CloudVolume(cloudpath)
+    yield cloudvolume.CloudVolume('graphene://' + cloudpath)
 
 @pytest.fixture(scope='session')
 def cv_supervoxels(N=64, blockN=16):

--- a/test/test_graphene.py
+++ b/test/test_graphene.py
@@ -4,6 +4,7 @@ import tempfile
 import cloudvolume
 import numpy as np
 import shutil
+import posixpath
 import pytest
 import os
 from scipy import sparse 
@@ -14,8 +15,7 @@ TEST_PATH = "file://{}".format(tempdir)
 TEST_DATASET_NAME = "testvol"
 PRECOMPUTED_MESH_TEST_DATASET_NAME = "meshvol_precompute"
 DRACO_MESH_TEST_DATASET_NAME = "meshvol_draco"
-PCG_LOCATION = "https://www.dynamicannotationframework.com/segmentation/1.0/"
-PCG_MESH_LOCATION = "https://www.dynamicannotationframework.com/meshing/1.0/"
+PCG_LOCATION = "https://www.dynamicannotationframework.com/"
 TEST_SEG_ID = 648518346349515986
 
 @pytest.fixture()
@@ -145,21 +145,22 @@ def cv_graphene_mesh_draco(requests_mock):
         }],
         "type": "segmentation"
     }
-    requests_mock.get(PCG_LOCATION+DRACO_MESH_TEST_DATASET_NAME+"/info", json=info_d)
+    infourl = posixpath.join(PCG_LOCATION, 'mesh/table', TEST_DATASET_NAME, "info")
+    requests_mock.get(infourl, json=info_d)
   
     frag_files = os.listdir(os.path.join(graphene_test_cv_dir, info_d['mesh']))
     # we want to filter out the manifest file
-    frag_files = [f for f in frag_files if f[0]=='1']
-    frag_d = {'fragments':frag_files}
-    mock_url = PCG_MESH_LOCATION + DRACO_MESH_TEST_DATASET_NAME+"/manifest/{}:0?verify=True".format(TEST_SEG_ID)
-    requests_mock.get(mock_url,
-                      json=frag_d)
-    print(mock_url)
-    gcv = cloudvolume.CloudVolume(
-        "graphene://{}{}".format(PCG_LOCATION, DRACO_MESH_TEST_DATASET_NAME)
+    frag_files = [ f for f in frag_files if f[0]=='1' ]
+    frag_d = { 'fragments':frag_files }
+    mock_url = posixpath.join(
+        PCG_LOCATION, 'meshing', 
+        DRACO_MESH_TEST_DATASET_NAME, 
+        "manifest/{}:0?verify=True".format(TEST_SEG_ID)
     )
-
-    yield gcv
+    requests_mock.get(mock_url, json=frag_d)
+    
+    cloudpath = posixpath.join(PCG_LOCATION, 'meshing/api/v1', DRACO_MESH_TEST_DATASET_NAME)
+    yield cloudvolume.CloudVolume(cloudpath)
 
 @pytest.fixture(scope='session')
 def cv_supervoxels(N=64, blockN=16):
@@ -227,14 +228,15 @@ def graphene_vol(cv_supervoxels,  requests_mock, monkeypatch, N=64):
         "type": "segmentation"
     }
 
-    requests_mock.get(PCG_LOCATION+TEST_DATASET_NAME+"/info", json=info_d)
+    infourl = posixpath.join(PCG_LOCATION, 'segmentation/table', TEST_DATASET_NAME, "info")
+    requests_mock.get(infourl, json=info_d)
     
     def mock_get_leaves(self, root_id, bbox, mip):
         return np.array([0,1,2,3], dtype=np.uint64)
 
-    gcv = cloudvolume.CloudVolume(
-        "graphene://{}{}".format(PCG_LOCATION, TEST_DATASET_NAME)
-    )
+    cloudpath = "graphene://" + posixpath.join(PCG_LOCATION, 'segmentation', 'api/v1/', TEST_DATASET_NAME)
+
+    gcv = cloudvolume.CloudVolume(cloudpath)
     gcv.get_leaves = partial(mock_get_leaves, gcv)
     yield gcv
 

--- a/test/test_graphene.py
+++ b/test/test_graphene.py
@@ -79,14 +79,10 @@ def cv_graphene_mesh_precomputed(requests_mock):
     frag_files = [f[:-3] for f in frag_files if f[0]=='9']
     frag_d = {'fragments':frag_files}
     mock_url = PCG_MESH_LOCATION + PRECOMPUTED_MESH_TEST_DATASET_NAME+"/manifest/{}:0?verify=True".format(TEST_SEG_ID)
-    requests_mock.get(mock_url,
-                      json=frag_d)
-    print(mock_url)
-    gcv = cloudvolume.CloudVolume(
-        "graphene://{}{}".format(PCG_LOCATION, PRECOMPUTED_MESH_TEST_DATASET_NAME)
-    )
+    requests_mock.get(mock_url, json=frag_d)
 
-    yield gcv
+    cloudpath = "graphene://{}{}".format(PCG_LOCATION, PRECOMPUTED_MESH_TEST_DATASET_NAME)
+    yield cloudvolume.CloudVolume(cloudpath)
 
 @pytest.fixture()
 def cv_graphene_mesh_draco(requests_mock):
@@ -150,10 +146,10 @@ def cv_graphene_mesh_draco(requests_mock):
   
     frag_files = os.listdir(os.path.join(graphene_test_cv_dir, info_d['mesh']))
     # we want to filter out the manifest file
-    frag_files = [ f for f in frag_files if f[0]=='1' ]
-    frag_d = { 'fragments':frag_files }
+    frag_files = [ f for f in frag_files if f[0] == '1' ]
+    frag_d = { 'fragments': frag_files }
     mock_url = posixpath.join(
-        PCG_LOCATION, 'meshing', 
+        PCG_LOCATION, 'meshing/api/v1/table', 
         DRACO_MESH_TEST_DATASET_NAME, 
         "manifest/{}:0?verify=True".format(TEST_SEG_ID)
     )


### PR DESCRIPTION
This PR does two tasks:
1. Support the legacy (1.0) and new (api/v1) style requests to graphene servers.
2. Provide a means for downloading flat segmentation at a given time-point from graphene. 

This is provided by the `agglomerate=True` and `timestamp=XXXX` flags on the `cv.download` method.

The agglomerate flag will work on both api/v1 and 1.0 endpoints, but it will only work practically on the api/v1 endpoints due to the implementation of "get_roots".


