### PR TITLE
feat(uviewer): support displaying bigint segmentation

### DIFF
--- a/cloudvolume/microviewer/__init__.py
+++ b/cloudvolume/microviewer/__init__.py
@@ -71,7 +71,7 @@ def hyperview(
   ):
 
   img = to3d(img)
-  segmentation = emulate_eight_uint64(to3d(segmentation))
+  segmentation = to3d(segmentation)
 
   assert np.all(img.shape[:3] == segmentation.shape[:3])
 
@@ -82,20 +82,6 @@ def hyperview(
 
   return run([ img, segmentation ], hostname=hostname, port=port)
 
-def emulate_eight_uint64(img):
-  # Makes sense for viewing not segmentation 
-  # which requires uints currently. (Jan. 2019)
-  if np.dtype(img.dtype).itemsize == 8 and not np.issubdtype(img.dtype, np.float64):
-    print(yellow(
-      """
-Converting {} to float64 for display. 
-Javascript does not support native 64-bit integer arrays.
-      """.format(img.dtype)
-    ))
-    return img.astype(np.float64)
-
-  return img
-
 def view(
     img, segmentation=False, resolution=None, offset=None,
     hostname="localhost", port=DEFAULT_PORT
@@ -105,7 +91,6 @@ def view(
   img = to3d(img)
   resolution = getresolution(img, resolution)
   offset = getoffset(img, offset)
-  img = emulate_eight_uint64(img)
 
   cutout = VolumeCutout(
     buf=img,

--- a/cloudvolume/microviewer/datacube.js
+++ b/cloudvolume/microviewer/datacube.js
@@ -1030,6 +1030,7 @@ class DataCube {
       1: Uint8Array,
       2: Uint16Array,
       4: Uint32Array,
+      8: BigUint64Array,
     };
 
     let ArrayType = choices[this.bytes];
@@ -1302,9 +1303,14 @@ function binary_get (url, progressfn) {
 function renumber (cube) {
   let assignments = new Map();
   
-  let last_label = 0;
-  let last_relabel = 0;
-  let next_label = 1;
+  let cast = (cube instanceof BigUint64Array)
+    ? BigInt
+    : Number;
+
+  let last_label = cast(0);
+  let last_relabel = cast(0);
+  let next_label = cast(1);
+  let zero = cast(0);
 
   if (cube.length) {
     last_label = cube[0];
@@ -1313,12 +1319,12 @@ function renumber (cube) {
     next_label++;
   }
 
-  let cur_label = 0;
+  let cur_label = cast(0);
   for (let i = cube.length - 1; i >= 0; i--) {
-    if (cube[i] == 0) {
+    if (cube[i] === zero) {
       continue;
     }
-    else if (cube[i] == last_label) {
+    else if (cube[i] === last_label) {
       cube[i] = last_relabel;
       continue;
     }
@@ -1338,7 +1344,7 @@ function renumber (cube) {
     }
   }
 
-  let renumbering = new cube.constructor(next_label);
+  let renumbering = new cube.constructor(Number(next_label));
   for (let [label, remap] of assignments) {
     renumbering[remap] = label;
   }

--- a/cloudvolume/volumecutout.py
+++ b/cloudvolume/volumecutout.py
@@ -105,5 +105,4 @@ class VolumeCutout(np.ndarray):
 
   def viewer(self, port=8080):
     """Start a local web app on the given port that lets you explore this cutout."""
-    img = microviewer.emulate_eight_uint64(self)
-    microviewer.run([ img ], port=port)
+    microviewer.run([ self ], port=port)


### PR DESCRIPTION
Resolves #171

It seems that FireFox and Chrome both support BigUint64Arrays now.
It's a little tricky because BigInt and Number do not mix so casting
has to be done carefully.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt