### PR TITLE
feat: add experimental zfpc codec to CloudVolume

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can find a collection of CloudVolume accessible and Neuroglancer viewable da
 
 - Multi-threaded, supports multi-process and green threads.
 - Memory optimized, supports shared memory.
-- Lossless connectomics relevant codecs ([`compressed_segmentation`](https://github.com/seung-lab/compressedseg), [`compresso`](https://github.com/seung-lab/compresso), [`fpzip`](https://github.com/seung-lab/fpzip/), [`png`](https://en.wikipedia.org/wiki/Portable_Network_Graphics), and [`brotli`](https://en.wikipedia.org/wiki/Brotli))
+- Lossless connectomics relevant codecs ([`compressed_segmentation`](https://github.com/seung-lab/compressedseg), [`compresso`](https://github.com/seung-lab/compresso), [`fpzip`](https://github.com/seung-lab/fpzip/), [`zfpc`](https://github.com/seung-lab/zfpc), [`png`](https://en.wikipedia.org/wiki/Portable_Network_Graphics), and [`brotli`](https://en.wikipedia.org/wiki/Brotli))
 - Understands image hierarchies & anisotropic pixel resolutions.
 - Accomodates downloading missing tiles (`fill_missing=True`).
 - Accomodates uploading compressed black tiles to erasure coded file systems (`delete_black_uploads=True`).
@@ -220,7 +220,7 @@ info = CloudVolume.create_new_info(
     num_channels    = 1,
     layer_type      = 'segmentation',
     data_type       = 'uint64', # Channel images might be 'uint8'
-    # raw, png, jpeg, compressed_segmentation, fpzip, kempressed, compresso
+    # raw, png, jpeg, compressed_segmentation, fpzip, kempressed, zfpc, compresso
     encoding        = 'raw', 
     resolution      = [4, 4, 40], # Voxel scaling, units are in nanometers
     voxel_offset    = [0, 0, 0], # x,y,z offset in voxels from the origin
@@ -243,9 +243,11 @@ vol[cfg.x: cfg.x + cfg.length, cfg.y:cfg.y + cfg.length, cfg.z: cfg.z + cfg.leng
 | compresso               | Segmentation               | Y        | Y           | Lossless high compression algorithm for connectomics segmentation.                       |
 | fpzip                   | Floating Point             | Y        | Y*           | Takes advantage of IEEE 754 structure + L1 Lorenzo predictor to get higher compression.  |
 | kempressed              | Anisotropic Z Floating Point | N**      | Y*           | Adds manipulations on top of fpzip to achieve higher compression.                        |
+| zfpc                    | Alignment Vector Fields    | N***     | N           | zfp stream container.                        |
 
 \* Not integrated into official Neuroglancer yet, but available [on a branch](https://github.com/william-silversmith/neuroglancer/tree/wms_fpzip).
 \*\* Lossless if your data can handle adding and then subtracting 2.
+\*\*\* Lossless by default, but you probably want to use the lossy mode.
 
 ### Examples
 
@@ -569,6 +571,7 @@ Python 2.7 is no longer supported by CloudVolume. Updated versions of `pip` will
 4. [compressed_segmentation](https://github.com/seung-lab/compressedseg): A Python Package wrapping the code for the compressed_segmentation format developed by Jeremy Maitin-Shepard and Stephen Plaza.
 5. [Kimimaro](https://github.com/seung-lab/kimimaro): High performance skeletonization of densely labeled 3D volumes.
 6. [compresso](https://github.com/seung-lab/compresso): High lossless compression of connectomics segmentation. Algorithm by and code derived from Matejek et al.
+7. [zfpc](https://github.com/seung-lab/zfpc): Optimized zfp multi-stream container for alignment vector fields (and similar floating point data).
 
 ## Acknowledgments
 

--- a/cloudvolume/chunks.py
+++ b/cloudvolume/chunks.py
@@ -21,7 +21,7 @@ import pyspng
 import simplejpeg
 import compresso
 import fastremap
-import pyzfp
+import zfpc
 
 from PIL import Image
 
@@ -50,13 +50,14 @@ except ImportError:
 SUPPORTED_ENCODINGS = (
   "raw", "kempressed", "fpzip",
   "compressed_segmentation", "compresso",
-  "jpeg", "png", "zfp"
+  "jpeg", "png", "zfpc"
 )
 
 def encode(
   img_chunk:np.ndarray, 
   encoding:str, 
-  block_size:Optional[Sequence[int]] = None
+  block_size:Optional[Sequence[int]] = None,
+  compression_params:dict = {},
 ) -> bytes:
   if encoding == "raw":
     return encode_raw(img_chunk)
@@ -65,10 +66,8 @@ def encode(
   elif encoding == "fpzip":
     img_chunk = np.asfortranarray(img_chunk)
     return fpzip.compress(img_chunk, order='F')
-  elif encoding == "zfp":
-    # arguments: tolerance, precision, rate, parallel
-    # will need to figure out how to integrate into CV
-    return pyfpz.compress(np.asfortranarray(img_chunk))
+  elif encoding == "zfpc":
+    return zfpc.compress(np.asfortranarray(img_chunk), **compression_params)
   elif encoding == "compressed_segmentation":
     return encode_compressed_segmentation(img_chunk, block_size=block_size)
   elif encoding == "compresso":
@@ -105,8 +104,8 @@ def decode(
     return decode_kempressed(filedata)
   elif encoding == "fpzip":
     return fpzip.decompress(filedata, order='F')
-  elif encoding == "zfp":
-    return pyfpz.decompress(filedata)
+  elif encoding == "zfpc":
+    return zfpc.decompress(filedata)
   elif encoding == "compressed_segmentation":
     return decode_compressed_segmentation(filedata, shape=shape, dtype=dtype, block_size=block_size)
   elif encoding == "compresso":
@@ -331,10 +330,4 @@ def read_voxel(
   else:
     img = decode(filedata, encoding, shape, dtype, block_size, background_color)
     return img[tuple(xyz)][:, np.newaxis, np.newaxis, np.newaxis]
-
-
-
-
-
-
 

--- a/cloudvolume/chunks.py
+++ b/cloudvolume/chunks.py
@@ -21,6 +21,7 @@ import pyspng
 import simplejpeg
 import compresso
 import fastremap
+import pyzfp
 
 from PIL import Image
 
@@ -49,7 +50,7 @@ except ImportError:
 SUPPORTED_ENCODINGS = (
   "raw", "kempressed", "fpzip",
   "compressed_segmentation", "compresso",
-  "jpeg", "png"
+  "jpeg", "png", "zfp"
 )
 
 def encode(
@@ -64,6 +65,10 @@ def encode(
   elif encoding == "fpzip":
     img_chunk = np.asfortranarray(img_chunk)
     return fpzip.compress(img_chunk, order='F')
+  elif encoding == "zfp":
+    # arguments: tolerance, precision, rate, parallel
+    # will need to figure out how to integrate into CV
+    return pyfpz.compress(np.asfortranarray(img_chunk))
   elif encoding == "compressed_segmentation":
     return encode_compressed_segmentation(img_chunk, block_size=block_size)
   elif encoding == "compresso":
@@ -100,6 +105,8 @@ def decode(
     return decode_kempressed(filedata)
   elif encoding == "fpzip":
     return fpzip.decompress(filedata, order='F')
+  elif encoding == "zfp":
+    return pyfpz.decompress(filedata)
   elif encoding == "compressed_segmentation":
     return decode_compressed_segmentation(filedata, shape=shape, dtype=dtype, block_size=block_size)
   elif encoding == "compresso":

--- a/cloudvolume/datasource/precomputed/common.py
+++ b/cloudvolume/datasource/precomputed/common.py
@@ -1,14 +1,14 @@
 def content_type(encoding):
   if encoding == 'jpeg':
     return 'image/jpeg'
-  elif encoding in ('compresso', 'compressed_segmentation', 'fpzip', 'kempressed'):
+  elif encoding in ('compresso', 'compressed_segmentation', 'fpzip', 'kempressed', 'zfpc'):
     return 'image/x.' + encoding 
   return 'application/octet-stream'
 
 def should_compress(encoding, compress, cache, iscache=False):
   if iscache and cache.compress != None:
     return cache.compress
-
+  
   if compress is None:
     return 'gzip' if encoding in ('raw', 'compressed_segmentation', 'compresso') else None
   elif compress == True:

--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -578,6 +578,7 @@ class PrecomputedImageSource(ImageSourceInterface):
       labels[morton_code] = chunks.encode(
         chunk, self.meta.encoding(mip),
         block_size=self.meta.compressed_segmentation_block_size(mip),
+        compression_params=self.meta.compression_params(mip),
       )
 
     shard_filename = reader.get_filename(first(labels.keys()))

--- a/cloudvolume/datasource/precomputed/image/tx.py
+++ b/cloudvolume/datasource/precomputed/image/tx.py
@@ -285,7 +285,11 @@ def threaded_upload_chunks(
   local = CloudFiles('file://' + cache.path, secrets=secrets)
 
   def do_upload(imgchunk, cloudpath):
-    encoded = chunks.encode(imgchunk, meta.encoding(mip), meta.compressed_segmentation_block_size(mip))
+    encoded = chunks.encode(
+      imgchunk, meta.encoding(mip), 
+      meta.compressed_segmentation_block_size(mip),
+      compression_params=meta.compression_params(mip),
+    )
 
     if lru is not None:
       lru[cloudpath] = encoded
@@ -294,7 +298,7 @@ def threaded_upload_chunks(
     cache_compress = should_compress(meta.encoding(mip), compress, cache, iscache=True)
     remote_compress = compression.normalize_encoding(remote_compress)
     cache_compress = compression.normalize_encoding(cache_compress)
-
+    
     encoded = compression.compress(encoded, remote_compress)
     cache_encoded = encoded
     if remote_compress != cache_compress:

--- a/cloudvolume/datasource/precomputed/metadata.py
+++ b/cloudvolume/datasource/precomputed/metadata.py
@@ -521,6 +521,31 @@ Hops:
 
     return encoding
 
+  def compression_params(self, mip):
+    encoding = self.encoding(mip)
+    if encoding == 'zfpc':
+      return self.zfpc_encoding_params(mip)
+    elif encoding == 'compressed_segmentation':
+      return { "block_size": self.compressed_segmentation_block_size(mip) }
+    else:
+      return {}
+
+  def zfpc_encoding_params(self, mip):
+    """
+    Returns tuning arguments for zfpc.compress.
+
+    Reads parameters from scale:
+    zfpc_rate, zfpc_precision, zfpc_tolerance, 
+    and zfpc_correlated_dims ([bool x 4])
+    """
+    scale = self.scale(mip)
+    return {
+      'rate': scale.get('zfpc_rate', -1),
+      'precision': scale.get('zfpc_precision', -1),
+      'tolerance': scale.get('zfpc_tolerance', -1),
+      'correlated_dims': scale.get('zfpc_correlated_dims', [True]*4),
+    }
+
   def compressed_segmentation_block_size(self, mip):
     if 'compressed_segmentation_block_size' in self.info['scales'][mip]:
       return self.info['scales'][mip]['compressed_segmentation_block_size']

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ compressed-segmentation>=2.1.1
 compresso>=3.0.0
 DracoPy>=1.0.0,<2.0.0
 fastremap>=1.12.0
-fpzip~=1.1.3
+fpzip>=1.2.0,<2.0.0
 gevent
 google-auth>=1.10.0
 google-cloud-core>=1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ six>=1.10.0
 tenacity>=4.10.0
 tqdm
 urllib3[secure,brotli]>=1.25.7
+zfpc

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -730,6 +730,37 @@ def test_write_compressed_segmentation():
   
   assert np.all(data == data2)
 
+def test_write_zfpc():
+  delete_layer()
+  cv, data = create_layer(
+    size=(128,64,64,1), offset=(0,0,0), 
+    layer_type="affinities", dtype=np.float32
+  )
+
+  # delete gzipped data (.gz) files
+  # which will take precedence over
+  # the non-gzipped zfpc files with 
+  # no extension
+  cv.delete(cv.bounds) 
+
+  cv.info['num_channels'] = 1
+  cv.info['data_type'] = 'float32'
+  cv.scale['encoding'] = 'zfpc'
+  cv.commit_info()
+
+  cv[:] = data.astype(np.float32)
+  data2 = cv[:]
+
+  assert np.all(data == data2)
+
+  cv.info['data_type'] = 'float64'
+  cv.commit_info()
+
+  cv[:] = data.astype(np.float64)
+  data2 = cv[:]
+  
+  assert np.all(data == data2)
+
 # def test_reader_negative_indexing():
 #     """negative indexing is supported"""
 #     delete_layer()


### PR DESCRIPTION
This PR adds experimental support for the experimental [zfpc](https://github.com/seung-lab/zfpc) zfp container format. i.e. `"encoding": "zfpc"` in the info file.

This will allow for maximum compression of zfpc streams and defines new fields for Precomputed info file scales:

`zfpc_rate`, `zfpc_precision`, `zfpc_tolerance`, `zfpc_correlated_dims`

You must specify one or none of rate, precision, and tolerance (tolerance and rate are probably going to be the most preferred). `zfpc_correlated_dims` is a list of 4 booleans, where true means that axis index's data is correlated with other true dimensions.

For definitions of rate, tolerance, and precision, consult zfp documentation: https://zfp.readthedocs.io/en/latest/modes.html

For more information on zfpc and the correlated_dims parameter, consult the zfpc page: https://github.com/seung-lab/zfpc  