### PR TITLE
fix(image shard): morton codes not handling single dimensions

### DIFF
--- a/cloudvolume/datasource/precomputed/image/common.py
+++ b/cloudvolume/datasource/precomputed/image/common.py
@@ -75,13 +75,20 @@ def compressed_morton_code(gridpt, grid_size):
     single_input = True
 
   code = np.zeros((gridpt.shape[0],), dtype=np.uint64)
-  num_bits = max(( math.ceil(math.log2(size)) for size in grid_size ))
+  num_bits = [ math.ceil(math.log2(size)) for size in grid_size ]
   j = np.uint64(0)
   one = np.uint64(1)
 
-  for i in range(num_bits):
+  if sum(num_bits) > 64:
+    raise ValueError(f"Unable to represent grids that require more than 64 bits. Grid size {grid_size} requires {num_bits} bits.")
+
+  max_coords = np.max(gridpt, axis=0)
+  if np.any(max_coords >= grid_size):
+    raise ValueError(f"Unable to represent grid points larger than the grid. Grid size: {grid_size} Grid points: {gridpt}")
+
+  for i in range(max(num_bits)):
     for dim in range(3):
-      if 2 ** i <= grid_size[dim]:
+      if 2 ** i <= grid_size[dim] and grid_size[dim] > 1:
         bit = (((np.uint64(gridpt[:, dim]) >> np.uint64(i)) & one) << j)
         code |= bit
         j += one

--- a/test/test_sharding.py
+++ b/test/test_sharding.py
@@ -52,7 +52,11 @@ def test_compressed_morton_code():
   assert cmc((0,0,0)) == 0b000000
   assert cmc((1,0,0)) == 0b000001
   assert cmc((2,0,0)) == 0b001000
-  assert cmc((3,0,0)) == 0b001001
+  try:
+    cmc((3,0,0))
+    assert False
+  except ValueError:
+    pass
   assert cmc((2,2,0)) == 0b011000
   assert cmc((2,2,1)) == 0b011100
 
@@ -60,10 +64,17 @@ def test_compressed_morton_code():
 
   assert cmc((0,0,0)) == 0b000000
   assert cmc((1,0,0)) == 0b000001
-  assert cmc((0,0,7)) == 0b000100
-  assert cmc((2,3,1)) == 0b011110
+  try:
+    cmc((0,0,7))
+    assert False
+  except ValueError:
+    pass
+  assert cmc((1,2,0)) == 0b001001
 
-  assert np.array_equal(cmc([(0,0,0), (1,0,1)]), [0b000000, 0b000101])
+  assert np.array_equal(cmc([(0,0,0), (1,2,0)]), [0b000000, 0b001001])
+
+  cmc = lambda coord: compressed_morton_code(coord, grid_size=(4,4,1))
+  assert cmc((3,3,0)) == 0b1111
 
 def test_image_sharding_hash():
   spec = ShardingSpecification(


### PR DESCRIPTION
Based on this issue filed in Igneous: https://github.com/seung-lab/igneous/issues/100