### PR TITLE
feat: cache graphene manifests

### DIFF
--- a/cloudvolume/cacheservice.py
+++ b/cloudvolume/cacheservice.py
@@ -509,6 +509,10 @@ class CacheService(object):
     kwargs['progress'] = False
     return self.put([ (path, content) ], *args, **kwargs)
 
+  def put_json(self, path, content, *args, **kwargs):
+    content = jsonify(content).encode("utf8")
+    return self.put_single(path, content, *args, *kwargs)
+
   def put(self, files, progress=None, compress=None, compress_level=None):
     """files: [ (filename, content) ]"""
     if progress is None:


### PR DESCRIPTION
Some options exclude caching.

Resolves #493 

Note that sharded meshes are not cached yet, though their manifests are.