### PR TITLE
feat: add support for base64 encoded token

### DIFF
--- a/cloudvolume/datasource/graphene/metadata.py
+++ b/cloudvolume/datasource/graphene/metadata.py
@@ -121,9 +121,8 @@ class GrapheneMetadata(PrecomputedMetadata):
         "No Graphene authentication token was provided. "
         "Does ~/.cloudvolume/secrets/chunkedgraph-secret.json exist?"
       )
-    elif not re.match(r'^[0-9a-f]+$', token):
-      raise exceptions.AuthenticationError("Graphene authentication token was not formatted correctly. It should be a hexadecimal string.")
-
+    elif not (re.match(r'^[0-9a-f]+$', token) or re.match(r'^[A-Za-z0-9+/]+={0,2}$', token)):
+      raise exceptions.AuthenticationError("Graphene authentication token was not formatted correctly. It should either be a hexadecimal or base64 string.")
     return token
 
   def supports_api(self, version):


### PR DESCRIPTION
currently only hexadecimal strings are supported for graphene auth tokens, this adds support for base64 encoded strings
regex used for this is from [here](https://base64.guru/learn/base64-characters ) (single line base64 string)

resolves #453 