### PR TITLE
perf(spatial_index): threaded, batched, and robust insert to mysql

### DIFF
--- a/cloudvolume/datasource/precomputed/spatial_index.py
+++ b/cloudvolume/datasource/precomputed/spatial_index.py
@@ -248,7 +248,7 @@ class SpatialIndex(object):
 
     finished_loading_evt = threading.Event()
     query_lock = threading.Lock()
-    
+
     qu = queue.Queue(maxsize=(2 * parallel + 1))
     threads = [ 
       threading.Thread(
@@ -503,7 +503,7 @@ class SpatialIndex(object):
     if self.sql_db and fast_path:
       conn = connect(self.sql_db)
       cur = conn.cursor()
-      cur.execute("select label from file_lookup")
+      cur.execute("select distinct label from file_lookup")
       while True:
         rows = cur.fetchmany(size=2**20)
         if len(rows) == 0:

--- a/cloudvolume/datasource/precomputed/spatial_index.py
+++ b/cloudvolume/datasource/precomputed/spatial_index.py
@@ -262,7 +262,6 @@ class SpatialIndex(object):
         t.start()
 
       for index_files in self.fetch_all_index_files(progress=progress, allow_missing=allow_missing):
-        print("put index files... qsize: ", qu.qsize())
         qu.put(index_files)
 
       finished_loading_evt.set()


### PR DESCRIPTION
Improves run time of inserts to mysql. Took 3h35m to upload 193M rows with these improvements. 

Note: Must use SSD not HDD for CloudSQL. 

sqlite will also benefit from these improvements.