### PR TITLE
Revert delay of creation of metadata when using dask

### DIFF
--- a/cloudvolume/dask.py
+++ b/cloudvolume/dask.py
@@ -63,7 +63,6 @@ def to_cloudvolume(arr,
   -------
   See notes on `compute` and `return_stored` parameters.
   """
-  import dask
   import dask.array as da
   if not da.core._check_regular_chunks(arr.chunks):
     raise ValueError('Attempt to save array to cloudvolume with irregular '
@@ -95,12 +94,7 @@ def to_cloudvolume(arr,
                                      arr.shape[:3],
                                      chunk_size=chunk_size,
                                      max_mip=max_mip)
-
-  # Delay writing any metadata until computation time.
-  #   - the caller may never do the full computation
-  #   - the filesystem may be slow, and there is a desire to open files
-  #     in parallel on worker machines.
-  vol = dask.delayed(_create_cloudvolume)(cloudpath, info, **kwargs)
+  vol = _create_cloudvolume(cloudpath, info, **kwargs)
   return arr.store(vol, lock=False, compute=compute, return_stored=return_stored)
 
 

--- a/test/test_dask.py
+++ b/test/test_dask.py
@@ -10,32 +10,31 @@ from cloudvolume import dask as dasklib
 def test_roundtrip_3d():
   da = pytest.importorskip('dask.array')
   du = pytest.importorskip('dask.utils')
-  a = da.zeros((3, 3, 3), chunks=1)
+  a = da.random.randint(100, size=(3, 3, 3), chunks=1)
   with du.tmpdir() as d:
     d = 'file://' + d
     dasklib.to_cloudvolume(a, d)
     a2 = dasklib.from_cloudvolume(d)
-    a2 = da.squeeze(a2, axis=3)
-    da.utils.assert_eq(a, a2, check_meta=False)  # TODO: add meta check
-    assert a.chunks == a2.chunks
+    da.utils.assert_eq(a, a2[..., 0], check_meta=False)
+    assert a.chunks == a2.chunks[:-1]
 
 @pytest.mark.skipif(sys.version_info[0] < 3, reason="Python 2 not supported.")
 def test_roundtrip_4d():
   da = pytest.importorskip('dask.array')
   du = pytest.importorskip('dask.utils')
-  a = da.zeros((3, 3, 3, 3))
+  a = da.random.randint(100, size=(3, 3, 3, 3))
   with du.tmpdir() as d:
     d = 'file://' + d
     dasklib.to_cloudvolume(a, d)
     a2 = dasklib.from_cloudvolume(d)
-    da.utils.assert_eq(a, a2, check_meta=False)  # TODO: add meta check
+    da.utils.assert_eq(a, a2, check_type=False)
     assert a.chunks == a2.chunks
 
 @pytest.mark.skipif(sys.version_info[0] < 3, reason="Python 2 not supported.")
 def test_roundtrip_4d_channel_rechunked():
   da = pytest.importorskip('dask.array')
   du = pytest.importorskip('dask.utils')
-  a = da.zeros((3, 3, 3, 3), chunks=(2, 2, 2, 3))
+  a = da.random.randint(100, size=(3, 3, 3, 3), chunks=(2, 2, 2, 3))
   with du.tmpdir() as d:
     d = 'file://' + d
     dasklib.to_cloudvolume(a, d)
@@ -48,19 +47,19 @@ def test_roundtrip_4d_channel_rechunked():
 def test_roundtrip_4d_1channel():
   da = pytest.importorskip('dask.array')
   du = pytest.importorskip('dask.utils')
-  a = da.zeros((3, 3, 3, 1))
+  a = da.random.randint(100, size=(3, 3, 3, 1))
   with du.tmpdir() as d:
     d = 'file://' + d
     dasklib.to_cloudvolume(a, d)
     a2 = dasklib.from_cloudvolume(d)
-    da.utils.assert_eq(a, a2, check_meta=False)  # TODO: add meta check
+    da.utils.assert_eq(a, a2, check_type=False)
     assert a.chunks == a2.chunks
 
 @pytest.mark.skipif(sys.version_info[0] < 3, reason="Python 2 not supported.")
 def test_roundtrip_rechunk_3d():
   da = pytest.importorskip('dask.array')
   du = pytest.importorskip('dask.utils')
-  a = da.zeros((9, 9, 9), chunks=3)
+  a = da.random.randint(100, size=(9, 9, 9), chunks=3)
   with du.tmpdir() as d:
     d = 'file://' + d
     dasklib.to_cloudvolume(a, d)
@@ -71,7 +70,7 @@ def test_roundtrip_rechunk_3d():
 def test_roundtrip_rechunk_4d():
   da = pytest.importorskip('dask.array')
   du = pytest.importorskip('dask.utils')
-  a = da.zeros((9, 9, 9, 3), chunks=3)
+  a = da.random.randint(100, size=(9, 9, 9, 3), chunks=3)
   with du.tmpdir() as d:
     d = 'file://' + d
     dasklib.to_cloudvolume(a, d)
@@ -84,26 +83,26 @@ def test_delayed_compute():
   da = pytest.importorskip('dask.array')
   dd = pytest.importorskip('dask.delayed')
   du = pytest.importorskip('dask.utils')
-  a = da.zeros((3, 3, 3, 1), chunks=1)
+  a = da.random.randint(100, size=(3, 3, 3, 1), chunks=1)
   with du.tmpdir() as d:
     d = 'file://' + d
     out = dasklib.to_cloudvolume(a, d, compute=False)
     assert isinstance(out, dd.Delayed)
     dask.compute(out)
     a2 = dasklib.from_cloudvolume(d)
-    da.utils.assert_eq(a, a2, check_meta=False)  # TODO: add meta check
+    da.utils.assert_eq(a, a2, check_meta=False)
     assert a.chunks == a2.chunks
 
 @pytest.mark.skipif(sys.version_info[0] < 3, reason="Python 2 not supported.")
 def test_roundtrip_delayed():
   da = pytest.importorskip('dask.array')
   du = pytest.importorskip('dask.utils')
-  a = da.zeros((3, 3, 3, 3))
+  a = da.random.randint(100, size=(3, 3, 3, 3))
   with du.tmpdir() as d:
     cloudpath = 'file://' + d
     task = dasklib.to_cloudvolume(a, cloudpath, compute=False)
     assert not os.listdir(d)
     task.compute()
     a2 = dasklib.from_cloudvolume(cloudpath)
-    da.utils.assert_eq(a, a2, check_meta=False)  # TODO: add meta check
+    da.utils.assert_eq(a, a2, check_type=False)
     assert a.chunks == a2.chunks

--- a/test/test_dask.py
+++ b/test/test_dask.py
@@ -93,16 +93,3 @@ def test_delayed_compute():
     da.utils.assert_eq(a, a2, check_meta=False)
     assert a.chunks == a2.chunks
 
-@pytest.mark.skipif(sys.version_info[0] < 3, reason="Python 2 not supported.")
-def test_roundtrip_delayed():
-  da = pytest.importorskip('dask.array')
-  du = pytest.importorskip('dask.utils')
-  a = da.random.randint(100, size=(3, 3, 3, 3))
-  with du.tmpdir() as d:
-    cloudpath = 'file://' + d
-    task = dasklib.to_cloudvolume(a, cloudpath, compute=False)
-    assert not os.listdir(d)
-    task.compute()
-    a2 = dasklib.from_cloudvolume(cloudpath)
-    da.utils.assert_eq(a, a2, check_type=False)
-    assert a.chunks == a2.chunks


### PR DESCRIPTION
I originally made this change before I understood the dask ecosystem, and I was desiring to have many volumes'  created in parallel across many workers.

For other output formats (parquet, zarr, etc), the metadata is written at graph creation time, not delayed to run time.  So this change modifies the behavior to be consistent with the rest of the ecosystem.