### PR TITLE
fix: update morton coding

### DIFF
--- a/cloudvolume/datasource/precomputed/image/common.py
+++ b/cloudvolume/datasource/precomputed/image/common.py
@@ -88,7 +88,7 @@ def compressed_morton_code(gridpt, grid_size):
 
   for i in range(max(num_bits)):
     for dim in range(3):
-      if 2 ** i <= grid_size[dim] and grid_size[dim] > 1:
+      if 2 ** i < grid_size[dim]:
         bit = (((np.uint64(gridpt[:, dim]) >> np.uint64(i)) & one) << j)
         code |= bit
         j += one
@@ -123,4 +123,3 @@ def shade(dest_img, dest_bbox, src_img, src_bbox):
     src_img = src_img[..., np.newaxis]
   
   dest_img[ dbox.to_slices() ] = src_img[ sbox.to_slices() ]
-

--- a/test/test_sharding.py
+++ b/test/test_sharding.py
@@ -69,12 +69,15 @@ def test_compressed_morton_code():
     assert False
   except ValueError:
     pass
-  assert cmc((1,2,0)) == 0b001001
+  assert cmc((1,2,0)) == 0b000101
 
-  assert np.array_equal(cmc([(0,0,0), (1,2,0)]), [0b000000, 0b001001])
+  assert np.array_equal(cmc([(0,0,0), (1,2,0)]), [0b000000, 0b000101])
 
   cmc = lambda coord: compressed_morton_code(coord, grid_size=(4,4,1))
   assert cmc((3,3,0)) == 0b1111
+
+  cmc = lambda coord: compressed_morton_code(coord, grid_size=(8,8,2))
+  assert cmc((5,5,0)) == 0b1100011
 
 def test_image_sharding_hash():
   spec = ShardingSpecification(
@@ -265,5 +268,3 @@ def test_write_image_shard():
     assert False
   except exceptions.AlignmentError:
     pass
-
-


### PR DESCRIPTION
For grid dimensions that are a power of 2, the code was attributing an extra bit.  Fixing that also seems to fix the prior problem of size=1 dimensions (a power of 2!) naturally, without the extra check.

I added a test for the case I recently hit, where the morton code was out of range (195, where the #chunks was 128).  In addition, a prior test was incorrect and updated.