### PR TITLE
fix(encode_jpeg): correct 3D->2D shape for Neuroglancer

### DIFF
--- a/cloudvolume/chunks.py
+++ b/cloudvolume/chunks.py
@@ -94,7 +94,7 @@ def encode_jpeg(arr, quality=85):
   reshaped = arr.T
   reshaped = np.moveaxis(reshaped, 0, -1)
   reshaped = reshaped.reshape(
-    arr.shape[0] * arr.shape[1], arr.shape[2], num_channel
+    reshaped.shape[0] * reshaped.shape[1], reshaped.shape[2], num_channel
   )
   if num_channel == 1:
     return simplejpeg.encode_jpeg(

--- a/test/test_chunks.py
+++ b/test/test_chunks.py
@@ -97,13 +97,22 @@ def test_npz():
   random_data = np.random.randint(255, size=(64,64,64,1), dtype=np.uint8)
   encode_decode(random_data, 'npz')
 
-@pytest.mark.parametrize("shape", ( (64,64,64), (64,61,50)))
+@pytest.mark.parametrize("shape", ( (64,64,64), (64,61,50), (128,128,16), ))
 @pytest.mark.parametrize("num_channels", (1,3))
 def test_jpeg(shape, num_channels):
+  import simplejpeg
+
   xshape = list(shape) + [ num_channels ]
   data = np.zeros(shape=xshape, dtype=np.uint8)
   encode_decode(data, 'jpeg', shape, num_channels)
   encode_decode(data + 255, 'jpeg', shape, num_channels)
+
+  jpg = simplejpeg.decode_jpeg(
+    encode(data, 'jpeg'), 
+    colorspace="GRAY",
+  )
+  assert jpg.shape[0] == shape[1] * shape[2]
+  assert jpg.shape[1] == shape[0]
 
   # Random jpeg won't decompress to exactly the same image
   # but it should have nearly the same average power


### PR DESCRIPTION
Array shape mixup in between the transposing / axis swapping / reshaping transformations.
Happened during the switch to simple_jpeg (#392)