### PR TITLE
Missing 'import re' in mesh.py.

### DIFF
--- a/cloudvolume/mesh.py
+++ b/cloudvolume/mesh.py
@@ -1,4 +1,5 @@
 import copy
+import re
 import struct
 
 import numpy as np


### PR DESCRIPTION
A missing 'import re' prevents Mesh.from_obj() from working.

```
Traceback (most recent call last):
  File "obj_to_ngl.py", line 28, in <module>
    main()
  File "obj_to_ngl.py", line 22, in main
    cv_mesh = Mesh.from_obj(text=Path(meshfile).read_text(), segid=mesh_id)
  File "/Users/eric/anaconda3/envs/fafb/lib/python3.8/site-packages/cloudvolume/mesh.py", line 258, in from_obj
    (v1, v2, v3) = re.match(r'v\s+([-\d\.]+)\s+([-\d\.]+)\s+([-\d\.]+)', line).groups()
NameError: name 're' is not defined
```