### PR TITLE
feat: cv.image.download_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ vol[cfg.x: cfg.x + cfg.length, cfg.y:cfg.y + cfg.length, cfg.z: cfg.z + cfg.leng
 
 ### Examples
 
-```python3
+```python
 # Basic Examples
 vol = CloudVolume('gs://mybucket/retina/image')
 vol = CloudVolume('gs://mybucket/retina/image', secrets=token, dict or json)
@@ -264,6 +264,8 @@ exists = vol.image.has_data(mip=0) # boolean check to see if any data is there
 listing = vol.delete( np.s_[0:64, 0:128, 0:64] ) # delete this region (bbox must be chunk aligned)
 vol[64:128, 64:128, 64:128] = image # Write a 64^3 image to the volume
 img = vol.download_point( (x,y,z), size=256, mip=3 ) # download region around (mip 0) x,y,z at mip 3
+# download image files without decompressing or rendering them. Good for caching!
+files = vol.download_files(bbox, mip, decompress=False) 
 
 # Server
 vol.viewer() # launches neuroglancer compatible web server on http://localhost:1337

--- a/cloudvolume/chunks.py
+++ b/cloudvolume/chunks.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Optional, Sequence
+from typing import Any, Optional, Sequence, Dict
 
 import zlib
 import io

--- a/cloudvolume/chunks.py
+++ b/cloudvolume/chunks.py
@@ -253,9 +253,9 @@ def decode_compressed_segmentation_pure_python(bytestring, shape, dtype, block_s
   return chunk.T
 
 def labels(
-  filedata, encoding, 
+  filedata:bytes, encoding:str, 
   shape=None, dtype=None, 
-  block_size=None, background_color=0
+  block_size=None, background_color:int = 0
 ) -> np.ndarray:
   """
   Extract unique labels from a chunk using
@@ -278,6 +278,27 @@ def labels(
     return compresso.labels(filedata)
   else:
     raise NotImplementedError(f"Encoding {encoding} is not supported. Try: raw, compressed_segmentation, or compresso.")
+
+def remap(
+  filedata:bytes, encoding:str, 
+  mapping:Dict[int,int],
+  preserve_missing_labels=False,
+  shape=None, dtype=None,
+  block_size=None
+) -> bytes:
+  if filedata is None or len(filedata) == 0:
+    return filedata
+  elif encoding == "compressed_segmentation":
+    return cseg.remap(
+      filedata, shape, dtype, mapping, 
+      preserve_missing_labels=preserve_missing_labels, block_size=block_size
+    )
+  elif encoding == "compresso":
+    return compresso.remap(filedata, mapping, preserve_missing_labels=preserve_missing_labels)
+  else:
+    img = decode(filedata, encoding, shape, dtype, block_size)
+    fastremap.remap(img, mapping, preserve_missing_labels=preserve_missing_labels, in_place=True)
+    return encode(img, encoding, block_size)
 
 def read_voxel(
   xyz:Sequence[int], 

--- a/cloudvolume/datasource/precomputed/common.py
+++ b/cloudvolume/datasource/precomputed/common.py
@@ -1,7 +1,7 @@
 def content_type(encoding):
   if encoding == 'jpeg':
     return 'image/jpeg'
-  elif encoding in ('compressed_segmentation', 'fpzip', 'kempressed'):
+  elif encoding in ('compresso', 'compressed_segmentation', 'fpzip', 'kempressed'):
     return 'image/x.' + encoding 
   return 'application/octet-stream'
 

--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -149,7 +149,7 @@ class PrecomputedImageSource(ImageSourceInterface):
 
     if self.is_sharded(mip):
       if renumber:
-        raise ValueError("renumber is only supported for non-shared volumes.")
+        raise ValueError("renumber is only supported for non-sharded volumes.")
 
       scale = self.meta.scale(mip)
       spec = sharding.ShardingSpecification.from_dict(scale['sharding'])
@@ -181,6 +181,51 @@ class PrecomputedImageSource(ImageSourceInterface):
         secrets=self.config.secrets,
         renumber=renumber,
         background_color=int(self.background_color),
+      )
+
+  def download_files(
+    self, bbox:Bbox, mip:int, 
+    decompress:bool = True, 
+    parallel:int = 1
+  ):
+    """
+    Download the files that comprise a cutout image from the dataset
+    without rendering them into an image. 
+
+    bbox: a Bbox object describing what region to download
+    mip: which resolution to fetch, 0 is the highest resolution
+    parallel: how many processes to use for downloading 
+
+    Returns: 
+      If sharded:
+        { morton_code: binary }
+      else:
+        { path: binary }
+    """
+    if self.autocrop:
+      bbox = Bbox.intersection(bbox, self.meta.bounds(mip))
+
+    self.check_bounded(bbox, mip)
+
+    if self.is_sharded(mip):
+      scale = self.meta.scale(mip)
+      spec = sharding.ShardingSpecification.from_dict(scale['sharding'])
+      return rx.download_raw_sharded(
+        bbox, mip, 
+        self.meta, self.cache, spec,
+        decompress=decompress,
+        progress=self.config.progress,
+      )
+    else:
+      return rx.download_raw_unsharded(
+        bbox, mip,
+        meta=self.meta,
+        cache=self.cache,
+        decompress=decompress,
+        progress=self.config.progress,
+        parallel=parallel, 
+        green=self.config.green,
+        secrets=self.config.secrets,
       )
 
   def unique(self, bbox:BboxLikeType, mip:int) -> set:
@@ -445,7 +490,7 @@ class PrecomputedImageSource(ImageSourceInterface):
       for srcpaths in sip(cloudpaths, step):
         files = check(cfsrc.get(srcpaths, raw=True))
         cfdest.puts(
-          compression.transcode(files, encoding=compress, level=compress_level), 
+          compression.transcode(files, encoding=compress, level=compress_level, in_place=True), 
           compress=compress,
           content_type=tx.content_type(destvol),
           raw=True

--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -226,6 +226,9 @@ class PrecomputedImageSource(ImageSourceInterface):
         parallel=parallel, 
         green=self.config.green,
         secrets=self.config.secrets,
+        fill_missing=self.fill_missing,
+        compress_type=self.config.compress,
+        background_color=int(self.background_color),
       )
 
   def unique(self, bbox:BboxLikeType, mip:int) -> set:

--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -186,7 +186,8 @@ class PrecomputedImageSource(ImageSourceInterface):
   def download_files(
     self, bbox:Bbox, mip:int, 
     decompress:bool = True, 
-    parallel:int = 1
+    parallel:int = 1, 
+    cache_only:bool = False
   ):
     """
     Download the files that comprise a cutout image from the dataset
@@ -195,6 +196,8 @@ class PrecomputedImageSource(ImageSourceInterface):
     bbox: a Bbox object describing what region to download
     mip: which resolution to fetch, 0 is the highest resolution
     parallel: how many processes to use for downloading 
+    cache_only: write downloaded files to cache and discard
+      the result to save memory
 
     Returns: 
       If sharded:
@@ -229,6 +232,7 @@ class PrecomputedImageSource(ImageSourceInterface):
         fill_missing=self.fill_missing,
         compress_type=self.config.compress,
         background_color=int(self.background_color),
+        cache_only=cache_only,
       )
 
   def unique(self, bbox:BboxLikeType, mip:int) -> set:

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -139,7 +139,8 @@ def download_raw_unsharded(
   decompress, 
   progress, parallel, 
   secrets, green, fill_missing,
-  compress_type, background_color
+  compress_type, background_color,
+  cache_only
 ):
   """
   Download all the chunks without rendering.
@@ -160,6 +161,8 @@ def download_raw_unsharded(
   results = {}
   def store_result(binary, bbox):
     nonlocal results
+    if cache_only:
+      return
     key = meta.join(meta.key(mip), bbox.to_filename())
     results[key] = binary
 

--- a/cloudvolume/datasource/precomputed/sharding.py
+++ b/cloudvolume/datasource/precomputed/sharding.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from collections import namedtuple, defaultdict
 import copy
 import json
@@ -540,8 +542,9 @@ class ShardReader(object):
     return shattered
 
   def get_data(
-    self, label, path="", 
-    progress=None, parallel=1
+    self, label:int, path:str = "", 
+    progress:Optional[bool] = None, parallel:int = 1,
+    raw:bool = False
   ):
     """Fetches data from shards.
 
@@ -549,6 +552,7 @@ class ShardReader(object):
     path: subdirectory path
     progress: display progress bars
     parallel: (int >= 0) use multiple processes
+    raw: if true, don't decompress or decode stream
 
     Return: 
       if label is a scalar:
@@ -635,7 +639,7 @@ class ShardReader(object):
     del bundles
     del bundles_resp
 
-    if self.spec.data_encoding != 'raw':
+    if not raw and self.spec.data_encoding != 'raw':
       for filepath, binary in tqdm(binaries.items(), desc="Decompressing", disable=(not progress)):
         if binary is None:
           continue

--- a/cloudvolume/frontends/graphene.py
+++ b/cloudvolume/frontends/graphene.py
@@ -285,12 +285,22 @@ class CloudVolumeGraphene(CloudVolumePrecomputed):
 
     labels = set([])
     for file in files.values():
-      labels.update(chunks.labels(file))
+      labels.update(chunks.labels(
+        file, 
+        encoding=self.meta.encoding(mip),
+        shape=self.meta.chunk_size(mip),
+        dtype=self.meta.dtype,
+        block_size=self.meta.compressed_segmentation_block_size(mip),
+      ))
 
     def apply_mapping(mapping):
       for key in files:
         files[key] = chunks.remap(
-          files[key], self.meta.encoding(mip), 
+          files[key], 
+          encoding=self.meta.encoding(mip), 
+          shape=self.meta.chunk_size(mip),
+          dtype=self.meta.dtype,
+          block_size=self.meta.compressed_segmentation_block_size(mip),
           mapping=mapping,
           preserve_missing_labels=True,
         )

--- a/cloudvolume/frontends/graphene.py
+++ b/cloudvolume/frontends/graphene.py
@@ -249,6 +249,7 @@ class CloudVolumeGraphene(CloudVolumePrecomputed):
     agglomerate=None, timestamp=None,
     stop_layer=None,
     coord_resolution=None,
+    cache_only=False,
   ):
     agglomerate = agglomerate if agglomerate is not None else self.agglomerate
     
@@ -280,7 +281,8 @@ class CloudVolumeGraphene(CloudVolumePrecomputed):
 
     files = self.image.download_files(
       bbox, mip=mip, 
-      decompress=True, parallel=parallel
+      decompress=True, parallel=parallel,
+      cache_only=cache_only,
     )
 
     labels = set([])

--- a/cloudvolume/frontends/graphene.py
+++ b/cloudvolume/frontends/graphene.py
@@ -15,6 +15,7 @@ import dateutil.parser
 import fastremap
 import numpy as np
 
+from .. import chunks
 from .. import compression
 from .. import exceptions
 from ..cacheservice import CacheService
@@ -241,6 +242,84 @@ class CloudVolumeGraphene(CloudVolumePrecomputed):
     if len(final_labels) < len(labels):
       final_labels.add(mask_value)
     return final_labels
+
+  def download_files(
+    self, bbox, mip=None, 
+    parallel=None, 
+    agglomerate=None, timestamp=None,
+    stop_layer=None,
+    coord_resolution=None,
+  ):
+    agglomerate = agglomerate if agglomerate is not None else self.agglomerate
+    
+    bbox = Bbox.create(
+      bbox, context=self.bounds, 
+      bounded=(self.bounded and coord_resolution is None), 
+      autocrop=self.autocrop
+    )
+
+    if mip is None:
+      mip = self.mip
+
+    if coord_resolution is not None:
+      factor = self.meta.resolution(mip) / coord_resolution
+      bbox /= factor
+      if self.bounded and not self.meta.bounds(mip).contains_bbox(bbox):
+        raise exceptions.OutOfBoundsError(f"Computed {bbox} is not contained within bounds {self.meta.bounds(mip)}")
+
+    if bbox.subvoxel():
+      raise exceptions.EmptyRequestException(f"Requested {bbox} is smaller than a voxel.")
+
+    if (agglomerate and stop_layer is not None) and (stop_layer <= 0 or stop_layer > self.meta.n_layers):
+      raise ValueError("Stop layer {} must be 1 <= stop_layer <= {} or None.".format(stop_layer, self.meta.n_layers))
+
+    mip0_bbox = self.bbox_to_mip(bbox, mip=mip, to_mip=0)
+    # Only ever necessary to make requests within the bounding box
+    # to the server. We can fill black in other situations.
+    mip0_bbox = bbox.intersection(self.meta.bounds(0), mip0_bbox)
+
+    files = self.image.download_files(
+      bbox, mip=mip, 
+      decompress=True, parallel=parallel
+    )
+
+    labels = set([])
+    for file in files.items():
+      chunks.labels(file)
+
+    if agglomerate:
+      img = self.agglomerate_cutout(img, timestamp=timestamp, stop_layer=stop_layer)
+      img = VolumeCutout.from_volume(self.meta, mip, img, bbox)
+
+    if segids is None or agglomerate:
+      if renumber_return: 
+        return img, renumber_remap
+      return img
+
+    segids = list(toiter(segids))
+
+    remapping = {}
+    for segid in segids:
+      leaves = self.get_leaves(segid, mip0_bbox, 0)
+      remapping.update({ leaf: segid for leaf in leaves })
+    
+    # Issue #434: Do not write img = fastremap.FN(in_place=True) as this allows
+    # the underlying buffer to get garbage collected. Make sure to carefully
+    # manage the buffer's references when making any changes.
+    fastremap.remap(img, remapping, preserve_missing_labels=True, in_place=True)
+
+    mask_value = 0
+    if preserve_zeros:
+      mask_value = np.inf
+      if np.issubdtype(self.dtype, np.integer):
+        mask_value = np.iinfo(self.dtype).max
+
+      segids.append(0)
+
+    fastremap.mask_except(img, segids, in_place=True, value=mask_value)
+    if renumber_return:
+      return img, renumber_remap
+    return img
 
   def download(
     self, bbox, mip=None, 

--- a/cloudvolume/frontends/precomputed.py
+++ b/cloudvolume/frontends/precomputed.py
@@ -565,6 +565,48 @@ class CloudVolumePrecomputed(object):
       bbox.astype(np.int64), mip
     )
 
+  def download_files(
+    self,
+    bbox:BboxLikeType, 
+    mip:Optional[int] = None, 
+    parallel:Optional[int] = None,
+    segids:Optional[Sequence[int]] = None, 
+    
+    # Absorbing polymorphic Graphene calls
+    agglomerate:Optional[bool] = None, 
+    timestamp:Optional[int] = None, 
+    stop_layer:Optional[int] = None,
+
+    coord_resolution:Optional[Sequence[int]] = None,
+    cache_only:bool = False,
+    decompress:bool = True,
+  ):
+    """Downloads files without rendering to an image."""
+    bbox = Bbox.create(
+      bbox, context=self.bounds, 
+      bounded=(self.bounded and coord_resolution is None), 
+      autocrop=self.autocrop
+    )
+
+    if mip is None:
+      mip = self.mip
+
+    if coord_resolution is not None:
+      factor = self.meta.resolution(mip) / coord_resolution
+      bbox /= factor
+      if self.bounded and not self.meta.bounds(mip).contains_bbox(bbox):
+        raise exceptions.OutOfBoundsError(f"Computed {bbox} is not contained within bounds {self.meta.bounds(mip)}")
+
+    if parallel is None:
+      parallel = self.parallel
+
+    return self.image.download_files(
+      bbox.astype(np.int64), mip, 
+      parallel=parallel,
+      decompress=decompress, 
+      cache_only=cache_only
+    )
+    
   def download(
     self, 
     bbox:BboxLikeType, 

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -10,7 +10,7 @@ import sys
 
 from cloudvolume import exceptions
 from cloudvolume.exceptions import AlignmentError, ReadOnlyException
-from cloudvolume import CloudVolume, chunks
+from cloudvolume import CloudVolume, chunks, compression
 from cloudvolume.lib import Bbox, Vec, yellow, mkdir
 import cloudvolume.sharedmemory as shm
 from layer_harness import (
@@ -520,6 +520,26 @@ def test_download_upload_file(green):
 
   assert np.all(cv2[:] == cv[:])
   shutil.rmtree('/tmp/file/')
+
+def test_download_files():
+  delete_layer()
+  cv, img = create_layer(size=(50,50,50,1), offset=(0,0,0))
+
+  files = cv.download_files(cv.bounds)
+  assert list(files.keys()) == [ '1_1_1/0-50_0-50_0-50' ]
+
+  chunk = chunks.decode(files['1_1_1/0-50_0-50_0-50'], 'raw', shape=(50,50,50,1), dtype=img.dtype)
+  assert np.all(chunk == img)
+
+  files = cv.download_files(cv.bounds, decompress=False)
+  assert list(files.keys()) == [ '1_1_1/0-50_0-50_0-50' ]
+
+  chunk = files['1_1_1/0-50_0-50_0-50']
+  binary = chunks.encode(img, "raw")
+  assert chunk == binary
+
+  files = cv.download_files(cv.bounds, cache_only=True)
+  assert files == {}
 
 def test_numpy_memmap():
   delete_layer()


### PR DESCRIPTION
Download image files without rendering into a numpy array.

```
a_dict = cv.image.download_files(bbox, mip, decompress=True)
```

This could be useful for creating larger shard files in Igneous as it helps reduce memory pressure substantially.
