### PR TITLE
fixing level=2 for bounding box queries

### DIFF
--- a/cloudvolume/datasource/graphene/mesh/sharded.py
+++ b/cloudvolume/datasource/graphene/mesh/sharded.py
@@ -146,7 +146,8 @@ class GrapheneShardedMeshSource(GrapheneUnshardedMeshSource):
     """
     level = self.meta.meta.decode_layer_id(seg_id)
     dynamic_cloudpath = self.meta.join(self.meta.meta.cloudpath, self.dynamic_path())
-
+    if bounding_box is not None:
+      level=2
     manifest = self.fetch_manifest(seg_id, level=level, bbox=bounding_box, return_segids=True)
     lists = self.parse_manifest_filenames(manifest)
 
@@ -189,6 +190,8 @@ class GrapheneShardedMeshSource(GrapheneUnshardedMeshSource):
 
   def get_meshes_via_manifest_labels(self, seg_id, bounding_box):
     level = self.meta.meta.decode_layer_id(seg_id)
+    if bounding_box is not None:
+      level=2
     labels = self.get_fragment_labels(seg_id, level=level, bbox=bounding_box)
     meshes = self.get_meshes_on_bypass(labels, allow_missing=True) # sometimes a tiny label won't get meshed
     return list(meshes.values())

--- a/cloudvolume/datasource/graphene/mesh/sharded.py
+++ b/cloudvolume/datasource/graphene/mesh/sharded.py
@@ -189,7 +189,7 @@ class GrapheneShardedMeshSource(GrapheneUnshardedMeshSource):
     return dynamic_meshes + initial_meshes
 
   def get_meshes_via_manifest_labels(self, seg_id, bounding_box):
-    level = self.meta.meta.decode_layer_id(seg_id)
+    level = 6
     if bounding_box is not None:
       level=2
     labels = self.get_fragment_labels(seg_id, level=level, bbox=bounding_box)

--- a/cloudvolume/datasource/graphene/mesh/sharded.py
+++ b/cloudvolume/datasource/graphene/mesh/sharded.py
@@ -189,7 +189,7 @@ class GrapheneShardedMeshSource(GrapheneUnshardedMeshSource):
     return dynamic_meshes + initial_meshes
 
   def get_meshes_via_manifest_labels(self, seg_id, bounding_box):
-    level = 6
+    level = None
     if bounding_box is not None:
       level=2
     labels = self.get_fragment_labels(seg_id, level=level, bbox=bounding_box)


### PR DESCRIPTION
When doing a bounding box query with graphene, it doesn't make sense to specify something other than level2 because you don't want to get stitched fragments that extend well beyond your bounding box in some inconsistent fashion depending on the state of mesh stitching in the backend. 

This simply sets the level=2 when specifying a bounding box. 

I have a corresponding PR on the PCG backend to make this functional. 
https://github.com/seung-lab/PyChunkedGraph/pull/229