### PR TITLE
Fix: get_meshes_on_bypass

### DIFF
--- a/cloudvolume/datasource/graphene/mesh/sharded.py
+++ b/cloudvolume/datasource/graphene/mesh/sharded.py
@@ -208,7 +208,7 @@ class GrapheneShardedMeshSource(GrapheneUnshardedMeshSource):
       if res['error']:
         raise res['error']
 
-      (label,) = re.search(label_regexp, res['filename']).groups()
+      (label,) = re.search(label_regexp, res['path']).groups()
       label = int(label)
 
       if res['content'] is None:


### PR DESCRIPTION
now that CloudFiles is being used, res['filename'] should become res['path']