### PR TITLE
Image shard generation

### DIFF
--- a/cloudvolume/chunks.py
+++ b/cloudvolume/chunks.py
@@ -151,7 +151,7 @@ def decode_npz(string):
 
 def decode_jpeg(bytestring, shape, dtype):
   img = Image.open(io.BytesIO(bytestring))
-  data = np.array(img.getdata(), dtype=dtype)
+  data = np.asarray(img, dtype=dtype).ravel()
 
   return data.reshape(shape, order='F')
 

--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -367,7 +367,7 @@ class PrecomputedImageSource(ImageSourceInterface):
         )
         pbar.update()
 
-  def make_shard(self, img, bbox, mip=None, spec=None):
+  def make_shard(self, img, bbox, mip=None, spec=None, progress=False):
     """
     Convert an image that represents a single complete shard 
     into a shard file.
@@ -390,26 +390,34 @@ class PrecomputedImageSource(ImageSourceInterface):
       else:
         raise ValueError("mip {} does not have a sharding specification.".format(mip))
 
+    bbox = Bbox.create(bbox)
     if bbox.subvoxel():
       raise ValueError("Bounding box is too small to make a shard. Got: {}".format(bbox))
 
-    bbox = Bbox.create(bbox, self.meta.bounds(mip), bounded=True)
+    # Alignment Checks:
+    # 1. Aligned to atomic chunks - required for grid point generation
     aligned_bbox = bbox.expand_to_chunk_size(
       self.meta.chunk_size(mip), offset=self.meta.voxel_offset(mip)
     )
-    aligned_bbox = Bbox.clamp(aligned_bbox, self.meta.bounds(mip))
-
     if bbox != aligned_bbox:
       raise exceptions.AlignmentError(
         "Unable to create shard from a non-chunk aligned bounding box. Requested: {}, Aligned: {}".format(
         bbox, aligned_bbox
       ))
 
+    # 2. Covers the dataset at least partially
+    aligned_bbox = Bbox.clamp(aligned_bbox, self.meta.bounds(mip))
+    if aligned_bbox.subvoxel():
+      raise exceptions.OutOfBoundsError("Shard completely outside dataset: Requested: {}, Dataset: {}".format(
+        bbox, self.meta.bounds(mip)
+      ))
+
     grid_size = self.grid_size(mip)
     chunk_size = self.meta.chunk_size(mip)
     reader = sharding.ShardReader(self.meta, self.cache, spec)
 
-    gpts = lambda: gridpoints(bbox, self.meta.bounds(mip), chunk_size)
+    # 3. Gridpoints all within this one shard
+    gpts = lambda: gridpoints(aligned_bbox, self.meta.bounds(mip), chunk_size)
     all_same_shard = bool(reduce(lambda a,b: operator.eq(a,b) and a,
       map(reader.get_filename,
         map(lambda gpt: compressed_morton_code(gpt, grid_size), gpts())
@@ -422,17 +430,21 @@ class PrecomputedImageSource(ImageSourceInterface):
       )
 
     labels = {}
-    pt_anchor = next(gpts())
+    pt_anchor = next(gpts()) * chunk_size
     for pt_abs in gpts():
-      pt_rel = pt_abs - pt_anchor
-      cutout_bbx = Bbox(pt_rel * chunk_size, (pt_rel + 1) * chunk_size)
+      cutout_bbx = Bbox(pt_abs * chunk_size, (pt_abs + 1) * chunk_size)
+
+      # Neuroglancer expects border chunks not to extend beyond dataset bounds
+      cutout_bbx.maxpt = cutout_bbx.maxpt.clip(None, self.meta.volume_size(mip))
+      cutout_bbx -= pt_anchor
+
       chunk = img[ cutout_bbx.to_slices() ]
       morton_code = compressed_morton_code(pt_abs, grid_size)
       labels[morton_code] = chunks.encode(chunk, self.meta.encoding(mip))
 
     shard_filename = reader.get_filename(first(labels.keys()))
 
-    return (shard_filename, spec.synthesize_shard(labels))
+    return (shard_filename, spec.synthesize_shard(labels, progress=progress))
 
   def is_sharded(self, mip):
     scale = self.meta.scale(mip)

--- a/cloudvolume/datasource/precomputed/sharding.py
+++ b/cloudvolume/datasource/precomputed/sharding.py
@@ -595,11 +595,7 @@ class ShardReader(object):
     bundles = []
     for chunk in sorted(files, key=itemgetter("path", "start")):
       if not bundles or (chunk['path'] != bundles[-1]['path']) or (chunk['start'] != bundles[-1]['end']):
-        bundles.append({
-          **chunk,
-          'content': None,
-          'subranges': []
-        })
+        bundles.append(dict(content=None, subranges=[], **chunk))
       else:
         bundles[-1]['end'] = chunk['end']
 

--- a/cloudvolume/datasource/precomputed/sharding.py
+++ b/cloudvolume/datasource/precomputed/sharding.py
@@ -728,8 +728,7 @@ def synthesize_shard_file(spec, label_group, progress=False, presorted=False):
       continue
 
     minishard_index = np.zeros( (3, len(labels)), dtype=np.uint64, order='C')
-    minishard = b''
-    
+    minishard_components = []
     # label and offset are delta encoded
     last_label = 0
     for i, label in enumerate(labels):
@@ -740,10 +739,11 @@ def synthesize_shard_file(spec, label_group, progress=False, presorted=False):
       minishard_index[0, i] = label - last_label
       minishard_index[1, i] = 0 # minishard_index[2, i - 1]
       minishard_index[2, i] = len(binary)
-      minishard += binary
+      minishard_components.append(binary)
       last_label = label
       del minishardgrp[label]
-    
+
+    minishard = b"".join(minishard_components)
     minishardnos.append(minishardno)
     minishard_indicies.append(minishard_index) 
     minishards.append(minishard)


### PR DESCRIPTION
Shard Write:
* fix: don't crop partially intersecting shards
* feat: Add progress flag to `make_shard`
* perf: Avoid repeated string concatenation

Shard Read:
* perf: Avoid copies when converting JPEG bytes to numpy array
  * 30ms -> 0.5ms per call
* perf: Bundle adjacent byte range requests
  * 1000 s -> 5 s for completely empty/black shard
  * 1 s -> 0.5 s for example in https://github.com/seung-lab/cloud-volume/issues/354