### PR TITLE
fix(spatial_index): correct calculation of file paths

### DIFF
--- a/cloudvolume/datasource/precomputed/spatial_index.py
+++ b/cloudvolume/datasource/precomputed/spatial_index.py
@@ -115,14 +115,16 @@ class SpatialIndex(object):
     pbar.close()
 
   def index_file_paths_for_bbox(self, bbox):
+    """
+    Returns an iterator over the spatial index filenames
+    that overlap with the bounding box.
+    """
     bbox = bbox.expand_to_chunk_size(self.chunk_size, offset=self.physical_bounds.minpt)
-
     if bbox.subvoxel():
       return []
 
     chunk_size = self.chunk_size
-    bounds = self.bounds
-    resolution = self.resolution
+    bounds = self.physical_bounds.clone()
     precision = self.precision
 
     class IndexPathIterator():
@@ -131,7 +133,6 @@ class SpatialIndex(object):
       def __iter__(self):
         for pt in xyzrange(bbox.minpt, bbox.maxpt, chunk_size):
           search = Bbox( pt, min2(pt + chunk_size, bounds.maxpt) )
-          search *= resolution
           yield search.to_filename(precision) + '.spatial'
 
     return IndexPathIterator()

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -3,7 +3,66 @@ import pytest
 import numpy as np
 
 import cloudvolume.lib as lib
-from cloudvolume.lib import Bbox, Vec
+from cloudvolume.lib import Bbox, Vec, xyzrange
+
+def test_xyzrange():
+  def xyz(*args):
+    return np.array(list(xyzrange(*args)))
+
+  assert list(xyzrange((0,0,0))) == []
+  assert list(xyzrange((1,0,0))) == []
+  assert np.all(xyz((1,1,1)) == [Vec(0,0,0)])
+  assert np.all(xyz((2,1,1)) == [Vec(0,0,0), Vec(1,0,0)])
+  assert np.all(xyz((2,2,2)) == [
+    Vec(0,0,0), Vec(1,0,0),
+    Vec(0,1,0), Vec(1,1,0),
+    Vec(0,0,1), Vec(1,0,1),
+    Vec(0,1,1), Vec(1,1,1),
+  ])
+  assert np.all(xyz((2,1,1), (3,2,2)) == [Vec(2,1,1)])
+  assert np.all(xyz((2,1,1), (5,2,2), (2,1,1)) == [Vec(2,1,1), Vec(4,1,1)])
+
+  z = xyz((0,0,0), (2,2,1), (0.5,0.5,0.5))
+  print(z)
+  print(len(z))
+
+  assert np.all(xyz((0,0,0), (2,2,1), (0.5,0.5,0.5)) == [
+    Vec(0.0,0.0,0.0),
+    Vec(0.5,0.0,0.0),
+    Vec(1.0,0.0,0.0),
+    Vec(1.5,0.0,0.0),
+    Vec(0.0,0.5,0.0),
+    Vec(0.5,0.5,0.0),
+    Vec(1.0,0.5,0.0),
+    Vec(1.5,0.5,0.0),
+    Vec(0.0,1.0,0.0),
+    Vec(0.5,1.0,0.0),
+    Vec(1.0,1.0,0.0),
+    Vec(1.5,1.0,0.0),
+    Vec(0.0,1.5,0.0),
+    Vec(0.5,1.5,0.0),
+    Vec(1.0,1.5,0.0),
+    Vec(1.5,1.5,0.0),
+    
+    Vec(0.0,0.0,0.5),
+    Vec(0.5,0.0,0.5),
+    Vec(1.0,0.0,0.5),
+    Vec(1.5,0.0,0.5),
+    Vec(0.0,0.5,0.5),
+    Vec(0.5,0.5,0.5),
+    Vec(1.0,0.5,0.5),
+    Vec(1.5,0.5,0.5),
+    Vec(0.0,1.0,0.5),
+    Vec(0.5,1.0,0.5),
+    Vec(1.0,1.0,0.5),
+    Vec(1.5,1.0,0.5),
+    Vec(0.0,1.5,0.5),
+    Vec(0.5,1.5,0.5),
+    Vec(1.0,1.5,0.5),
+    Vec(1.5,1.5,0.5),
+    
+  ])
+
 
 def test_divisors():
 


### PR DESCRIPTION
Broke the spatial index query during the move to floating point resolution.

This fix changes how xyzrange is implemented to allow floating point steps and also return a clone of the point Vec (which should avoid certain issues anyway). It also makes Vec check for floating point arguments to determine dtype, so this change is technically backwards incompatible though I think few people will notice.