### PR TITLE
feat: add cave-secret.json and allow for fqdn qualification

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,16 +162,19 @@ You can create the `google-secret.json` file [here](https://console.cloud.google
 }
 ```
 
-#### `chunkedgraph-secret.json`
+#### `cave-secret.json`
 
-If you have a token from Graphene/Chunkedgraph server, create the `chunkedgraph-secret.json` file as shown in the example below.
-You may also pass the token to `GrapheneMetadata` class `auth_token="<your_token>"`, this will override the token from `json` file.
+*Note: used to be called chunkedgraph-secret.json. This is still supported but deprecated.*
+
+If you have a token from Graphene/Chunkedgraph server, create the `cave-secret.json` file as shown in the example below. You may also pass the token to `CloudVolume(..., secrets=token)`.
 
 ```json
 {
   "token": "<your_token>"
 }
 ```
+
+Note that to take advantage of multiple credential files, prepend the fully qualified domain name (FQDN) of the server instead of the bucket for GCS and S3. For example, `sudomain.domain.com-cave-secret.json`.
 
 ## Usage
 

--- a/cloudvolume/datasource/graphene/metadata.py
+++ b/cloudvolume/datasource/graphene/metadata.py
@@ -119,7 +119,7 @@ class GrapheneMetadata(PrecomputedMetadata):
     if not token:
       raise exceptions.AuthenticationError(
         "No Graphene authentication token was provided. "
-        "Does ~/.cloudvolume/secrets/chunkedgraph-secret.json exist?"
+        "Does ~/.cloudvolume/secrets/cave-secret.json exist?"
       )
     elif not (re.match(r'^[0-9a-f]+$', token) or re.match(r'^[A-Za-z0-9+/]+={0,2}$', token)):
       raise exceptions.AuthenticationError("Graphene authentication token was not formatted correctly. It should either be a hexadecimal or base64 string.")

--- a/cloudvolume/datasource/graphene/metadata.py
+++ b/cloudvolume/datasource/graphene/metadata.py
@@ -10,7 +10,7 @@ import numpy as np
 from ...lib import Vec, Bbox
 from ... import exceptions
 from ... import paths
-from ...secrets import chunkedgraph_credentials
+from ...secrets import cave_credentials
 from ..precomputed import PrecomputedMetadata
 
 VERSION_ORDERING = [  
@@ -104,8 +104,8 @@ class GrapheneMetadata(PrecomputedMetadata):
     token = None
     if auth_token:
       token = auth_token
-    elif chunkedgraph_credentials:
-      token = chunkedgraph_credentials
+    else:
+      token = cave_credentials(self.server_path.fqdn)
 
     if isinstance(token, str):
       try:
@@ -114,9 +114,9 @@ class GrapheneMetadata(PrecomputedMetadata):
         pass
 
     if isinstance(token, dict):
-      token = token["token"]
+      token = token.get("token", None)
 
-    if token is None:
+    if not token:
       raise exceptions.AuthenticationError(
         "No Graphene authentication token was provided. "
         "Does ~/.cloudvolume/secrets/chunkedgraph-secret.json exist?"
@@ -140,9 +140,7 @@ class GrapheneMetadata(PrecomputedMetadata):
   @property
   def base_path(self):
     path = self.server_path
-    if path.subdomain is None:
-      return path.scheme + '://' + path.domain + '/'   
-    return path.scheme + '://' + path.subdomain + '.' + path.domain + '/' 
+    return f"{path.scheme}://{path.fqdn}/"
 
   @property
   def table_path(self):
@@ -366,7 +364,7 @@ class GrapheneMetadata(PrecomputedMetadata):
   def manifest_endpoint(self):
     pth = self.server_path
     pth = GraphenePath(
-      pth.scheme, pth.subdomain, pth.domain, 
+      pth.scheme, pth.fqdn,
       'meshing', pth.version, pth.dataset
     )
 
@@ -429,7 +427,7 @@ class GrapheneMetadata(PrecomputedMetadata):
       )
     return self.mesh_metadata["draco_grid_sizes"][str(level)]
 
-GraphenePath = namedtuple('GraphenePath', ('scheme', 'subdomain', 'domain', 'modality', 'version', 'dataset'))
+GraphenePath = namedtuple('GraphenePath', ('scheme', 'fqdn', 'modality', 'version', 'dataset'))
 LEGACY_EXTRACTION_RE = re.compile(r'/?(\w+)/([\d\.]+)/([\w\d\.\_\-]+)/?')
 API_VX_EXTRACTION_RE = re.compile(r'/?(\w+)/api/(v[\d\.]+)/([\w\d\.\_\-]+)/?')
 LATEST_API_EXTRACTION_RE = re.compile(r'/?(\w+)/(table)/([\w\d\.\_\-]+)/?')
@@ -445,8 +443,6 @@ def extract_graphene_path(url):
     graphene://https://SUBDOMAIN.DOMAIN_DOT_COM/segmentation/table/DATASET
   """
   parse = urllib.parse.urlparse(url)
-  subdomain = parse.netloc.split('.')[0]
-  domain = '.'.join(parse.netloc.split('.')[1:])
 
   schemes = [ 
     LATEST_API_EXTRACTION_RE, API_VX_EXTRACTION_RE, LEGACY_EXTRACTION_RE 
@@ -460,5 +456,5 @@ def extract_graphene_path(url):
     raise exceptions.UnsupportedFormatError("Unable to parse Graphene URL: " + url)
 
   modality, version, dataset = match.groups()
-  return GraphenePath(parse.scheme, subdomain, domain, modality, version, dataset)
+  return GraphenePath(parse.scheme, parse.netloc, modality, version, dataset)
 

--- a/cloudvolume/secrets.py
+++ b/cloudvolume/secrets.py
@@ -142,9 +142,30 @@ else:
   boss_credentials = ''
 
 
-chunkedgraph_credentials_path = secretpath('secrets/chunkedgraph-secret.json')
-if os.path.exists(chunkedgraph_credentials_path):
-  with open(chunkedgraph_credentials_path, 'r') as f:
-    chunkedgraph_credentials = json.loads(f.read())
-else:
-  chunkedgraph_credentials = None
+# Graphene PyChunkGraph server
+# CAVE = Connectomics Annotation Versioning Engine
+CAVE_CREDENTIALS_CACHE = defaultdict(list)
+def cave_credentials(domain=''):
+  global CAVE_CREDENTIALS_CACHE
+
+  if domain in CAVE_CREDENTIALS_CACHE.keys():
+    return CAVE_CREDENTIALS_CACHE[domain]
+
+  default_file_path = secretpath('secrets/cave-secret.json')
+  legacy_file_path = secretpath('secrets/chunkedgraph-secret.json')
+
+  paths = [ default_file_path, legacy_file_path ]
+
+  if domain:
+    paths = [ secretpath('secrets/{}-cave-secret.json'.format(bucket)) ] + paths
+
+  credentials = {}
+  for path in paths:
+    if os.path.exists(path):
+      with open(path, 'rt') as f:
+        credentials = json.loads(f.read())
+      break
+
+  CAVE_CREDENTIALS_CACHE[domain] = credentials
+  return credentials
+

--- a/cloudvolume/secrets.py
+++ b/cloudvolume/secrets.py
@@ -157,7 +157,7 @@ def cave_credentials(domain=''):
   paths = [ default_file_path, legacy_file_path ]
 
   if domain:
-    paths = [ secretpath('secrets/{}-cave-secret.json'.format(bucket)) ] + paths
+    paths = [ secretpath('secrets/{}-cave-secret.json'.format(domain)) ] + paths
 
   credentials = {}
   for path in paths:

--- a/cloudvolume/secrets.py
+++ b/cloudvolume/secrets.py
@@ -8,6 +8,8 @@ from .lib import mkdir, colorize
 
 HOME = os.path.expanduser('~')
 CLOUD_VOLUME_DIR = os.path.join(HOME, '.cloudvolume')
+CLOUD_VOLUME_DIR = os.environ.get("CLOUD_VOLUME_DIR", CLOUD_VOLUME_DIR)
+
 try:
   mkdir(CLOUD_VOLUME_DIR)
 except PermissionError: # allow operation in read-only mode

--- a/cloudvolume/secrets.py
+++ b/cloudvolume/secrets.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from collections import defaultdict
 import os
 import json


### PR DESCRIPTION
e.g. flywire.dynamicannotationframework.com-cave-secret.json
(fake example)

Also adds the ability to configure the `.cloudvolume` directory via an environment variable `CLOUD_VOLUME_DIR`

Resolves #458 