### PR TITLE
feat: add image write locking per mip level 

### DIFF
--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -147,6 +147,13 @@ class PrecomputedImageSource(ImageSourceInterface):
       use_shared_memory=False, use_file=False      
     ):
 
+    if mip in self.meta.locked_mips():
+      raise exceptions.ReadOnlyException(
+        "MIP {} is currently write locked. If this should not be the case, run vol.meta.unlock_mip({}).".format(
+          mip, mip
+        )
+      )
+
     offset = Vec(*offset)
     bbox = Bbox( offset, offset + Vec(*image.shape[:3]) )
 
@@ -203,6 +210,13 @@ class PrecomputedImageSource(ImageSourceInterface):
   def delete(self, bbox, mip=None):
     if mip is None:
       mip = self.config.mip
+
+    if mip in self.meta.locked_mips():
+      raise exceptions.ReadOnlyException(
+        "MIP {} is currently write locked. If this should not be the case, run vol.meta.unlock_mip({}).".format(
+          mip, mip
+        )
+      )
 
     bbox = Bbox.create(bbox, self.meta.bounds(mip), bounded=True)
     realized_bbox = bbox.expand_to_chunk_size(

--- a/cloudvolume/datasource/precomputed/image/tx.py
+++ b/cloudvolume/datasource/precomputed/image/tx.py
@@ -6,7 +6,7 @@ from six.moves import range
 from tqdm import tqdm
 
 from cloudvolume import lib, chunks
-from cloudvolume.exceptions import AlignmentError
+from cloudvolume.exceptions import AlignmentError, WriteLockViolationError
 from cloudvolume.lib import ( 
   mkdir, clamp, xyzrange, Vec, 
   Bbox, min2, max2
@@ -45,6 +45,13 @@ def upload(
     green=False, fill_missing=False
   ):
   """Upload img to vol with offset. This is the primary entry point for uploads."""
+
+  if mip in meta.locked_mips():
+    raise WriteLockViolationError(
+      "MIP {} is currently write locked. If this should not be the case, run vol.meta.unlock_mip({}).".format(
+        mip, mip
+      )
+    )
 
   if not np.issubdtype(image.dtype, np.dtype(meta.dtype).type):
     raise ValueError("""

--- a/cloudvolume/datasource/precomputed/image/tx.py
+++ b/cloudvolume/datasource/precomputed/image/tx.py
@@ -6,7 +6,7 @@ from six.moves import range
 from tqdm import tqdm
 
 from cloudvolume import lib, chunks
-from cloudvolume.exceptions import AlignmentError, WriteLockViolationError
+from cloudvolume.exceptions import AlignmentError
 from cloudvolume.lib import ( 
   mkdir, clamp, xyzrange, Vec, 
   Bbox, min2, max2

--- a/cloudvolume/datasource/precomputed/image/tx.py
+++ b/cloudvolume/datasource/precomputed/image/tx.py
@@ -46,13 +46,6 @@ def upload(
   ):
   """Upload img to vol with offset. This is the primary entry point for uploads."""
 
-  if mip in meta.locked_mips():
-    raise WriteLockViolationError(
-      "MIP {} is currently write locked. If this should not be the case, run vol.meta.unlock_mip({}).".format(
-        mip, mip
-      )
-    )
-
   if not np.issubdtype(image.dtype, np.dtype(meta.dtype).type):
     raise ValueError("""
       The uploaded image data type must match the volume data type. 

--- a/cloudvolume/datasource/precomputed/metadata.py
+++ b/cloudvolume/datasource/precomputed/metadata.py
@@ -703,7 +703,7 @@ Hops:
       for mip in mips:
         self.info['scales'][mip]['locked'] = False
 
-      self.commit_info(info)
+      self.commit_info()
     except Exception as err:
       msg = lib.yellow("Unable to release lock on mips {}".format(list(mips)))
       raise exceptions.WriteLockReleaseError(msg)

--- a/cloudvolume/datasource/precomputed/metadata.py
+++ b/cloudvolume/datasource/precomputed/metadata.py
@@ -709,4 +709,4 @@ Hops:
       raise exceptions.WriteLockReleaseError(msg) from err
 
   def locked_mips(self):
-    return set([ i for i, scale in enumerate(self.info['scale']) if scale.get('locked', False) ])
+    return set([ i for i, scale in enumerate(self.info['scales']) if scale.get('locked', False) ])

--- a/cloudvolume/datasource/precomputed/metadata.py
+++ b/cloudvolume/datasource/precomputed/metadata.py
@@ -146,10 +146,14 @@ class PrecomputedMetadata(object):
     
     return info
 
-  def refresh_info(self, max_redirects=10):
+  def refresh_info(self, max_redirects=10, force_fetch=False):
     """
     Refresh the current info file from the cache (if enabled) 
     or primary storage (e.g. the cloud) if not cached.
+
+    max_redirects: number of times to allow redirection. set to 0 to
+      force getting the origin info file loaded.
+    force_fetch: bypass the cache for reading, but allow writing
 
     Raises:
       cloudvolume.exceptions.InfoUnavailableError when the info file 
@@ -163,7 +167,7 @@ class PrecomputedMetadata(object):
 
     Returns: dict
     """
-    if self.cache and self.cache.enabled:
+    if self.cache and self.cache.enabled and not force_fetch:
       info = self.cache.get_json('info')
       if info:
         self.info = info
@@ -659,3 +663,50 @@ Hops:
       info['scales'].append(newscale)
 
     return newscale
+
+  def lock_mips(self, mips):
+    """
+    Establishes a write lock on the specified mip levels.
+    The lock is written to the cloud info file.
+    """
+    mips = lib.toiter(mips)
+    if max(mips) > max(self.available_mips):
+      raise ValueError("Cannot lock a mip level that doesn't exist. Highest mip: {} Got: {}".format(
+        max(self.available_mips), mips
+      ))
+
+    try:
+      self.refresh_info(force_fetch=True)
+
+      for mip in mips:
+        self.info['scales'][mip]['locked'] = True
+
+      self.commit_info()
+    except Exception as err:
+      msg = lib.red("Unable to acquire write lock on mips {}!".format(list(mips)))
+      raise exceptions.WriteLockAcquisitionError(msg) from err
+
+  def unlock_mips(self, mips):
+    """
+    Releases a write lock on the specified mip levels.
+    The lock is written to the cloud info file.
+    """
+    mips = lib.toiter(mips)
+    if max(mips) > max(self.available_mips):
+      raise ValueError("Cannot unlock a mip level that doesn't exist. Highest mip: {} Got: {}".format(
+        max(self.available_mips), mips
+      ))
+
+    try:
+      self.refresh_info(force_fetch=True)
+
+      for mip in mips:
+        self.info['scales'][mip]['locked'] = False
+
+      self.commit_info(info)
+    except Exception as err:
+      msg = lib.yellow("Unable to release lock on mips {}".format(list(mips)))
+      raise exceptions.WriteLockReleaseError(msg) from err
+
+  def locked_mips(self):
+    return set([ i for i, scale in enumerate(self.info['scale']) if scale.get('locked', False) ])

--- a/cloudvolume/datasource/precomputed/metadata.py
+++ b/cloudvolume/datasource/precomputed/metadata.py
@@ -684,7 +684,7 @@ Hops:
       self.commit_info()
     except Exception as err:
       msg = lib.red("Unable to acquire write lock on mips {}!".format(list(mips)))
-      raise exceptions.WriteLockAcquisitionError(msg) from err
+      raise exceptions.WriteLockAcquisitionError(msg)
 
   def unlock_mips(self, mips):
     """
@@ -706,7 +706,7 @@ Hops:
       self.commit_info(info)
     except Exception as err:
       msg = lib.yellow("Unable to release lock on mips {}".format(list(mips)))
-      raise exceptions.WriteLockReleaseError(msg) from err
+      raise exceptions.WriteLockReleaseError(msg)
 
   def locked_mips(self):
     return set([ i for i, scale in enumerate(self.info['scales']) if scale.get('locked', False) ])

--- a/cloudvolume/exceptions.py
+++ b/cloudvolume/exceptions.py
@@ -126,10 +126,6 @@ class SpatialIndexGapError(Exception):
   """Part of the spatial index was not found. A complete result set cannot be fetched."""
   pass
 
-class WriteLockViolationError(Exception):
-  """Cannot write or delete files in a volume that are marked as write locked. Please consult the info file."""
-  pass
-
 class WriteLockAcquisitionError(Exception):
   """Unable to obtain a lock on this data layer element."""
   pass

--- a/cloudvolume/exceptions.py
+++ b/cloudvolume/exceptions.py
@@ -125,3 +125,15 @@ class SpecViolation(Exception):
 class SpatialIndexGapError(Exception):
   """Part of the spatial index was not found. A complete result set cannot be fetched."""
   pass
+
+class WriteLockViolationError(Exception):
+  """Cannot write or delete files in a volume that are marked as write locked. Please consult the info file."""
+  pass
+
+class WriteLockAcquisitionError(Exception):
+  """Unable to obtain a lock on this data layer element."""
+  pass
+
+class WriteLockReleaseError(Exception):
+  """Unable to release a lock on this data layer element."""
+  pass


### PR DESCRIPTION
This sets the property "locked" to true in each selected mip within info['scales']. It is then checked when calling upload or delete.

This mechanism is very vulnerable to race conditions, and is mainly intended for an additional safety mechanism to prevent accidental deletion. It's not meant to be called frequently.