### PR TITLE
fixing dynamic exists

### DIFF
--- a/cloudvolume/datasource/graphene/mesh/sharded.py
+++ b/cloudvolume/datasource/graphene/mesh/sharded.py
@@ -61,7 +61,7 @@ class GrapheneShardedMeshSource(GrapheneUnshardedMeshSource):
 
     output = {}
     for filepath, exists in results.items():
-      label = int(os.path.basename(filepath)[:-2]) # strip :0
+      label = int(os.path.basename(filepath).split(':')[0]) # strip :0
       output[label] = filepath if exists else None
 
     return output


### PR DESCRIPTION
this function wasn't working for the PCG, as the mesh fragments had multiple : in them, the label is the one before the first :