### PR TITLE
Unpin Dependencies json5, backports-abc, and chardet

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-backports-abc==0.5
+backports-abc>=0.5
 boto3>=1.4.7
-chardet==3.0.4
+chardet>=3.0.4
 compressed-segmentation>=1.0.0
 fastremap>=1.9.2
 fpzip>=1.1.3
@@ -8,7 +8,7 @@ gevent
 google-auth>=1.10.0
 google-cloud-core>=1.1.0
 google-cloud-storage>=1.24.1
-json5==0.5.1
+json5>=0.5.1
 numpy>=1.13.3
 python-jsonschema-objects>=0.3.3
 Pillow>=4.2.1


### PR DESCRIPTION
backports-abc and chardet were pinned to their most recent versions, which are 3-4 years old (likely not to change much)
json5 was pinned to a 3 year old version, but development has continued with many minor releases in the interim.

Would the json5 update likely break anything that relied on older behavior?