### PR TITLE
feat(microviewer): add segmentation toggle to plain segmentation

### DIFF
--- a/cloudvolume/microviewer/__init__.py
+++ b/cloudvolume/microviewer/__init__.py
@@ -71,7 +71,7 @@ def hyperview(
   ):
 
   img = to3d(img)
-  segmentation = to3d(segmentation)
+  segmentation = emulate_eight_uint64(to3d(segmentation))
 
   assert np.all(img.shape[:3] == segmentation.shape[:3])
 

--- a/cloudvolume/microviewer/datacube.js
+++ b/cloudvolume/microviewer/datacube.js
@@ -114,10 +114,6 @@ class MonoVolume {
       _this.channel.normalized = false;
       _this.cache.valid = false;
 
-      if (_this.is_segmentation) {
-        _this.initializeColorAssignments(_this.channel.cube);
-      }
-
       return _this.channel;
     });
   }

--- a/cloudvolume/microviewer/index.html
+++ b/cloudvolume/microviewer/index.html
@@ -80,7 +80,13 @@
 
         let datacube = create_datacube(data.data_types[0], data.data_bytes, SIZE);
 
-        window.vol = new MonoVolume(datacube, (data.layer_type === 'segmentation'));
+        if (data.layer_type === 'segmentation') {
+          window.vol = new SegmentationVolume(datacube, true);
+        }
+        else {
+          window.vol = new MonoVolume(datacube, false);
+        }
+
         let vol = window.vol;
 
         vol.load('/channel', function (ratio) {
@@ -109,6 +115,18 @@
 
           render(); 
         });
+
+        if (vol.is_segmentation) {
+          $(channel).on('click', function (evt) {
+            var x = evt.offsetX / $(this).innerWidth(), 
+              y = evt.offsetY / $(this).innerHeight();
+
+            x = clamp(x, 0, 1);
+            y = clamp(y, 0, 1);  
+            
+            vol.toggleSegment(AXIS, SLICE[AXIS], x, y);        
+          });
+        }
       }
 
       function setup_hyper_volume (data) {
@@ -322,7 +340,9 @@
 
           if (PARAMETERS.layer_type === 'image') {
             $('#instructions .segmentation').hide();
-          }PARAMETERS.cloudpath[0].split('/')
+          }
+
+          PARAMETERS.cloudpath[0].split('/')
         }
 
         let hyper = (PARAMETERS.viewtype === 'hyper') ? 'Hyper ' : '';
@@ -471,8 +491,8 @@
         <li class="hyperview">+/- increase, decrease opacity</li>
       </ul>
 
-      <p class="hyperview">SELECTED SEGMENTS</p>
-      <div class="hyperview" id="selected_segments"></div>
+      <p class="segmentation">SELECTED SEGMENTS</p>
+      <div class="segmentation" id="selected_segments"></div>
     </div>
     
     <canvas id="channel" width="256" height="256"></canvas>

--- a/cloudvolume/microviewer/index.html
+++ b/cloudvolume/microviewer/index.html
@@ -441,7 +441,7 @@
 
         if (vol.segments) {
           elems.selected_segments.text( 
-            Object.keys(vol.segments).filter( (segid) => vol.segments[segid] ).join(', ') 
+            vol.selected().join(', ') 
           );
         }
 
@@ -449,6 +449,10 @@
       }
 
       function display_value (val) {
+        if (vol.is_segmentation) {
+          val = vol.renumbering[val];
+        }
+
         if (PARAMETERS.is_floating) {
           return val.toFixed(4);
         }

--- a/cloudvolume/microviewer/index.html
+++ b/cloudvolume/microviewer/index.html
@@ -116,7 +116,7 @@
           render(); 
         });
 
-        if (vol.is_segmentation) {
+        if (vol.has_segmentation) {
           $(channel).on('click', function (evt) {
             var x = evt.offsetX / $(this).innerWidth(), 
               y = evt.offsetY / $(this).innerHeight();
@@ -248,8 +248,11 @@
 
             if (vol.segmentation) {
               CLICK.pxvalue.push(
-                vol.segmentation.get(CLICK.x, CLICK.y, CLICK.z)
+                vol.renumbering[vol.segmentation.get(CLICK.x, CLICK.y, CLICK.z)]
               );
+            }
+            else if (vol.has_segmentation) {
+              CLICK.pxvalue[0] = vol.renumbering[CLICK.pxvalue[0]];
             }
             
             render();
@@ -371,17 +374,21 @@
       }
 
       function update_pxvalue () {
-          PXVALUE = [ vol.channel.get(SLICE.x, SLICE.y, SLICE.z) ];
+        PXVALUE = [];
 
-          vol.hover_id = null;
-          if (vol.is_segmentation) {
-            vol.hover_id = PXVALUE[0];
-          }
-
-          if (vol.segmentation) {
-            vol.hover_id = vol.segmentation.get(SLICE.x, SLICE.y, SLICE.z);
-            PXVALUE.push(vol.hover_id);
-          }
+        vol.hover_id = null;
+        if (vol.segmentation) {
+          PXVALUE.push( vol.channel.get(SLICE.x, SLICE.y, SLICE.z) );
+          vol.hover_id = vol.segmentation.get(SLICE.x, SLICE.y, SLICE.z);
+          PXVALUE.push( vol.renumbering[vol.hover_id] );
+        }
+        else if (vol.has_segmentation) {
+          vol.hover_id =  vol.channel.get(SLICE.x, SLICE.y, SLICE.z);
+          PXVALUE.push( vol.renumbering[vol.hover_id] );
+        }
+        else {
+          PXVALUE.push( vol.channel.get(SLICE.x, SLICE.y, SLICE.z) );
+        }
       }
 
       function render () {
@@ -449,10 +456,6 @@
       }
 
       function display_value (val) {
-        if (vol.is_segmentation) {
-          val = vol.renumbering[val];
-        }
-
         if (PARAMETERS.is_floating) {
           return val.toFixed(4);
         }


### PR DESCRIPTION
This implementation is a little slow right now and includes some duplicated code.

I realized we can avoid using hashes with a double array scheme.

1. renumber data
2. second array size of number of uniques contains original label

However, making this happen requires a slowdown in load time due to array renumbering. We should test a larger volume to see if this is a problem.

