### PR TITLE
feat+perf: use precomputed ROIs to improve performance on empty regions

### DIFF
--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -57,7 +57,7 @@ def download_sharded(
     dtype=meta.dtype, order=order
   )
 
-  if not meta.inside_roi(requested_bbox, mip):
+  if not meta.overlaps_roi(requested_bbox, mip):
     return renderbuffer
 
   chunk_size = meta.chunk_size(mip)
@@ -227,7 +227,7 @@ def download(
 
   dtype = np.uint16 if renumber else meta.dtype
 
-  if not meta.inside_roi(requested_bbox, mip):
+  if not meta.overlaps_roi(requested_bbox, mip):
     return np.full(
       shape=shape, fill_value=background_color,
       dtype=dtype, order=order

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -52,13 +52,19 @@ def download_sharded(
   shape = list(requested_bbox.size3()) + [ meta.num_channels ]
   compress_cache = should_compress(meta.encoding(mip), compress, cache, iscache=True)
 
+  renderbuffer = np.full(
+    shape=shape, fill_value=background_color,
+    dtype=meta.dtype, order=order
+  )
+
+  if not meta.inside_roi(requested_bbox):
+    return renderbuffer
+
   chunk_size = meta.chunk_size(mip)
   grid_size = np.ceil(meta.bounds(mip).size3() / chunk_size).astype(np.uint32)
 
   reader = sharding.ShardReader(meta, cache, spec)
   bounds = meta.bounds(mip)
-
-  renderbuffer = np.zeros(shape=shape, dtype=meta.dtype, order=order)
 
   gpts = list(gridpoints(full_bbox, bounds, chunk_size))
 
@@ -220,6 +226,12 @@ def download(
     raise ValueError("use_shared_memory and use_file are mutually exclusive arguments.")
 
   dtype = np.uint16 if renumber else meta.dtype
+
+  if not meta.inside_roi(requested_bbox):
+    return np.full(
+      shape=shape, fill_value=background_color,
+      dtype=dtype, order=order
+    )
 
   if requested_bbox.volume() == 1:
     return download_single_voxel_unsharded(

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -57,7 +57,7 @@ def download_sharded(
     dtype=meta.dtype, order=order
   )
 
-  if not meta.inside_roi(requested_bbox):
+  if not meta.inside_roi(requested_bbox, mip):
     return renderbuffer
 
   chunk_size = meta.chunk_size(mip)
@@ -227,7 +227,7 @@ def download(
 
   dtype = np.uint16 if renumber else meta.dtype
 
-  if not meta.inside_roi(requested_bbox):
+  if not meta.inside_roi(requested_bbox, mip):
     return np.full(
       shape=shape, fill_value=background_color,
       dtype=dtype, order=order

--- a/cloudvolume/datasource/precomputed/metadata.py
+++ b/cloudvolume/datasource/precomputed/metadata.py
@@ -189,9 +189,11 @@ class PrecomputedMetadata(object):
 
   def parse_rois(self, info) -> List[Bbox]:
     """Parse ROIs from the info file at mip 0."""
-    return [ 
+    bboxes = [ 
       Bbox.from_list(roi) for roi in info['scales'][0]["rois"] 
     ]
+    bboxes.sort(key=lambda bx: bx.minpt.z)
+    return bboxes
 
   def fetch_info(self):
     """

--- a/cloudvolume/datasource/precomputed/metadata.py
+++ b/cloudvolume/datasource/precomputed/metadata.py
@@ -678,15 +678,15 @@ Hops:
 
   def inside_roi(self, pt_or_bbox) -> bool:
     """Returns True if the point lies inside of the ROI including the boundary."""
-    if self.roi is None:
+    if self.rois is None:
       return True
 
     if isinstance(pt_or_bbox, Bbox):
-      for bbox in self.roi:
+      for bbox in self.rois:
         if bbox.contains_bbox(pt_or_bbox):
           return True
     else:
-      for bbox in self.roi:
+      for bbox in self.rois:
         if bbox.contains(pt_or_bbox):
           return True
 

--- a/cloudvolume/datasource/precomputed/metadata.py
+++ b/cloudvolume/datasource/precomputed/metadata.py
@@ -179,9 +179,7 @@ class PrecomputedMetadata(object):
         return self.info
 
     self.info = self.redirectable_fetch_info(max_redirects)
-
-    if 'rois' in self.scale(0):
-      self.rois = self.parse_rois(self.info)
+    self.rois = self.parse_rois(self.info)
 
     if self.cache:
       self.cache.maybe_cache_info()
@@ -189,8 +187,12 @@ class PrecomputedMetadata(object):
 
   def parse_rois(self, info) -> List[Bbox]:
     """Parse ROIs from the info file at mip 0."""
+    scale = info['scales'][0]
+    if 'rois' not in scale:
+      return None
+
     bboxes = [ 
-      Bbox.from_list(roi) for roi in info['scales'][0]["rois"] 
+      Bbox.from_list(roi) for roi in scale["rois"] 
     ]
     bboxes.sort(key=lambda bx: bx.minpt.z)
     return bboxes

--- a/cloudvolume/datasource/precomputed/metadata.py
+++ b/cloudvolume/datasource/precomputed/metadata.py
@@ -676,8 +676,8 @@ Hops:
 
     return bbox
 
-  def inside_roi(self, pt_or_bbox, mip = 0) -> bool:
-    """Returns True if the point lies inside of the ROI including the boundary."""
+  def overlaps_roi(self, pt_or_bbox, mip = 0) -> bool:
+    """Returns True if the point or bbox overlaps the ROI including the boundary."""
     if self.rois is None:
       return True      
 

--- a/cloudvolume/datasource/precomputed/metadata.py
+++ b/cloudvolume/datasource/precomputed/metadata.py
@@ -676,16 +676,22 @@ Hops:
 
     return bbox
 
-  def inside_roi(self, pt_or_bbox) -> bool:
+  def inside_roi(self, pt_or_bbox, mip = 0) -> bool:
     """Returns True if the point lies inside of the ROI including the boundary."""
     if self.rois is None:
-      return True
+      return True      
 
     if isinstance(pt_or_bbox, Bbox):
+      if mip > 0:
+        pt_or_bbox = self.bbox_to_mip(pt_or_bbox, mip, 0)
+
       for bbox in self.rois:
-        if bbox.contains_bbox(pt_or_bbox):
+        if bbox.overlaps_bbox(pt_or_bbox):
           return True
     else:
+      if mip > 0:
+        pt_or_bbox = self.point_to_mip(pt_or_bbox, mip, 0)
+
       for bbox in self.rois:
         if bbox.contains(pt_or_bbox):
           return True

--- a/cloudvolume/lib.py
+++ b/cloudvolume/lib.py
@@ -792,6 +792,12 @@ class Bbox(object):
       and self.contains(bbox.minpt) 
     )
 
+  def overlaps_bbox(self, bbox):
+    return not (
+      np.any(self.maxpt < bbox.minpt)
+      or np.any(self.minpt > bbox.maxpt)
+    )
+
   def clone(self):
     return Bbox(self.minpt, self.maxpt, dtype=self.dtype)
 


### PR DESCRIPTION
ROI format:

Added as key "rois" to the mip 0 scale in the info file.

List of lists of 6 integers [ xstart, ystart, zstart, xend, yend, zend ] specified in voxels at that scale.
