### PR TITLE
test(graphene): add tests for meshes based on real data

### DIFF
--- a/test/test_cv/sharded_info.json
+++ b/test/test_cv/sharded_info.json
@@ -1,0 +1,362 @@
+
+{
+    "app": {
+      "supported_api_versions": [
+        0,
+        1
+      ]
+    },
+    "chunks_start_at_voxel_offset": true,
+    "data_dir": "gs://minnie65_pcg/ws",
+    "data_type": "uint64",
+    "graph": {
+      "chunk_size": [
+        256,
+        256,
+        512
+      ],
+      "cv_mip": 0,
+      "n_bits_for_layer_id": 8,
+      "n_layers": 12,
+      "spatial_bit_masks": {
+        "1": 10,
+        "2": 10,
+        "3": 9,
+        "4": 8,
+        "5": 7,
+        "6": 6,
+        "7": 5,
+        "8": 4,
+        "9": 3,
+        "10": 2,
+        "11": 1,
+        "12": 1
+      }
+    },
+    "mesh": "graphene_meshes_minnie3_v1",
+    "mesh_metadata": {
+      "uniform_draco_grid_size": 21,
+      "unsharded_mesh_dir": "dynamic"
+    },
+    "num_channels": 1,
+    "scales": [
+      {
+        "chunk_sizes": [
+          [
+            256,
+            256,
+            32
+          ]
+        ],
+        "compressed_segmentation_block_size": [
+          8,
+          8,
+          8
+        ],
+        "encoding": "compressed_segmentation",
+        "key": "8_8_40",
+        "locked": true,
+        "resolution": [
+          8,
+          8,
+          40
+        ],
+        "size": [
+          192424,
+          131051,
+          13008
+        ],
+        "voxel_offset": [
+          26385,
+          30308,
+          14850
+        ]
+      },
+      {
+        "chunk_sizes": [
+          [
+            256,
+            256,
+            32
+          ]
+        ],
+        "compressed_segmentation_block_size": [
+          8,
+          8,
+          8
+        ],
+        "encoding": "compressed_segmentation",
+        "key": "16_16_40",
+        "locked": true,
+        "resolution": [
+          16,
+          16,
+          40
+        ],
+        "size": [
+          96212,
+          65526,
+          13008
+        ],
+        "voxel_offset": [
+          13192,
+          15154,
+          14850
+        ]
+      },
+      {
+        "chunk_sizes": [
+          [
+            256,
+            256,
+            32
+          ]
+        ],
+        "compressed_segmentation_block_size": [
+          8,
+          8,
+          8
+        ],
+        "encoding": "compressed_segmentation",
+        "key": "32_32_40",
+        "locked": true,
+        "resolution": [
+          32,
+          32,
+          40
+        ],
+        "size": [
+          48106,
+          32763,
+          13008
+        ],
+        "voxel_offset": [
+          6596,
+          7577,
+          14850
+        ]
+      },
+      {
+        "chunk_sizes": [
+          [
+            256,
+            256,
+            32
+          ]
+        ],
+        "compressed_segmentation_block_size": [
+          8,
+          8,
+          8
+        ],
+        "encoding": "compressed_segmentation",
+        "key": "64_64_40",
+        "locked": true,
+        "resolution": [
+          64,
+          64,
+          40
+        ],
+        "size": [
+          24053,
+          16382,
+          13008
+        ],
+        "voxel_offset": [
+          3298,
+          3788,
+          14850
+        ]
+      },
+      {
+        "chunk_sizes": [
+          [
+            256,
+            256,
+            32
+          ]
+        ],
+        "compressed_segmentation_block_size": [
+          8,
+          8,
+          8
+        ],
+        "encoding": "compressed_segmentation",
+        "key": "128_128_80",
+        "resolution": [
+          128,
+          128,
+          80
+        ],
+        "size": [
+          12027,
+          8191,
+          6504
+        ],
+        "voxel_offset": [
+          1649,
+          1894,
+          7425
+        ]
+      },
+      {
+        "chunk_sizes": [
+          [
+            256,
+            256,
+            32
+          ]
+        ],
+        "compressed_segmentation_block_size": [
+          8,
+          8,
+          8
+        ],
+        "encoding": "compressed_segmentation",
+        "key": "256_256_160",
+        "resolution": [
+          256,
+          256,
+          160
+        ],
+        "size": [
+          6014,
+          4096,
+          3252
+        ],
+        "voxel_offset": [
+          824,
+          947,
+          3712
+        ]
+      },
+      {
+        "chunk_sizes": [
+          [
+            256,
+            256,
+            32
+          ]
+        ],
+        "compressed_segmentation_block_size": [
+          8,
+          8,
+          8
+        ],
+        "encoding": "compressed_segmentation",
+        "key": "512_512_320",
+        "resolution": [
+          512,
+          512,
+          320
+        ],
+        "size": [
+          3007,
+          2048,
+          1626
+        ],
+        "voxel_offset": [
+          412,
+          473,
+          1856
+        ]
+      },
+      {
+        "chunk_sizes": [
+          [
+            256,
+            256,
+            32
+          ]
+        ],
+        "compressed_segmentation_block_size": [
+          8,
+          8,
+          8
+        ],
+        "encoding": "compressed_segmentation",
+        "key": "1024_1024_640",
+        "resolution": [
+          1024,
+          1024,
+          640
+        ],
+        "size": [
+          1504,
+          1024,
+          813
+        ],
+        "voxel_offset": [
+          206,
+          236,
+          928
+        ]
+      },
+      {
+        "chunk_sizes": [
+          [
+            256,
+            256,
+            32
+          ]
+        ],
+        "compressed_segmentation_block_size": [
+          8,
+          8,
+          8
+        ],
+        "encoding": "compressed_segmentation",
+        "key": "2048_2048_1280",
+        "resolution": [
+          2048,
+          2048,
+          1280
+        ],
+        "size": [
+          752,
+          512,
+          407
+        ],
+        "voxel_offset": [
+          103,
+          118,
+          464
+        ]
+      },
+      {
+        "chunk_sizes": [
+          [
+            256,
+            256,
+            32
+          ]
+        ],
+        "compressed_segmentation_block_size": [
+          8,
+          8,
+          8
+        ],
+        "encoding": "compressed_segmentation",
+        "key": "4096_4096_2560",
+        "resolution": [
+          4096,
+          4096,
+          2560
+        ],
+        "size": [
+          376,
+          256,
+          204
+        ],
+        "voxel_offset": [
+          51,
+          59,
+          232
+        ]
+      }
+    ],
+    "sharded_mesh": true,
+    "skeletons": "skeletons_mip_2",
+    "type": "segmentation",
+    "verify_mesh": false
+  }

--- a/test/test_graphene.py
+++ b/test/test_graphene.py
@@ -10,7 +10,7 @@ import os
 from scipy import sparse 
 import sys
 import json
-
+import re
 tempdir = tempfile.mkdtemp()
 TEST_PATH = "file://{}".format(tempdir)
 TEST_DATASET_NAME = "testvol"
@@ -186,10 +186,8 @@ def cv_graphene_mesh_draco(requests_mock):
 @pytest.fixture()
 def cv_graphene_sharded(requests_mock):
   test_dir = os.path.dirname(os.path.abspath(__file__))
- 
   graphene_test_cv_dir = os.path.join(test_dir,'test_cv')
-  graphene_test_cv_path = "file://{}".format(graphene_test_cv_dir)
-  #TODO: change this to point to a cloud bucket
+  graphene_test_cv_path = "gs://seunglab-test/graphene/meshes"
 
   with open(os.path.join(graphene_test_cv_dir, 'sharded_info.json'), 'r') as fp:
     info_d = json.load(fp)
@@ -262,9 +260,11 @@ def cv_graphene_sharded(requests_mock):
 
   requests_mock.get(verify_manifest_url, json=valid_manifest)
   requests_mock.get(speculative_manifest_url, json=speculative_manifest)
+  matcher = re.compile('https://storage.googleapis.com/')
 
+  requests_mock.get(matcher,real_http=True)
   cloudpath = posixpath.join(PCG_LOCATION, 'segmentation/table/', GRAPHENE_SHARDED_MESH_TEST_DATASET_NAME)
-  yield cloudvolume.CloudVolume('graphene://' + cloudpath)
+  yield cloudvolume.CloudVolume('graphene://' + cloudpath, use_https=True)
 
 
 @pytest.fixture(scope='session')

--- a/test/test_graphene.py
+++ b/test/test_graphene.py
@@ -91,7 +91,7 @@ def cv_graphene_mesh_precomputed(requests_mock):
   mock_url = posixpath.join(PCG_LOCATION,
               "meshing/api/v1/table",
               PRECOMPUTED_MESH_TEST_DATASET_NAME,
-              f"manifest/{TEST_SEG_ID}:0?verify=True")
+              "manifest/{}:0?verify=True".format(TEST_SEG_ID))
   requests_mock.get(mock_url, json=frag_d)
 
   cloudpath =   posixpath.join(PCG_LOCATION,


### PR DESCRIPTION
I have added some more tests to ensure that mesh access works properly with the newer graphene server protocols.