### PR TITLE
fix(encode_jpeg): Neuroglancer expects vertical tile layout

### DIFF
--- a/cloudvolume/chunks.py
+++ b/cloudvolume/chunks.py
@@ -90,7 +90,7 @@ def encode_jpeg(arr):
 
   reshaped = arr.T 
   reshaped = np.moveaxis(reshaped, 0, -1)
-  reshaped = reshaped.reshape(reshaped.shape[0], reshaped.shape[1] * reshaped.shape[2], reshaped.shape[3])
+  reshaped = reshaped.reshape(reshaped.shape[0] * reshaped.shape[1], reshaped.shape[2], reshaped.shape[3])
   if reshaped.shape[2] == 1:
     img = Image.fromarray(reshaped[:,:,0], mode='L')
   elif reshaped.shape[2] == 3:


### PR DESCRIPTION
Don't exactly understand the operations involved here, but I verified that with the change below a chunk downloaded with CloudVolume and re-uploaded as JPEG shows up at the correct position / in the correct orientation in Neuroglancer. Previously, for my 128x128x16 chunks Neuroglancer would complain about shape 16384x16, instead of the expected 128x2048
