### PR TITLE
address issue with windows basepath extraction

### DIFF
--- a/cloudvolume/paths.py
+++ b/cloudvolume/paths.py
@@ -117,7 +117,6 @@ def extract(cloudpath, windows=None, disable_toabs=False):
   if len(cloudpath) == 0:
     return ExtractedPath('','','','','','','')
 
-  # windows_file_re = re.compile(r'((?:\w:\\)[\d\w_\.\-]+(?:\\)?)') # for C:\what\a\great\path
   windows_file_re = re.compile(r'((?:\w:\\)[\d\w_\.\-]+)')
   bucket_re = re.compile(r'^(/?[~\d\w_\.\-]+(?::\d+)?)/') # posix /what/a/great/path
   

--- a/cloudvolume/paths.py
+++ b/cloudvolume/paths.py
@@ -161,8 +161,12 @@ def extract(cloudpath, windows=None, disable_toabs=False):
     no_bucket_basepath = split_char.join(splitties[1:-1])
   elif len(splitties) >= 2:
     dataset, layer = splitties[-2:]
-    no_bucket_basepath = split_char.join(splitties[1:-1])
-    basepath = split_char.join([bucket] + splitties[1:-1])
+    if windows:
+      no_bucket_basepath = split_char.join(splitties[2:-1])
+      basepath = split_char.join([bucket] + splitties[2:-1])
+    else:
+      no_bucket_basepath = split_char.join(splitties[1:-1])
+      basepath = split_char.join([bucket] + splitties[1:-1])
 
   return ExtractedPath(
     fmt, protocol, bucket, 

--- a/cloudvolume/paths.py
+++ b/cloudvolume/paths.py
@@ -132,8 +132,7 @@ def extract(cloudpath, windows=None, disable_toabs=False):
     abspath = toabs    
 
   fmt, protocol, cloudpath = extract_format_protocol(cloudpath)
-  print("cloudpath:")
-  print(cloudpath)
+
   split_char = '/'
   if protocol == 'file':
     cloudpath = abspath(cloudpath)
@@ -152,7 +151,6 @@ def extract(cloudpath, windows=None, disable_toabs=False):
   if splitcloudpath[-1] == split_char:
     splitcloudpath = splitcloudpath[:-1]
   splitties = splitcloudpath.split(split_char)
-  print(splitties)
   if len(splitties) == 0:
     return ExtractedPath(fmt, protocol, bucket, cloudpath, '', bucket, '')
   elif len(splitties) == 1:
@@ -168,21 +166,7 @@ def extract(cloudpath, windows=None, disable_toabs=False):
     else:
       no_bucket_basepath = split_char.join(splitties[1:-1])
       basepath = split_char.join([bucket] + splitties[1:-1])
-  print("made it here with:")
-  print("fmt:")
-  print(fmt)
-  print("protocol:")
-  print(protocol)
-  print("bucket:")
-  print(bucket)
-  print("basepath:")
-  print(basepath)
-  print("no_bucket_basepath:")
-  print(no_bucket_basepath)
-  print("dataset:")
-  print(dataset)
-  print("layer:")
-  print(layer)
+
   return ExtractedPath(
     fmt, protocol, bucket, 
     basepath, no_bucket_basepath, 

--- a/cloudvolume/paths.py
+++ b/cloudvolume/paths.py
@@ -117,7 +117,8 @@ def extract(cloudpath, windows=None, disable_toabs=False):
   if len(cloudpath) == 0:
     return ExtractedPath('','','','','','','')
 
-  windows_file_re = re.compile(r'((?:\w:\\)[\d\w_\.\-]+(?:\\)?)') # for C:\what\a\great\path
+  # windows_file_re = re.compile(r'((?:\w:\\)[\d\w_\.\-]+(?:\\)?)') # for C:\what\a\great\path
+  windows_file_re = re.compile(r'((?:\w:\\)[\d\w_\.\-]+)')
   bucket_re = re.compile(r'^(/?[~\d\w_\.\-]+(?::\d+)?)/') # posix /what/a/great/path
   
   error = UnsupportedProtocolError(CLOUDPATH_ERROR.format(cloudpath))
@@ -131,27 +132,27 @@ def extract(cloudpath, windows=None, disable_toabs=False):
     abspath = toabs    
 
   fmt, protocol, cloudpath = extract_format_protocol(cloudpath)
-  
+  print("cloudpath:")
+  print(cloudpath)
   split_char = '/'
   if protocol == 'file':
     cloudpath = abspath(cloudpath)
     if windows:
       bucket_re = windows_file_re
-    split_char = os.path.sep
+      split_char = '\\'
 
   match = re.match(bucket_re, cloudpath)
   if not match:
     raise error
 
   (bucket,) = match.groups()
-
   splitcloudpath = cloudpath 
   if splitcloudpath[0] == split_char:
     splitcloudpath = splitcloudpath[1:]
   if splitcloudpath[-1] == split_char:
     splitcloudpath = splitcloudpath[:-1]
-
   splitties = splitcloudpath.split(split_char)
+  print(splitties)
   if len(splitties) == 0:
     return ExtractedPath(fmt, protocol, bucket, cloudpath, '', bucket, '')
   elif len(splitties) == 1:
@@ -167,7 +168,21 @@ def extract(cloudpath, windows=None, disable_toabs=False):
     else:
       no_bucket_basepath = split_char.join(splitties[1:-1])
       basepath = split_char.join([bucket] + splitties[1:-1])
-
+  print("made it here with:")
+  print("fmt:")
+  print(fmt)
+  print("protocol:")
+  print(protocol)
+  print("bucket:")
+  print(bucket)
+  print("basepath:")
+  print(basepath)
+  print("no_bucket_basepath:")
+  print(no_bucket_basepath)
+  print("dataset:")
+  print(dataset)
+  print("layer:")
+  print(layer)
   return ExtractedPath(
     fmt, protocol, bucket, 
     basepath, no_bucket_basepath, 

--- a/test/test_paths.py
+++ b/test/test_paths.py
@@ -9,9 +9,12 @@ from cloudvolume import lib
 
 def test_path_extraction():
   extract = paths.extract(r'file://C:\wow\this\is\a\cool\path', windows=True, disable_toabs=True)
-  print(extract)
+  assert extract.fmt == 'precomputed'
   assert extract.protocol == 'file'
   assert extract.bucket == 'C:\\wow\\'
+
+  assert extract.no_bucket_basepath == 'this\\is\\a\\cool'  
+
 
   # on linux the toabs prepends the current path because it
   # doesn't understand C:\... so we can't test that here.
@@ -143,10 +146,12 @@ def test_path_extraction():
 
 
 def test_windows_path_extraction():
-  """ This test is added specifically to make sure
-  that no_bucket_basepath does not contain the bucket,
-  for windows paths. """
   extract = paths.extract(r'file://C:\wow\this\is\a\cool\path', windows=True, disable_toabs=True)
+  print(extract)
+  assert extract.format == 'precomputed'
   assert extract.protocol == 'file'
-  assert extract.bucket == 'C:\\wow\\'
-  assert 'wow' not in extract.no_bucket_basepath
+  assert extract.bucket == 'C:\\wow'
+  assert extract.basepath == 'C:\\wow\\this\\is\\a\\cool'
+  assert extract.no_bucket_basepath == 'this\\is\\a\\cool'  
+  assert extract.dataset == 'cool'  
+  assert extract.layer == 'path'  

--- a/test/test_paths.py
+++ b/test/test_paths.py
@@ -137,3 +137,12 @@ def test_windows_path_extraction():
   assert extract.no_bucket_basepath == 'this\\is\\a\\cool'  
   assert extract.dataset == 'cool'  
   assert extract.layer == 'path'  
+
+  extract = paths.extract('file://C:\\wow\\this\\is\\a\\cool\\path\\', windows=True, disable_toabs=True)
+  assert extract.format == 'precomputed'
+  assert extract.protocol == 'file'
+  assert extract.bucket == 'C:\\wow'
+  assert extract.basepath == 'C:\\wow\\this\\is\\a\\cool'
+  assert extract.no_bucket_basepath == 'this\\is\\a\\cool'  
+  assert extract.dataset == 'cool'  
+  assert extract.layer == 'path'  

--- a/test/test_paths.py
+++ b/test/test_paths.py
@@ -8,23 +8,6 @@ from cloudvolume.exceptions import UnsupportedProtocolError
 from cloudvolume import lib
 
 def test_path_extraction():
-  extract = paths.extract(r'file://C:\wow\this\is\a\cool\path', windows=True, disable_toabs=True)
-  assert extract.fmt == 'precomputed'
-  assert extract.protocol == 'file'
-  assert extract.bucket == 'C:\\wow\\'
-
-  assert extract.no_bucket_basepath == 'this\\is\\a\\cool'  
-
-
-  # on linux the toabs prepends the current path because it
-  # doesn't understand C:\... so we can't test that here.
-  # assert extract.path == 'this\\is\\a\\cool\\path' 
-
-  try:
-    extract = paths.strict_extract(r'file://C:\wow\this\is\a\cool\path', windows=False, disable_toabs=True)
-    assert False 
-  except UnsupportedProtocolError:
-    pass
 
   def shoulderror(url):
     try:
@@ -147,7 +130,6 @@ def test_path_extraction():
 
 def test_windows_path_extraction():
   extract = paths.extract(r'file://C:\wow\this\is\a\cool\path', windows=True, disable_toabs=True)
-  print(extract)
   assert extract.format == 'precomputed'
   assert extract.protocol == 'file'
   assert extract.bucket == 'C:\\wow'

--- a/test/test_paths.py
+++ b/test/test_paths.py
@@ -140,3 +140,13 @@ def test_path_extraction():
   assert path.bucket == '/tmp'
   assert path.dataset == 'removeme'
   assert path.layer == 'layer'
+
+
+def test_windows_path_extraction():
+  """ This test is added specifically to make sure
+  that no_bucket_basepath does not contain the bucket,
+  for windows paths. """
+  extract = paths.extract(r'file://C:\wow\this\is\a\cool\path', windows=True, disable_toabs=True)
+  assert extract.protocol == 'file'
+  assert extract.bucket == 'C:\\wow\\'
+  assert 'wow' not in extract.no_bucket_basepath


### PR DESCRIPTION
To address: [https://github.com/seung-lab/cloud-volume/issues/349](https://github.com/seung-lab/cloud-volume/issues/349), an issue where windows paths were not parsed properly. Specifically, the bucket was getting added to the cloudpath twice.   

I added a simple test to make sure the fix works. 