### PR TITLE
make contain more accurate for boundary points

### DIFF
--- a/cloudvolume/lib.py
+++ b/cloudvolume/lib.py
@@ -476,15 +476,9 @@ class Bbox(object):
       ]
     """
     arr = np.array(arr, dtype=np.float32)
-
-    mins = []
-    maxes = []
-
-    for i in range(arr.shape[1]):
-      mins.append( np.min(arr[:,i]) )
-      # Note that the right side should be exclusive
-      # following the python indexing scheme
-      maxes.append( np.max(arr[:,i]) + 1)
+    
+    mins = np.min(arr, axis=0)
+    maxes = np.max(arr, axis=0) + 1
 
     return Bbox( mins, maxes, dtype=np.int64)
 

--- a/cloudvolume/lib.py
+++ b/cloudvolume/lib.py
@@ -482,7 +482,9 @@ class Bbox(object):
 
     for i in range(arr.shape[1]):
       mins.append( np.min(arr[:,i]) )
-      maxes.append( np.max(arr[:,i]) )
+      # Note that the right side should be exclusive
+      # following the python indexing scheme
+      maxes.append( np.max(arr[:,i]) + 1)
 
     return Bbox( mins, maxes, dtype=np.int64)
 

--- a/cloudvolume/lib.py
+++ b/cloudvolume/lib.py
@@ -761,7 +761,7 @@ class Bbox(object):
 
     Returns: boolean
     """
-    return np.all(point >= self.minpt) and np.all(point <= self.maxpt)
+    return np.all(point >= self.minpt) and np.all(point < self.maxpt)
 
   def contains_bbox(self, bbox):
     return self.contains(bbox.minpt) and self.contains(bbox.maxpt)


### PR DESCRIPTION
following the convention of python indexing, the `maxpt` should not be inclusive?
according to the measurement of `size` or `length`, it seems that this is true.
if so, the point should not be contained if it is on the coordinate of `maxpt`?