### PR TITLE
fix: default to 'raw' for shard encodings

### DIFF
--- a/cloudvolume/datasource/precomputed/sharding.py
+++ b/cloudvolume/datasource/precomputed/sharding.py
@@ -26,8 +26,9 @@ class ShardingSpecification(object):
   def __init__(
     self, type, preshift_bits, 
     hash, minishard_bits, 
-    shard_bits, minishard_index_encoding, 
-    data_encoding
+    shard_bits, 
+    minishard_index_encoding='raw', 
+    data_encoding='raw'
   ):
 
     self.type = type 


### PR DESCRIPTION
Looks like neuroglancer uses this default. Thanks for reporting @schlegelp! 

Related to #354 