### PR TITLE
Pass secrets in PrecomputedImageSource.upload

### DIFF
--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -324,6 +324,7 @@ class PrecomputedImageSource(ImageSourceInterface):
       delete_black_uploads=self.delete_black_uploads,
       background_color=self.background_color,
       non_aligned_writes=self.non_aligned_writes,
+      secrets=self.config.secrets,
       green=self.config.green,
       fill_missing=self.fill_missing, # applies only to unaligned writes
     )


### PR DESCRIPTION
Secrets were not being passed to `tx.upload` on precomputed volumes.

I hit this as part of an experiment use cloud-files for https uploads (which will be a different PR). I found that info files, etc, were being created but the actual image data uploads were missing credentials.