### PR TITLE
Respect compression settings for skeleton uploads.

### DIFF
--- a/cloudvolume/datasource/precomputed/skeleton/unsharded.py
+++ b/cloudvolume/datasource/precomputed/skeleton/unsharded.py
@@ -108,13 +108,18 @@ class UnshardedPrecomputedSkeletonSource(object):
     
   @readonlyguard
   def upload(self, skeletons):
+
+    compress = self.config.compress 
+    if compress is None:
+      compress = True
+
     if type(skeletons) == Skeleton:
       skeletons = [ skeletons ]
 
     files = [ (self.meta.join(self.meta.skeleton_path, str(skel.id)), skel.to_precomputed()) for skel in skeletons ]
     self.cache.upload(
       files=files, 
-      compress='gzip', 
+      compress=compress, 
       cache_control=cdn_cache_control(self.config.cdn_cache)
     )
 


### PR DESCRIPTION
A quick fix to respect compression settings when uploading skeletons.

I do replicate this logic from `get()`:

```python
    compress = self.config.compress 
    if compress is None:
      compress = True
```

Is this logic encapsulated somewhere else in cloud-volume? It seems like it should probably not be replicated. (Perhaps this could be done by making config.compress a property?)