### PR TITLE
feat: download sharded meshes based on mesh manifests

### DIFF
--- a/cloudvolume/datasource/graphene/mesh/sharded.py
+++ b/cloudvolume/datasource/graphene/mesh/sharded.py
@@ -33,7 +33,7 @@ class GrapheneShardedMeshSource(GrapheneUnshardedMeshSource):
   def initial_path(self, level):
     return self.meta.join(self.meta.mesh_path, 'initial', str(level))
 
-  def dynamic_path(self, level):
+  def dynamic_path(self):
     return self.meta.join(self.meta.mesh_path, 'dynamic')
 
   # 1. determine if the segid is before or after the shard time point
@@ -48,11 +48,9 @@ class GrapheneShardedMeshSource(GrapheneUnshardedMeshSource):
     """
     labels = toiter(labels)
 
-    checks = [
-      self.meta.join('dynamic', str(label)) for label in labels
-    ]
+    checks = [ str(label) for label in labels ]
     
-    cloudpath = self.meta.join(self.meta.meta.cloudpath, self.meta.mesh_path) 
+    cloudpath = self.meta.join(self.meta.meta.cloudpath, self.meta.mesh_path, 'dynamic') 
     StorageClass = GreenStorage if self.config.green else Storage
 
     with StorageClass(cloudpath, progress=progress) as stor:
@@ -112,33 +110,95 @@ class GrapheneShardedMeshSource(GrapheneUnshardedMeshSource):
     dynamic_labels.update(initial_labels)
     return dynamic_labels
 
-  def download_segid(self, seg_id, bounding_box):    
-    """See GrapheneUnshardedMeshSource.get for the user facing function."""
-    import DracoPy
-    
-    level = self.meta.meta.decode_layer_id(seg_id)
-    if level not in self.readers:
-      raise KeyError("There is no shard configuration in the mesh info file for level {}.".format(level))
+  def parse_manifest_filenames(self, filenames):
+    lists = defaultdict(list)
+    for filename in filenames:
+      # eg. ~2/344239114-0.shard:224659:442 
+      # tilde means initial, missing tilde means dynamic
+      (initial, layer_id, filename, byte_start, size) = re.search(
+        r'(~)?(\d+)/([\d\-]+\.shard):(\d+):(\d+)', filename
+      ).groups()
+      if initial:
+        lists['initial'].append(filename)
+      else:
+        lists['dynamic'].append((layer_id, filename, int(byte_start), int(size)))
 
-    subdirectory = self.meta.join(self.meta.mesh_path, 'initial', str(level))
-    raw_binary = self.readers[level].get_data(seg_id, path=subdirectory)
+    return lists
+
+  def get_meshes_via_manifest(self, seg_id, bounding_box):
+    """
+    The manifest for sharded is a bit strange in that exists(..., return_byte_offset=True)
+    is being called on the server side. To avoid duplicative delay by recomputing the offset
+    locations, the manifest breaks encapsulation by returning the shard filename and byte
+    offsets. This breaks enapsulation of the shard fetching logic rather severely but 
+    it is probably worth it.
+    """
+    level = self.meta.meta.decode_layer_id(seg_id)
+    dynamic_cloudpath = self.meta.join(self.meta.meta.cloudpath, self.dynamic_path())
+    StorageClass = GreenStorage if self.config.green else Storage
+
+    filenames = self.get_fragment_filenames(seg_id, level=level, bbox=bounding_box)
+    lists = self.parse_manifest_filenames(filenames)
+
+    # with StorageClass(dynamic_cloudpath) as stor:
+    #   files = stor.get_files(lists['dynamic'])
+
+    meshes = [ 
+      Mesh.from_draco(f['content']) for f in files 
+    ]
+
+    filenames = []
+    starts = []
+    ends = []
+    for layer_id, filename, byte_start, size in lists['initial']:
+      filenames.append(self.meta.join(layer_id, filename))
+      starts.append(byte_start)
+      ends.append(byte_start + size)
+
+    cloudpath = self.meta.join(self.meta.meta.cloudpath, self.meta.mesh_path, 'initial')
+
+    raw_binaries = []
+    
+    with StorageClass(cloudpath) as stor:
+      initial_meshes = stor.get_files(filenames, starts, ends)
+
+    meshes += [ Mesh.from_draco(mesh['content']) for mesh in initial_meshes ]
+
+    return meshes
+
+  def get_mesh_on_bypass(self, seg_id):
+    """
+    Attempt to fetch a mesh directly from storage without going through
+    the chunk graph server. This capability should only be used in special
+    circumstances.
+    """
+    level = self.meta.meta.decode_layer_id(seg_id)
+    dynamic_cloudpath = self.meta.join(self.meta.meta.cloudpath, self.dynamic_path())
+    raw_binary = SimpleStorage(dynamic_cloudpath).get_file(str(label))
+
+    if raw_binary is None:
+      subdirectory = self.meta.join(self.meta.mesh_path, 'initial', str(level))
+      raw_binary = self.readers[level].get_data(seg_id, path=subdirectory)
 
     if raw_binary is None:
       raise IndexError('No mesh found for segment {}'.format(seg_id))
 
-    is_draco = False
-    mesh = None
+    return Mesh.from_draco(raw_binary)
 
-    try:
-      # Easier to ask forgiveness than permission
-      mesh = Mesh.from_draco(raw_binary)
-      is_draco = True
-    except DracoPy.FileTypeException:
-      mesh = Mesh.from_precomputed(raw_binary)
-    
+  def download_segid(self, seg_id, bounding_box, bypass=False):    
+    """See GrapheneUnshardedMeshSource.get for the user facing function."""
+    level = self.meta.meta.decode_layer_id(seg_id)
+    if level not in self.readers:
+      raise KeyError("There is no shard configuration in the mesh info file for level {}.".format(level))
+
+    if bypass:
+      mesh = self.get_mesh_on_bypass(seg_id)
+    else:
+      meshes = self.get_meshes_via_manifest(seg_id, bounding_box)
+      mesh = Mesh.concatenate(*meshes)
+
     if mesh is None:
       raise IndexError('No mesh found for segment {}'.format(seg_id))
 
     mesh.segid = seg_id
-    return mesh, is_draco
-
+    return mesh, True


### PR DESCRIPTION
Enables `cv.mesh.get` for Graphene sharded meshes. There are two special parameters this PR adds to the `get` function as well.

Ordinarily for Graphene, the `cv.mesh.get` function will contact the PCG server to request a manifest. Since the server, in order to traverse the PyChunkGraph octree to find the child labels with actual meshes, performs a series of `exists` calls, it already does the work of finding the index and minishard index of each shard. It therefore returns the manifest in an atypical fashion: 
```json
{
  "fragments": [
       "~3/47461891-0.shard:3430219:1073", 
       "~3/45385220-0.shard:310763:1182", 
       "~3/42020357-0.shard:2270331:304"
   ],
}
```
Here the tilde means the mesh is an initial sharded mesh, the 3 means layer 3 of the PCG, she middle section is the name of the shard file, and the two numbers separated by colons are the byte offset and the size of the data in bytes.  

Using this data allows us to rapidly retrieve the mesh. However, this severely breaks encapsulation of the shard accessing logic and so may be non-functional in exceptional circumstances. For example, such as when developing a second mesh with different shard parameters while maintaining the older mesh for proofreading and visualization concurrently. Since the new mesh filenames and byte offsets would be different, this model becomes unworkable. 

Therefore, we have to additional modes: `use_byte_offsets` and `bypass` modes. 

`cv.mesh.get(..., bypass=True)` mode bypasses the PCG server and fetches meshes directly from the storage media based solely on their segment ID. It first checks for a dynamic version of the mesh, and if that fails, tries from the initial shards.  

`use_byte_offsets=False` mode is a hybrid mode between normal and `bypass` modes. We request a manifest from PCG, but ask it to return mesh segment IDs. We then use these labels in bypass mode to construct the mesh. This would allow us to access a mesh under the conditions described above.

```
/manifest/864691135492962144:0?return_seg_ids=1

 "seg_ids": [
    241653690820204416, 
    240538786566506912, 
    238732289498941469, 
    241256767659446532, 
```

Unfortunately, the implementation of bypass mode is currently very slow.







