### PR TITLE
feat(image): download an image already renumbered

### DIFF
--- a/cloudvolume/datasource/boss/image.py
+++ b/cloudvolume/datasource/boss/image.py
@@ -32,7 +32,12 @@ class BossImageSource(ImageSourceInterface):
     self.non_aligned_writes = bool(non_aligned_writes)
     self.readonly = bool(readonly)
 
-  def download(self, bbox, mip):
+  def download(self, bbox, mip, parallel=1, renumber=False):
+    if parallel != 1:
+      raise ValueError("Only parallel=1 is supported for boss.")
+    elif renumber != False:
+      raise ValueError("Only renumber=False is supported for boss.")
+
     bounds = Bbox.clamp(bbox, self.meta.bounds(mip))
 
     if self.autocrop:

--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -173,6 +173,7 @@ class PrecomputedImageSource(ImageSourceInterface):
         green=self.config.green,
         secrets=self.config.secrets,
         renumber=renumber,
+        background_color=int(self.background_color),
       )
 
   @readonlyguard

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -116,27 +116,31 @@ def download(
 
   handle = None
 
+  if renumber and (parallel != 1):
+    raise ValueError("renumber is not supported for parallel operation.")
+
   if use_shared_memory and use_file:
     raise ValueError("use_shared_memory and use_file are mutually exclusive arguments.")
+
+  dtype = np.uint16 if renumber else meta.dtype
 
   if parallel == 1:
     if use_shared_memory: # write to shared memory
       handle, renderbuffer = shm.ndarray(
-        shape, dtype=meta.dtype, order=order,
+        shape, dtype=dtype, order=order,
         location=location, lock=fs_lock
       )
       if not retain:
         shm.unlink(location)
     elif use_file: # write to ordinary file
       handle, renderbuffer = shm.ndarray_fs(
-        shape, dtype=meta.dtype, order=order,
+        shape, dtype=dtype, order=order,
         location=location, lock=fs_lock,
         emulate_shm=False
       )
       if not retain:
         os.unlink(location)
     else:
-      dtype = np.uint16 if renumber else meta.dtype
       renderbuffer = np.zeros(shape=shape, dtype=dtype, order=order)
 
     def process(img3d, bbox):

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -2,12 +2,14 @@ from functools import partial
 import itertools
 import math
 import os
+import threading
 
 import numpy as np
 from six.moves import range
 from tqdm import tqdm
 
 from cloudfiles import reset_connection_pools, CloudFiles, compression
+import fastremap
 
 from ....exceptions import EmptyVolumeException, EmptyFileException
 from ....lib import (  
@@ -94,7 +96,8 @@ def download(
     parallel, location, 
     retain, use_shared_memory, 
     use_file, compress, order='F',
-    green=False, secrets=None
+    green=False, secrets=None,
+    renumber=False
   ):
   """Cutout a requested bounding box from storage and return it as a numpy array."""
   
@@ -133,16 +136,41 @@ def download(
       if not retain:
         os.unlink(location)
     else:
-      renderbuffer = np.zeros(shape=shape, dtype=meta.dtype, order=order)
+      dtype = np.uint16 if renumber else meta.dtype
+      renderbuffer = np.zeros(shape=shape, dtype=dtype, order=order)
 
     def process(img3d, bbox):
       shade(renderbuffer, requested_bbox, img3d, bbox)
 
+    remap = { 0: 0 }
+    lock = threading.Lock()
+    N = 1
+    def process_renumber(img3d, bbox):
+      nonlocal N
+      nonlocal lock 
+      nonlocal remap
+      nonlocal renderbuffer
+      img_labels = fastremap.unique(img3d)
+      with lock:
+        for lbl in img_labels:
+          if lbl not in remap:
+            remap[lbl] = N
+            N += 1
+        if N > np.iinfo(renderbuffer.dtype).max:
+          renderbuffer = fastremap.refit(renderbuffer, value=N, increase_only=True)
+
+      fastremap.remap(img3d, remap, in_place=True)
+      shade(renderbuffer, requested_bbox, img3d, bbox)
+
+    fn = process
+    if renumber and not (use_file or use_shared_memory):
+      fn = process_renumber  
+
     download_chunks_threaded(
       meta, cache, mip, cloudpaths, 
-      fn=process, fill_missing=fill_missing,
+      fn=fn, fill_missing=fill_missing,
       progress=progress, compress_cache=compress_cache, 
-      green=green, secrets=secrets 
+      green=green, secrets=secrets
     )
   else:
     handle, renderbuffer = multiprocess_download(
@@ -156,10 +184,13 @@ def download(
       secrets=secrets,
     )
   
-  return VolumeCutout.from_volume(
+  out = VolumeCutout.from_volume(
     meta, mip, renderbuffer, 
     requested_bbox, handle=handle
   )
+  if renumber:
+    return (out, remap)
+  return out
 
 def multiprocess_download(
     requested_bbox, mip, cloudpaths,

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -97,7 +97,7 @@ def download(
     retain, use_shared_memory, 
     use_file, compress, order='F',
     green=False, secrets=None,
-    renumber=False
+    renumber=False, background_color=0
   ):
   """Cutout a requested bounding box from storage and return it as a numpy array."""
   
@@ -146,7 +146,7 @@ def download(
     def process(img3d, bbox):
       shade(renderbuffer, requested_bbox, img3d, bbox)
 
-    remap = { 0: 0 }
+    remap = { background_color: background_color }
     lock = threading.Lock()
     N = 1
     def process_renumber(img3d, bbox):


### PR DESCRIPTION
This can save 2-4x on memory usage.

```python
lbls, remap = cv.download(cv.bounds, renumber=True)
```
If you download a large volume as a uint64 but it could be represented using a uint16, you can theoretically resize it, but that requires allocating the larger memory structure, allocating more, and then downsizing it. With this approach, you never allocate the larger data type and render the volume in renumbered form.


