### PR TITLE
Deprecation notice about urllib3[secure]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,5 @@ simplejpeg
 six>=1.10.0
 tenacity>=4.10.0
 tqdm
-urllib3[secure,brotli]>=1.25.7
+urllib3[brotli]>=1.25.7
 zfpc


### PR DESCRIPTION
### Description
pyOpenSSL and urllib3[secure] are deprecated in the upcoming release (1.26.12)
https://github.com/urllib3/urllib3/issues/2680
