### PR TITLE
fix: adjustments to get multires meshes displaying correctly

### DIFF
--- a/cloudvolume/datasource/precomputed/mesh/multilod.py
+++ b/cloudvolume/datasource/precomputed/mesh/multilod.py
@@ -241,10 +241,12 @@ class ShardedMultiLevelPrecomputedMeshSource(UnshardedLegacyPrecomputedMeshSourc
       ]
       total_fragment_size = np.sum(fragment_sizes)
       full_path = self.reader.meta.join(self.reader.meta.cloudpath)
+
+      manifest_byte_start = (manifest.shard_offset - total_fragment_size) + np.sum(fragment_sizes[0:lod])
       lod_binary = CloudFiles(full_path, progress=progress, secrets=self.config.secrets).get({
         'path': manifest.path,
-        'start': (manifest.shard_offset - total_fragment_size) + np.sum(fragment_sizes[0:lod]),
-        'end': (manifest.shard_offset - total_fragment_size) + np.sum(fragment_sizes[0:lod+1]),  
+        'start': int(manifest_byte_start),
+        'end': int(manifest_byte_start + fragment_sizes[lod]),
       })
 
       meshes = extract_lod_meshes(


### PR DESCRIPTION
Hi @SridharJagannathan I was working on implementing multi-res meshes in Igneous. I haven't gotten as far as you or David on producing actual different resolutions, but I did manage to get a single resolution to display. In order to do so, I had to make two changes to CloudVolume that alter the `data_offset` you added to the sharding handler. The changes work, and they seem to conform to the spec, but I wanted to make sure I am not breaking something that is working for you with these changes.

In the Neuroglancer spec, it says that the manifest should be located after the mesh data and implies that the manifest should be the first element accessed. I changed the minishard_index so that the offset points to the beginning of the manifest and the size is the manifest size. 

https://github.com/google/neuroglancer/blob/056a3548abffc3c76c93c7a906f1603ce02b5fa3/src/neuroglancer/datasource/precomputed/meshes.md#sharded-storage-of-multi-resolution-mesh-fragment-data

> If the sharded format is used, the mesh fragment data file is located immediately before the 
> manifest file in the same shard data file. The starting offset within that shard data file is not
> specified explicitly but may be computed from the starting offset of the manifest file and 
> the sum of the mesh fragment sizes specified in the manifest.


I also changed the code that was inactivated in order to make sure the offsets cumulative accounted for the presence of other minishards. 

Let me know if you have any feedback!




