### PR TITLE
BREAKING: Drop official support for Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,24 @@
 language: python
 python:
-- '2.7'
 - '3.5'
 - '3.6'
-- '3.7-dev'
-- '3.8-dev'
+- '3.7'
+- '3.8'
 before_install:
 - PYTHON_MAJOR_VERSION=`echo $TRAVIS_PYTHON_VERSION | head -c 1`
-- if [[ $PYTHON_MAJOR_VERSION == 3 ]]; then sudo apt-get install python3-pip; fi
+- sudo apt-get install python3-pip
 - mkdir -p ~/.cloudvolume/secrets/
 - echo $AWS_SECRET > ~/.cloudvolume/secrets/aws-secret.json
 - echo $GOOGLE_SECRET > ~/.cloudvolume/secrets/google-secret.json
 - echo $BOSS_SECRET > ~/.cloudvolume/secrets/boss-secret.json
 install:
-- if [[ $PYTHON_MAJOR_VERSION == 2 ]]; then virtualenv venv; fi
-- if [[ $PYTHON_MAJOR_VERSION == 3 ]]; then virtualenv -p python3 venv; fi
+- virtualenv -p python3 venv
 - source venv/bin/activate
-- if [[ $PYTHON_MAJOR_VERSION == 2 ]]; then pip install numpy; fi
-- if [[ $PYTHON_MAJOR_VERSION == 3 ]]; then pip3 install numpy; fi
-- if [[ $PYTHON_MAJOR_VERSION == 2 ]]; then pip install fpzip; fi
-- if [[ $PYTHON_MAJOR_VERSION == 3 ]]; then pip3 install fpzip; fi
-- if [[ $PYTHON_MAJOR_VERSION == 2 ]]; then pip install -e .[test,dask]; fi
-- if [[ $PYTHON_MAJOR_VERSION == 3 ]]; then pip3 install -e .[test,dask]; fi
-- if [[ $PYTHON_MAJOR_VERSION == 2 ]]; then python setup.py sdist; fi
-- if [[ $PYTHON_MAJOR_VERSION == 3 ]]; then python3 setup.py sdist bdist_wheel --universal; fi
+- pip3 install numpy
+- pip3 install fpzip
+- pip3 install -e .[test,dask]
+- python3 setup.py sdist bdist_wheel --universal
 script:
-- if [[ $PYTHON_MAJOR_VERSION == 2 ]]; then python -m pytest -v -x test --cov=./; fi
-- if [[ $PYTHON_MAJOR_VERSION == 3 ]]; then python3 -m pytest -v -x test --cov=./; fi
+- python3 -m pytest -v -x test --cov=./
 after_success:
   - codecov --token=$CODECOV_TOKEN

--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ You can find a collection of CloudVolume accessible and Neuroglancer viewable da
 
 ## Setup
 
-Cloud-volume is regularly tested on Ubuntu with Python 2.7, 3.5, 3.6, 3.7, and 3.8 (we've noticed it's faster on Python 3). We officially support Linux and Mac OS. Windows is community supported. After installation, you'll also need to set up your cloud credentials if you're planning on writing files or reading from a private dataset. Once you're finished setting up, you can try [reading from a public dataset](https://github.com/seung-lab/cloud-volume/wiki/Reading-Public-Data-Examples).
-
-Note that Python 2.7 does not currently support the DracoPy library, and therefore does not support the `graphene://` format.
+Cloud-volume is regularly tested on Ubuntu with 3.5, 3.6, 3.7, and 3.8. We officially support Linux and Mac OS. Windows is community supported. After installation, you'll also need to set up your cloud credentials if you're planning on writing files or reading from a private dataset. Once you're finished setting up, you can try [reading from a public dataset](https://github.com/seung-lab/cloud-volume/wiki/Reading-Public-Data-Examples).
 
 #### `pip` Binary Installation
 
@@ -532,7 +530,7 @@ pip install vtk matplotlib
 
 ## Python 2.7 End of Life
 
-Python 2.7's [End of Life date](https://pythonclock.org/) is January, 1 2020. CloudVolume will support Python 2.7 up to that point and possibly a few months after. Numpy will be dropping support on January 1. We may accelerate the deprecation schedule if substantial technical problems arise with supporting Python 2.7, but so far the impact has been mostly limited.
+Python 2.7 is no longer supported by CloudVolume. Updated versions of `pip` will download the last supported release 1.21.1. You can read more on the policy page: https://github.com/seung-lab/cloud-volume/wiki/Policy#python-27-end-of-life
 
 ## Related Projects
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setuptools.setup(
     'numpy<1.17; python_version<"3.5"',
     'numpy; python_version>="3.5"',
   ],
+  python_requires="~=3.4", # >= 3.4 < 4.0
   install_requires=requirements(),
   # Environment Marker Examples:
   # https://www.python.org/dev/peps/pep-0496/
@@ -58,8 +59,6 @@ setuptools.setup(
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 2",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Retain backwards compatibility using the python_requires flag.

See https://github.com/seung-lab/cloud-volume/wiki/Policy