### PR TITLE
force level2 if bounding box

### DIFF
--- a/cloudvolume/datasource/graphene/mesh/unsharded.py
+++ b/cloudvolume/datasource/graphene/mesh/unsharded.py
@@ -131,8 +131,10 @@ class GrapheneUnshardedMeshSource(UnshardedLegacyPrecomputedMeshSource):
       an error.
     """
     import DracoPy
-
-    level = self.meta.meta.decode_layer_id(seg_id)
+    if bounding_box is not None:
+      level = 2
+    else:
+      level = self.meta.meta.decode_layer_id(seg_id)
     fragment_filenames = self.get_fragment_filenames(
       seg_id, level=level, bbox=bounding_box, bypass=bypass
     )


### PR DESCRIPTION
If a user is asking for a bounding box, then we need to force the server to use level 2 meshes, as the high level meshes will intersect with the bounding box and return a larger mesh than is desirable. 