### PR TITLE
perf: faster decode of spatial_index json

### DIFF
--- a/cloudvolume/datasource/precomputed/spatial_index.py
+++ b/cloudvolume/datasource/precomputed/spatial_index.py
@@ -193,7 +193,7 @@ class SpatialIndex(object):
     # optimization is important for querying 
     # entire datasets, which is contemplated
     # for shard generation.    
-    fast_path = bbox.contains_bbox(self.bounds) or True
+    fast_path = bbox.contains_bbox(self.bounds)
 
     labels = set()
     for filename, content in tqdm(results.items(), desc="Decoding Labels", disable=(not self.config.progress)):
@@ -247,7 +247,7 @@ class SpatialIndex(object):
     # optimization is important for querying 
     # entire datasets, which is contemplated
     # for shard generation.    
-    fast_path = bbox.contains_bbox(self.bounds) or True
+    fast_path = bbox.contains_bbox(self.bounds)
 
     labels = set()
     iterator = tqdm(


### PR DESCRIPTION
It looks like on this test, the decode time was faster by about 30%, but the cost is a huge increase in memory usage. It also creates duplicated code which will be expensive to maintain. The real situation requires > 100k files whereas this test was on about 1200 files, so the memory problem will be 100x worse.

<img width="858" alt="image" src="https://user-images.githubusercontent.com/2517065/97402349-cefac980-18c8-11eb-9ebe-f012bd3c2cfd.png">
