### PR TITLE
adding smart graphene multi-level mesh stitching

### DIFF
--- a/cloudvolume/datasource/graphene/mesh/sharded.py
+++ b/cloudvolume/datasource/graphene/mesh/sharded.py
@@ -181,7 +181,8 @@ class GrapheneShardedMeshSource(GrapheneUnshardedMeshSource):
     while files:
       f = files.pop()
       mesh = Mesh.from_draco(f['content'])
-      key = (f['path'], f['start'], f['end'])
+      start, end = f['byte_range']
+      key = (f['path'], start, end)
       mesh.segid = segid_map[key]
       initial_meshes.append(mesh)    
 
@@ -202,7 +203,7 @@ class GrapheneShardedMeshSource(GrapheneUnshardedMeshSource):
   def get_chunk_aligned_mask(self, meshes):
     meta = self.meta.meta
     draco_grid_size = meta.get_draco_grid_size(
-      self.meta.decode_layer_id(first(meshes).segid)
+      meta.decode_layer_id(first(meshes).segid)
     )
     base_resolution = meta.resolution(self.config.mip)
     lvl2_resolution = meta.resolution(self.meta.mip)
@@ -216,7 +217,7 @@ class GrapheneShardedMeshSource(GrapheneUnshardedMeshSource):
 
     chunk_aligned_masks = []
     for mesh in meshes:
-      level = self.meta.decode_layer_id(mesh.segid)
+      level = meta.decode_layer_id(mesh.segid)
       chunk_size = (lvl_2_size_nm * (2 ** (level-2))).astype(np.int32)
       verts = mesh.vertices - offset
       # find all vertices that are exactly on chunk_size boundaries

--- a/cloudvolume/datasource/graphene/mesh/sharded.py
+++ b/cloudvolume/datasource/graphene/mesh/sharded.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 
 from cloudfiles import CloudFiles
 
-from ....lib import red, toiter, Bbox, Vec
+from ....lib import red, toiter, Bbox, Vec, first
 from ....mesh import Mesh
 from .... import paths
 
@@ -102,8 +102,7 @@ class GrapheneShardedMeshSource(GrapheneUnshardedMeshSource):
 
     Returns: { label: path or None, ... }
     """
-    labels = toiter(labels)
-    labels = set(labels)
+    labels = set(toiter(labels))
 
     dynamic_labels = self.dynamic_exists(labels, progress)
     remainder_labels = set([ label for label, path in dynamic_labels.items() if path ])
@@ -113,11 +112,13 @@ class GrapheneShardedMeshSource(GrapheneUnshardedMeshSource):
     dynamic_labels.update(initial_labels)
     return dynamic_labels
 
-  def parse_manifest_filenames(self, filenames):
+  def parse_manifest_filenames(self, manifest):
     lists = defaultdict(list)
     initial_regexp = re.compile(r'~(\d+)/([\d\-]+\.shard):(\d+):(\d+)')
 
-    for filename in filenames:
+    filenames, segids = manifest['fragments'], manifest['seg_ids']
+
+    for filename, segid in zip(filenames, segids):
       if not filename:
         continue
 
@@ -129,7 +130,7 @@ class GrapheneShardedMeshSource(GrapheneUnshardedMeshSource):
         (layer_id, parsed_filename, byte_start, size) = re.search(
           initial_regexp, filename
         ).groups()
-        lists['initial'].append((layer_id, parsed_filename, int(byte_start), int(size)))
+        lists['initial'].append((layer_id, parsed_filename, int(byte_start), int(size), int(segid)))
       else:
         lists['dynamic'].append(filename)
         
@@ -146,78 +147,90 @@ class GrapheneShardedMeshSource(GrapheneUnshardedMeshSource):
     level = self.meta.meta.decode_layer_id(seg_id)
     dynamic_cloudpath = self.meta.join(self.meta.meta.cloudpath, self.dynamic_path())
 
-    filenames = self.get_fragment_filenames(seg_id, level=level, bbox=bounding_box)
-    lists = self.parse_manifest_filenames(filenames)
+    manifest = self.fetch_manifest(seg_id, level=level, bbox=bounding_box, return_segids=True)
+    lists = self.parse_manifest_filenames(manifest)
 
     files = []
-    levels = []
 
     if lists['dynamic']:
       files = CloudFiles(dynamic_cloudpath, green=self.config.green).get(lists['dynamic'])
-      frag_ids = [int(s.split(':')[0]) for s in lists['dynamic']]
-      levels = [self.meta.meta.decode_layer_id(id_) for id_ in frag_ids]
     
-    meshes = [ 
-      f for f in files 
-    ]
+    dynamic_meshes = []
+    while files:
+      f = files.pop()
+      mesh = Mesh.from_draco(f['content'])
+      mesh.segid = int(os.path.basename(f['path']).split(':')[0])
+      dynamic_meshes.append(mesh)
 
     fetches = []
-    for layer_id, filename, byte_start, size in lists['initial']:
+    segid_map = {}
+    for layer_id, filename, byte_start, size, segid in lists['initial']:
+      path = self.meta.join(layer_id, filename)
+      byte_end = byte_start + size
       fetches.append({
-        'path': self.meta.join(layer_id, filename),
+        'path': path,
         'start': byte_start,
-        'end': byte_start + size,
+        'end': byte_end,
       })
-      levels.append(int(layer_id))
+      segid_map[(path, byte_start, byte_end)] = segid
 
     cloudpath = self.meta.join(self.meta.meta.cloudpath, self.meta.mesh_path, 'initial')
-    raw_binaries = []
     
-    initial_meshes = CloudFiles(cloudpath, green=self.config.green).get(fetches)
-    meshes += initial_meshes
+    files = CloudFiles(cloudpath, green=self.config.green).get(fetches)
+    initial_meshes = []
+    while files:
+      f = files.pop()
+      mesh = Mesh.from_draco(f['content'])
+      key = (f['path'], f['start'], f['end'])
+      mesh.segid = segid_map[key]
+      initial_meshes.append(mesh)    
 
-    return [ Mesh.from_draco(mesh['content']) for mesh in meshes ], levels
+    return dynamic_meshes + initial_meshes
 
   def get_meshes_via_manifest_labels(self, seg_id, bounding_box):
     level = self.meta.meta.decode_layer_id(seg_id)
     labels = self.get_fragment_labels(seg_id, level=level, bbox=bounding_box)
     meshes = self.get_meshes_on_bypass(labels)
     meshes = list(meshes.values())
-    return meshes, [level for i in range(len(meshes))]
+    return meshes
 
   def get_meshes_via_manifest(self, seg_id, bounding_box, use_byte_offsets):
     if use_byte_offsets:
       return self.get_meshes_via_manifest_byte_offsets(seg_id, bounding_box)
     return self.get_meshes_via_manifest_labels(seg_id, bounding_box)
 
-  def get_chunk_aligned_mask(self, meshes, levels):
+  def get_chunk_aligned_mask(self, meshes):
     meta = self.meta.meta
-    draco_grid_size=meta.get_draco_grid_size(levels[0])
+    draco_grid_size = meta.get_draco_grid_size(
+      self.meta.decode_layer_id(first(meshes).segid)
+    )
     base_resolution = meta.resolution(self.config.mip)
     lvl2_resolution = meta.resolution(self.meta.mip)
+
+    voxel_offset = Vec(0,0,0)
     if meta.chunks_start_at_voxel_offset:
       voxel_offset = meta.voxel_offset(self.meta.mip)
-    else:
-      voxel_offset = Vec(0,0,0)
+      
     offset = voxel_offset * lvl2_resolution
     lvl_2_size_nm = meta.chunk_size(self.meta.mip) * base_resolution
 
     chunk_aligned_masks = []
-    for mesh, level in zip(meshes, levels):
-      chunk_size = (lvl_2_size_nm * (2**(level-2))).astype(np.int32)
+    for mesh in meshes:
+      level = self.meta.decode_layer_id(mesh.segid)
+      chunk_size = (lvl_2_size_nm * (2 ** (level-2))).astype(np.int32)
       verts = mesh.vertices - offset
       # find all vertices that are exactly on chunk_size boundaries
-      is_chunk_aligned = is_draco_chunk_aligned(verts, chunk_size,
-                                                draco_grid_size=draco_grid_size)
+      is_chunk_aligned = is_draco_chunk_aligned(
+        verts, chunk_size, draco_grid_size=draco_grid_size
+      )
       chunk_aligned_masks.append(is_chunk_aligned)
     
     return np.concatenate(chunk_aligned_masks)
 
-  def stitch_multi_level_draco_mesh_fragments(self, meshes, levels, segid):
-    chunk_aligned_mask = self.get_chunk_aligned_mask(meshes, levels)
+  def stitch_multi_level_draco_mesh_fragments(self, meshes, segid):
+    chunk_aligned_mask = self.get_chunk_aligned_mask(meshes)
     mesh = Mesh.concatenate(*meshes)
-    mesh.segid=segid
-
+    mesh.segid = segid
     return mesh.deduplicate_vertices(chunk_aligned_mask)
 
   def get_meshes_on_bypass(self, segids):
@@ -276,8 +289,8 @@ class GrapheneShardedMeshSource(GrapheneUnshardedMeshSource):
     if bypass:
       mesh = self.get_meshes_on_bypass(seg_id)[seg_id]
     else:
-      meshes, levels = self.get_meshes_via_manifest(seg_id, bounding_box, use_byte_offsets=use_byte_offsets)
-      mesh = self.stitch_multi_level_draco_mesh_fragments(meshes, levels, seg_id)
+      meshes = self.get_meshes_via_manifest(seg_id, bounding_box, use_byte_offsets=use_byte_offsets)
+      mesh = self.stitch_multi_level_draco_mesh_fragments(meshes, seg_id)
 
     if mesh is None:
       raise IndexError('No mesh found for segment {}'.format(seg_id))

--- a/cloudvolume/frontends/graphene.py
+++ b/cloudvolume/frontends/graphene.py
@@ -21,6 +21,7 @@ from ..volumecutout import VolumeCutout
 from ..datasource.graphene.metadata import GrapheneApiVersion
 
 from .precomputed import CloudVolumePrecomputed
+import tqdm
 
 def warn(text):
   print(colorize('yellow', text))
@@ -36,7 +37,7 @@ def to_unix_time(timestamp):
   if isinstance(timestamp, datetime): # NB. do not change to elif
     timestamp = datetime.timestamp(timestamp)
 
-  if not isinstance(timestamp, int) and timestamp is not None:
+  if not isinstance(timestamp, float) and timestamp is not None:
     raise ValueError("Not able to convert {} to UNIX time.".format(timestamp))
 
   return timestamp

--- a/cloudvolume/frontends/graphene.py
+++ b/cloudvolume/frontends/graphene.py
@@ -37,10 +37,10 @@ def to_unix_time(timestamp):
   if isinstance(timestamp, datetime): # NB. do not change to elif
     timestamp = datetime.timestamp(timestamp)
 
-  if not isinstance(timestamp, float) and timestamp is not None:
+  if not isinstance(timestamp, (int, float, np.integer, np.floating)) and timestamp is not None:
     raise ValueError("Not able to convert {} to UNIX time.".format(timestamp))
 
-  return timestamp
+  return int(timestamp)
 
 class CloudVolumeGraphene(CloudVolumePrecomputed):
 

--- a/cloudvolume/mesh.py
+++ b/cloudvolume/mesh.py
@@ -369,7 +369,7 @@ end_header
     else:
       is_chunk_aligned = np.any(np.mod(verts, chunk_size) == 0, axis=1)
 
-    return self.deduplicate_vertices(self, is_chunk_aligned)
+    return self.deduplicate_vertices(is_chunk_aligned)
 
   def viewer(self):
     try:

--- a/cloudvolume/mesh.py
+++ b/cloudvolume/mesh.py
@@ -22,7 +22,6 @@ def deprecation_notice(key):
   """.format(key, key)))
     NOTICE[key] += 1
 
-
 def is_draco_chunk_aligned(verts, chunk_size, draco_grid_size):
   """
   Return a mask that for each vertex is true iff it is within
@@ -330,19 +329,9 @@ end_header
       encoding_options=mesh_object.encoding_options
     )
 
-  def deduplicate_chunk_boundaries(self, chunk_size, is_draco=False, draco_grid_size=None, offset=(0,0,0)):
-    offset = Vec(*offset)
-    verts = self.vertices - offset
-    # find all vertices that are exactly on chunk_size boundaries
-    if is_draco:
-      if draco_grid_size is None:
-        raise ValueError('Must specify draco grid size to dedup draco meshes')
-      is_chunk_aligned = is_draco_chunk_aligned(verts, chunk_size, draco_grid_size=draco_grid_size)
-    else:
-      is_chunk_aligned = np.any(np.mod(verts, chunk_size) == 0, axis=1)
-
+  def deduplicate_vertices(self, is_chunk_aligned):
     faces = self.faces
-
+    verts = self.vertices
     # find all vertices that have exactly 2 duplicates
     unique_vertices, unique_inverse, counts = np.unique(
       verts, return_inverse=True, return_counts=True, axis=0
@@ -365,9 +354,22 @@ end_header
     vertices, newfaces = np.unique(new_vertices[faces], return_inverse=True, axis=0)
     newfaces = newfaces.astype(np.uint32).reshape( (len(newfaces) // 3, 3) )
 
-    return Mesh(vertices[:,0:3] + offset, newfaces, None, segid=self.segid, 
+    return Mesh(vertices[:,0:3], newfaces, None, segid=self.segid, 
       encoding_type=self.encoding_type, encoding_options=self.encoding_options
     )
+
+  def deduplicate_chunk_boundaries(self, chunk_size, is_draco=False, draco_grid_size=None, offset=(0,0,0)):
+    offset = Vec(*offset)
+    verts = self.vertices - offset
+    # find all vertices that are exactly on chunk_size boundaries
+    if is_draco:
+      if draco_grid_size is None:
+        raise ValueError('Must specify draco grid size to dedup draco meshes')
+      is_chunk_aligned = is_draco_chunk_aligned(verts, chunk_size, draco_grid_size=draco_grid_size)
+    else:
+      is_chunk_aligned = np.any(np.mod(verts, chunk_size) == 0, axis=1)
+
+    return self.deduplicate_vertices(self, is_chunk_aligned)
 
   def viewer(self):
     try:


### PR DESCRIPTION
I have implemented a more elaborate mesh stitching routine for graphene sharded.  It now takes into account the mesh level of each fragment that is downloaded, in order to label the chunk boundaries dynamically on each fragment in a way that scales with the level of the chunk the fragment came from, and then only removes duplicate vertices on those chunk boundaries.

To do so, i did a little refactoring of the deduplication code so i could call it outside of the Mesh class.  Happy to consider refactoring this in some way, and might be duplicating effort that exists elsewhere in pychunkedgraph. 

I've tested that this enables proper mesh stitching of graphene sharded meshes on a proofread ID example from minnie, but haven't tested it on fly. 