### PR TITLE
 unnecessary integer casting for floating  chunk size

### DIFF
--- a/cloudvolume/datasource/graphene/mesh/sharded.py
+++ b/cloudvolume/datasource/graphene/mesh/sharded.py
@@ -235,7 +235,7 @@ class GrapheneShardedMeshSource(GrapheneUnshardedMeshSource):
     chunk_aligned_masks = []
     for mesh in meshes:
       level = meta.decode_layer_id(mesh.segid)
-      chunk_size = (lvl_2_size_nm * (2 ** (level-2))).astype(np.int32)
+      chunk_size = lvl_2_size_nm * (2 ** (level-2))
       verts = mesh.vertices - offset
       # find all vertices that are exactly on chunk_size boundaries
       is_chunk_aligned = is_draco_chunk_aligned(


### PR DESCRIPTION
I discovered trying to work with a dataset with a floating point resolution that the draco mesh deduplication wasn't working correctly with graphene sharded.. i tracked the problem to this line, where casting the chunksize to integers caused the chunk boundary position prediction to accumulate error over many boundaries.... leading to incorrect detection of chunk boundaries and therefore improper stitching.  