### PR TITLE
fix: raise errors from cloud files download

### DIFF
--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -293,6 +293,9 @@ def download_chunk(
   (file,) = CloudFiles(cloudpath, secrets=secrets).get([ filename ], raw=True)
   content = file['content']
 
+  if file['error']:
+    raise file['error']
+
   if enable_cache:
     cache_content = next(compression.transcode(file, compress_cache))['content'] 
     CloudFiles('file://' + cache.path).put(


### PR DESCRIPTION
rx was not checking the cloud files error.

This raise is not behind a retry, so it should kill the process.