### PR TITLE
Make vol.transfer_to() compatible with fill_missing

### DIFF
--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -519,6 +519,10 @@ class PrecomputedImageSource(ImageSourceInterface):
     cfdest = CloudFiles(cloudpath)
 
     def check(files):
+      if self.fill_missing:
+        for file in files:
+          if file['content'] is None:
+            file['content'] = b''
       errors = [
         file for file in files if \
         (file['content'] is None or file['error'] is not None)


### PR DESCRIPTION
When I ran `create_transfer_tasks(fill_missing=True)` tasks, they still raised `EmptyFileException: ... were empty or had IO errors` in the `src_cv.image.transfer_to()` (line 420, tasks/image/image.py) . Thus, I added extra handling to "empty but no IO error" files in the `vol.transfer_to()` (precomputed/image/\_\_init\_\_.py).