### PR TITLE
Fix: multilod mesh vertex corruption

### DIFF
--- a/cloudvolume/datasource/precomputed/mesh/multilod.py
+++ b/cloudvolume/datasource/precomputed/mesh/multilod.py
@@ -127,11 +127,6 @@ class ShardedMultiLevelPrecomputedMeshSource(UnshardedLegacyPrecomputedMeshSourc
           continue
         mesh = Mesh.from_draco(frag_binary)
 
-        # Conversion references:
-        # https://github.com/google/neuroglancer/blob/master/src/neuroglancer/mesh/draco/neuroglancer_draco.cc
-        # Treat the draco result as integers in the range [0, 2**vertex_quantization_bits)
-        mesh.vertices = mesh.vertices.view(dtype=np.int32)
-        
         # Convert from "stored model" space to "model" space
         mesh.vertices = manifest.grid_origin + manifest.vertex_offsets[lod] + \
                 manifest.chunk_shape * (2 ** lod) * \

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ boto3>=1.4.7
 chardet>=3.0.4
 cloud-files>=1.23.1
 compressed-segmentation>=2.0.1
-DracoPy
+DracoPy>=0.0.19
 fastremap>=1.9.2
 fpzip>=1.1.3
 gevent


### PR DESCRIPTION
DracoPy <= 0.0.15 erroneously assumes that every vertex is a float32, by copying the draco vertex buffers into float arrays. This works with the current `multilod.py` code (in certain platforms) because the multilod code views the DracoPy float data as np.int32, so if the original vertices were also int32 the data is unchanged. DracoPy 0.0.19 fixes this earlier bug, by appropriately converting the vertices into floats if they are of a different type. Ironically that fix means that the multilod code is now broken, because it views the now converted float data as np.int32. Therefore, we should remove this np.view call. Talked with Will and we agreed that this is the appropriate fix, and that the view was likely originally added to get around DracoPy's bug. Additionally, I confirmed that DracoPy 0.0.19 without the view call returns the same vertices as 0.0.15 with it, and that google's draco decoder decodes the same mesh from the draco file as DracoPy 0.0.19.

The related issues are here: https://github.com/seung-lab/cloud-volume/issues/450 and https://github.com/seung-lab/DracoPy/issues/16