### PR TITLE
feat: add warning for placeholder mips

### DIFF
--- a/cloudvolume/datasource/precomputed/metadata.py
+++ b/cloudvolume/datasource/precomputed/metadata.py
@@ -68,6 +68,10 @@ class PrecomputedMetadata(object):
     else:
       self.provenance = self._cast_provenance(provenance)
 
+  def check_for_placeholder_scale(self, mip:int):
+    key = self.key(mip).lower()
+    return 'placeholder' in key
+
   @classmethod
   def create_info(cls, 
     num_channels, layer_type, data_type, encoding, 

--- a/cloudvolume/frontends/precomputed.py
+++ b/cloudvolume/frontends/precomputed.py
@@ -19,7 +19,7 @@ from .. import lib
 from ..cacheservice import CacheService
 from .. import exceptions 
 from ..lib import ( 
-  colorize, red, mkdir, 
+  colorize, yellow, red, mkdir, 
   Vec, Bbox, jsonify, BboxLikeType,
 )
 
@@ -54,6 +54,10 @@ class CloudVolumePrecomputed(object):
     # its setter is based off of scales
     self.mip = mip
     self.pid = os.getpid()
+
+    is_placeholder = self.meta.check_for_placeholder_scale(self.mip)
+    if is_placeholder:
+      print(yellow("Warning: The currently selected mip level is marked as a placeholder and likely has no associated image data."))
 
   @property 
   def autocrop(self):


### PR DESCRIPTION
Prints a yellow warning in the terminal if the currently selected scale key contains the string 'placeholder'.