### PR TITLE
feat: add cv.unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ vol = CloudVolume('gs://bucket/dataset/channel', mip=[ 8, 8, 40 ], bounded=True,
 vol = CloudVolume('gs://bucket/datasset/channel', info=info) # New info file from scratch
 image = vol[:,:,:] # Download the entire image stack into a numpy array
 image = vol.download(bbox, mip=2, renumber=True) # download w/ smaller dtype
+uniq = vol.unique(bbox, mip=0) # efficient extraction of unique labels
 listing = vol.exists( np.s_[0:64, 0:128, 0:64] ) # get a report on which chunks actually exist
 exists = vol.image.has_data(mip=0) # boolean check to see if any data is there
 listing = vol.delete( np.s_[0:64, 0:128, 0:64] ) # delete this region (bbox must be chunk aligned)

--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -18,7 +18,7 @@ from tqdm import tqdm
 from cloudfiles import CloudFiles, compression
 
 from cloudvolume import lib, exceptions
-from ....lib import Bbox, Vec, sip, first
+from ....lib import Bbox, Vec, sip, first, BboxLikeType
 from .... import sharedmemory, chunks
 
 from ... import autocropfn, readonlyguard, ImageSourceInterface
@@ -177,7 +177,8 @@ class PrecomputedImageSource(ImageSourceInterface):
         background_color=int(self.background_color),
       )
 
-  def unique(self, bbox, mip):
+  def unique(self, bbox:BboxLikeType, mip:int) -> set:
+    """Extract unique values in an efficient way."""
     bbox = Bbox.create(bbox, context=self.meta.bounds(mip))
     
     if self.autocrop:

--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -186,20 +186,29 @@ class PrecomputedImageSource(ImageSourceInterface):
     self.check_bounded(bbox, mip)
 
     if self.is_sharded(mip):
-      raise NotImplementedError("Shards are not yet supported.")
-
-    return rx.unique_unsharded(
-      bbox, mip, 
-      meta=self.meta,
-      cache=self.cache,
-      parallel=1,
-      fill_missing=self.fill_missing,
-      progress=self.config.progress,
-      compress=self.config.compress,
-      green=self.config.green,
-      secrets=self.config.secrets,
-      background_color=int(self.background_color),
-    )
+      scale = self.meta.scale(mip)
+      spec = sharding.ShardingSpecification.from_dict(scale['sharding'])
+      return rx.unique_sharded(
+        bbox, mip, 
+        self.meta, self.cache, spec,
+        compress=self.config.compress,
+        progress=self.config.progress,
+        fill_missing=self.fill_missing,
+        background_color=int(self.background_color),
+      )
+    else:
+      return rx.unique_unsharded(
+        bbox, mip, 
+        meta=self.meta,
+        cache=self.cache,
+        parallel=1,
+        fill_missing=self.fill_missing,
+        progress=self.config.progress,
+        compress=self.config.compress,
+        green=self.config.green,
+        secrets=self.config.secrets,
+        background_color=int(self.background_color),
+      )
 
   @readonlyguard
   def upload(

--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -177,7 +177,9 @@ class PrecomputedImageSource(ImageSourceInterface):
         background_color=int(self.background_color),
       )
 
-  def unique(self, bbox, mip=None):
+  def unique(self, bbox, mip):
+    bbox = Bbox.create(bbox, context=self.meta.bounds(mip))
+    
     if self.autocrop:
       bbox = Bbox.intersection(bbox, self.meta.bounds(mip))
 

--- a/cloudvolume/datasource/precomputed/image/common.py
+++ b/cloudvolume/datasource/precomputed/image/common.py
@@ -171,6 +171,9 @@ def gridpoints(bbox, volume_bbox, chunk_size):
     yield Vec(x,y,z)
 
 def compressed_morton_code(gridpt, grid_size):
+  if gridpt == []:
+    return np.zeros((0,), dtype=np.uint32)
+
   gridpt = np.asarray(gridpt, dtype=np.uint32)
   single_input = False
   if gridpt.ndim == 1:

--- a/cloudvolume/frontends/graphene.py
+++ b/cloudvolume/frontends/graphene.py
@@ -1,3 +1,5 @@
+from typing import Optional, List, Any
+
 from collections import defaultdict
 from datetime import datetime
 import math
@@ -16,7 +18,7 @@ import numpy as np
 from .. import compression
 from .. import exceptions
 from ..cacheservice import CacheService
-from ..lib import Bbox, Vec, toiter
+from ..lib import Bbox, Vec, toiter, BboxLikeType
 from ..storage import SimpleStorage, Storage, reset_connection_pools
 from ..volumecutout import VolumeCutout
 from ..datasource.graphene.metadata import GrapheneApiVersion
@@ -118,6 +120,71 @@ class CloudVolumeGraphene(CloudVolumePrecomputed):
       parallel = self.parallel
 
     return self.download(bbox, mip, parallel=parallel, **kwargs)
+
+  def unique(
+    self, 
+    bbox:BboxLikeType, 
+    mip:Optional[int] = None, 
+    segids:Optional[List[int]] = None,
+    preserve_zeros:bool = False,
+    agglomerate:Optional[bool] = None, 
+    timestamp:Optional[int] = None,
+    stop_layer:Optional[int] = None,
+  ) -> set:
+    agglomerate = agglomerate if agglomerate is not None else self.agglomerate
+    
+    bbox = Bbox.create(
+      bbox, context=self.bounds, 
+      bounded=self.bounded, 
+      autocrop=self.autocrop
+    )
+  
+    if bbox.subvoxel():
+      raise exceptions.EmptyRequestException("Requested {} is smaller than a voxel.".format(bbox))
+
+    if (agglomerate and stop_layer is not None) and (stop_layer <= 0 or stop_layer > self.meta.n_layers):
+      raise ValueError("Stop layer {} must be 1 <= stop_layer <= {} or None.".format(stop_layer, self.meta.n_layers))
+
+    if mip is None:
+      mip = self.mip
+
+    mip0_bbox = self.bbox_to_mip(bbox, mip=mip, to_mip=0)
+    # Only ever necessary to make requests within the bounding box
+    # to the server. We can fill black in other situations.
+    mip0_bbox = bbox.intersection(self.meta.bounds(0), mip0_bbox)
+
+    labels = super(CloudVolumeGraphene, self).unique(bbox, mip=mip)
+
+    if agglomerate:
+      return set(self.get_roots(
+        list(labels), 
+        timestamp=timestamp, 
+        binary=True, 
+        stop_layer=stop_layer
+      ))
+
+    labels = set(labels)
+
+    for segid in segids:
+      leaves = set(self.get_leaves(segid, mip0_bbox, 0))
+      if labels.isdisjoint(leaves):
+        continue
+      labels -= leaves
+      labels.add(segid)
+
+    mask_value = 0
+    if preserve_zeros:
+      mask_value = np.inf
+      if np.issubdtype(self.dtype, np.integer):
+        mask_value = np.iinfo(self.dtype).max
+
+      segids.append(0)
+
+    segids = set(segids)
+    final_labels = set([ label for label in labels if label in segids ])
+    if len(final_labels) < len(labels):
+      final_labels.add(mask_value)
+    return final_labels
 
   def download(
     self, bbox, mip=None, 

--- a/cloudvolume/frontends/graphene.py
+++ b/cloudvolume/frontends/graphene.py
@@ -143,7 +143,10 @@ class CloudVolumeGraphene(CloudVolumePrecomputed):
       raise exceptions.EmptyRequestException("Requested {} is smaller than a voxel.".format(bbox))
 
     if (agglomerate and stop_layer is not None) and (stop_layer <= 0 or stop_layer > self.meta.n_layers):
-      raise ValueError("Stop layer {} must be 1 <= stop_layer <= {} or None.".format(stop_layer, self.meta.n_layers))
+      raise ValueError(
+        f"Stop layer {stop_layer} must be "
+        f"1 <= stop_layer <= {self.meta.n_layers} or None."
+      )
 
     if mip is None:
       mip = self.mip

--- a/cloudvolume/frontends/graphene.py
+++ b/cloudvolume/frontends/graphene.py
@@ -153,7 +153,7 @@ class CloudVolumeGraphene(CloudVolumePrecomputed):
     # to the server. We can fill black in other situations.
     mip0_bbox = bbox.intersection(self.meta.bounds(0), mip0_bbox)
 
-    labels = super(CloudVolumeGraphene, self).unique(bbox, mip=mip)
+    labels = super().unique(bbox, mip=mip)
 
     if agglomerate:
       return set(self.get_roots(
@@ -366,7 +366,7 @@ class CloudVolumeGraphene(CloudVolumePrecomputed):
       layer_id = self.meta.decode_layer_id(segid)
       if layer_id in (stop_layer, self.meta.n_layers):
         base_remap[segid] = segid
-    
+
     segids = np.array(
       [ segid for segid in segids if segid not in base_remap ], 
       dtype=self.meta.dtype

--- a/cloudvolume/frontends/graphene.py
+++ b/cloudvolume/frontends/graphene.py
@@ -363,9 +363,10 @@ class CloudVolumeGraphene(CloudVolumePrecomputed):
     base_remap = { 0: 0 }
     # skip ids that are already root IDs
     for segid in segids:
-      if self.meta.decode_layer_id(segid) == self.meta.n_layers:
+      layer_id = self.meta.decode_layer_id(segid)
+      if layer_id in (stop_layer, self.meta.n_layers):
         base_remap[segid] = segid
-
+    
     segids = np.array(
       [ segid for segid in segids if segid not in base_remap ], 
       dtype=self.meta.dtype

--- a/cloudvolume/frontends/precomputed.py
+++ b/cloudvolume/frontends/precomputed.py
@@ -529,7 +529,7 @@ class CloudVolumePrecomputed(object):
     return img[::steps.x, ::steps.y, ::steps.z, channel_slice]
 
   def unique(
-    self, bbox, mip=None, parallel=None,
+    self, bbox, mip=None,
     # Absorbing polymorphic Graphene calls
     agglomerate=None, timestamp=None, stop_layer=None,
   ):
@@ -547,11 +547,8 @@ class CloudVolumePrecomputed(object):
     if mip is None:
       mip = self.mip
 
-    if parallel is None:
-      parallel = self.parallel
-
     return self.image.unique(
-      bbox.astype(np.int64), mip#, parallel=parallel,
+      bbox.astype(np.int64), mip
     )
 
   def download(

--- a/cloudvolume/frontends/precomputed.py
+++ b/cloudvolume/frontends/precomputed.py
@@ -528,6 +528,32 @@ class CloudVolumePrecomputed(object):
     img = self.download(requested_bbox, self.mip)
     return img[::steps.x, ::steps.y, ::steps.z, channel_slice]
 
+  def unique(
+    self, bbox, mip=None, parallel=None,
+    # Absorbing polymorphic Graphene calls
+    agglomerate=None, timestamp=None, stop_layer=None,
+  ):
+    """
+    Downloads segmentation and extracts unique
+    labels from it without rendering a full image.
+    Faster and saves memory.
+    """
+    bbox = Bbox.create(
+      bbox, context=self.bounds, 
+      bounded=self.bounded, 
+      autocrop=self.autocrop
+    )
+
+    if mip is None:
+      mip = self.mip
+
+    if parallel is None:
+      parallel = self.parallel
+
+    return self.image.unique(
+      bbox.astype(np.int64), mip#, parallel=parallel,
+    )
+
   def download(
       self, bbox, mip=None, parallel=None,
       segids=None, preserve_zeros=False,

--- a/cloudvolume/lib.py
+++ b/cloudvolume/lib.py
@@ -1,4 +1,4 @@
-from typing import Union, cast
+from typing import Union, Sequence, List, cast
 import decimal
 from functools import reduce
 import json
@@ -876,6 +876,8 @@ class Bbox(object):
 
   def __repr__(self):
     return f"Bbox({list(self.minpt)},{list(self.maxpt)}, dtype={self.dtype})"
+
+BboxLikeType = Union[Bbox, Sequence[slice], str, Vec]
 
 def save_images(
   image, directory=None, axis='z', 

--- a/cloudvolume/scheduler.py
+++ b/cloudvolume/scheduler.py
@@ -86,7 +86,7 @@ def schedule_jobs(
   all complete. 
 
   fns: iterable of functions
-  concurrency: number of threads
+  concurrency: number of threads (0: no threads)
   progress: Falsey (no progress), String: Progress + description
   total: If fns is a generator, this is the number of items to be generated.
   green: If True, use green threads.
@@ -96,7 +96,7 @@ def schedule_jobs(
   if concurrency < 0:
     raise ValueError("concurrency value cannot be negative: {}".format(concurrency))
   elif concurrency == 0:
-    return [ fn() for fn in tqdm(fns, disable=(not progress), desc=progress) ]
+    return [ fn() for fn in tqdm(fns, disable=(not progress), desc=progress, total=total) ]
 
   if green:
     return schedule_green_jobs(fns, concurrency, progress, total)

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -343,6 +343,22 @@ def test_non_aligned_read():
   assert data[19:74:2, 15:190:3, 11:21,:].shape == (28,59,10,1) 
   assert np.all(cv[22:77:2, 22:197:3, 22:32] == data[19:74:2, 15:190:3, 11:21,:])
 
+@pytest.mark.parametrize("encoding", [ "raw", "compressed_segmentation", "compresso" ])
+def test_unique(encoding):
+  delete_layer()
+  cv, data = create_layer(size=(128,128,50,1), offset=(0,0,0), encoding=encoding, dtype=np.uint32)
+
+  uniq = cv.unique(cv.bounds)
+  uniq = np.array(list(uniq))
+  uniq.sort()
+  assert np.all(uniq == np.unique(data))
+
+  slc = np.s_[10:40,50:90,:50]
+  uniq = cv.unique(slc)
+  uniq = np.array(list(uniq))
+  uniq.sort()
+  assert np.all(uniq == np.unique(data[slc]))
+
 def test_autocropped_read():
   delete_layer()
   cv, data = create_layer(size=(50,50,50,1), offset=(0,0,0))


### PR DESCRIPTION
`cv.unique` allows you to query arbitrarily large bounding boxes and extracts the unique labels in an online fashion to avoid excessive memory consumption. 

I also exploit the cseg and compresso formats so that the extraction can occur after only the first stage of decompression for additional speed.