### PR TITLE
feat: add cache multi-processing locking feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,8 @@ CloudVolume(
     background_color:int=0, green_threads:bool=False, use_https:bool=False,
     max_redirects:int=10, mesh_dir:Optional[str]=None, skel_dir:Optional[str]=None, 
     agglomerate:bool=False, secrets:SecretsType=None, 
-    spatial_index_db:Optional[str]=None, lru_bytes:int = 0
+    spatial_index_db:Optional[str]=None, lru_bytes:int = 0,
+    cache_locking:bool = True
 )
 ```
 
@@ -448,7 +449,7 @@ CloudVolume(
 
           Note: This cache is totally separate from the LRU controlled by 
           lru_bytes.
-
+*      cache_locking: (bool) The local cache will use file locks via fasteners to prevent issues with multi-process cache access. If this is not a concern, performance can be slightly improved by setting this to False. This uses CloudFiles' locking mechanism.
 *      cdn_cache: (int, bool, or str) Sets Cache-Control HTTP header on uploaded 
         image files. Most cloud providers perform some kind of caching. As of 
         this writing, Google defaults to 3600 seconds. Most of the time you'll 

--- a/cloudvolume/cacheservice.py
+++ b/cloudvolume/cacheservice.py
@@ -94,8 +94,14 @@ class CacheService(object):
     else:
       return mip_size(self.config.mip)
 
+  def cloudfiles(self):
+    return CloudFiles(
+      'file://' + self.path, 
+      locking=self.config.cache_locking
+    )
+
   def has(self, filename):
-    return CloudFiles('file://' + self.path).exists(filename)
+    return self.cloudfiles().exists(filename)
     
   def list(self, mip=None):
     mip = self.config.mip if mip is None else mip
@@ -161,6 +167,8 @@ class CacheService(object):
     
     Return: void
     """
+    self.cloudfiles().clear_locks()
+
     if not os.path.exists(self.path):
       return
 
@@ -299,16 +307,15 @@ class CacheService(object):
       """.format(cached_prov.serialize(), fresh_prov.serialize()))
 
   def get_json(self, filename):
-    return CloudFiles('file://' + self.path).get_json(filename)
+    return self.cloudfiles().get_json(filename)
 
   def maybe_cache_info(self):
     if self.enabled:
-      cf = CloudFiles('file://' + self.path)
-      cf.put_json('info', self.meta.info)
+      self.cloudfiles().put_json('info', self.meta.info)
 
   def maybe_cache_provenance(self):
     if self.enabled and self.meta.provenance:
-      cf = CloudFiles('file://' + self.path)
+      cf = self.cloudfiles()
       cf.put('provenance', self.meta.provenance.serialize().encode('utf8'))
 
   def upload_single(self, filename, content, *args, **kwargs):
@@ -320,7 +327,12 @@ class CacheService(object):
 
     progress = progress if progress is not None else self.config.progress
 
-    cf = CloudFiles(self.meta.cloudpath, progress=progress, secrets=self.config.secrets)
+    cf = CloudFiles(
+      self.meta.cloudpath, 
+      progress=progress, 
+      secrets=self.config.secrets,
+      locking=self.config.cache_locking,
+    )
     files = list(compression.transcode(files, encoding=compress, level=compress_level))
     cf.puts( 
       files, 
@@ -333,7 +345,11 @@ class CacheService(object):
 
     if self.enabled:
       self.put(files, compress=compress)
-      cf_cache = CloudFiles('file://' + self.path, progress=('to Cache' if progress else None))
+      cf_cache = CloudFiles(
+        'file://' + self.path, 
+        progress=('to Cache' if progress else None),
+        locking=self.config.cache_locking,
+      )
       cf_cache.puts(
         files,
         compress=compress,
@@ -370,7 +386,11 @@ class CacheService(object):
       if locs['local']:
         return self.get_single(local_alias)
 
-    filedata = CloudFiles(self.meta.cloudpath, secrets=self.config.secrets)[path, start:end]
+    filedata = CloudFiles(
+      self.meta.cloudpath, 
+      secrets=self.config.secrets,
+      locking=self.config.cache_locking,
+    )[path, start:end]
 
     if self.enabled:
       self.put([ (local_alias, filedata) ], compress=compress)
@@ -422,6 +442,7 @@ class CacheService(object):
       progress=progress, 
       secrets=self.config.secrets,
       parallel=self.config.parallel,
+      locking=self.config.cache_locking,
     )
     remote_fragments = cf.get(
       ( { 'path': p[0], 'start': p[1], 'end': p[2] } for p in remote_path_tuples ),
@@ -483,6 +504,7 @@ class CacheService(object):
       progress=progress, 
       secrets=self.config.secrets,
       parallel=self.config.parallel,
+      locking=self.config.cache_locking,
     )
     remote_fragments = cf.get(locs['remote'], raw=True)
 
@@ -491,7 +513,11 @@ class CacheService(object):
         raise frag['error']
 
     if self.enabled:
-      cf_cache = CloudFiles('file://' + self.path, progress=('to Cache' if progress else None))
+      cf_cache = CloudFiles(
+        'file://' + self.path, 
+        progress=('to Cache' if progress else None),
+        locking=self.config.cache_locking,
+      )
       cf_cache.puts(
         compression.transcode(
           ( frag for frag in remote_fragments if frag['content'] is not None ),
@@ -516,7 +542,11 @@ class CacheService(object):
   def get(self, cloudpaths, progress=None):
     progress = self.config.progress if progress is None else progress
     
-    cf = CloudFiles('file://' + self.path, progress=progress)
+    cf = CloudFiles(
+      'file://' + self.path, 
+      progress=progress, 
+      locking=self.config.cache_locking,
+    )
     return cf.get(cloudpaths, return_dict=True)
 
   def put_single(self, path, content, *args, **kwargs):
@@ -540,7 +570,11 @@ class CacheService(object):
     
     save_location = 'file://' + self.path
     progress = 'to Cache' if progress else None
-    cf = CloudFiles(save_location, progress=progress)
+    cf = CloudFiles(
+      save_location, 
+      progress=progress, 
+      locking=self.config.cache_locking
+    )
     cf.puts(
       files, 
       compress=compress, 

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -35,7 +35,7 @@ class SharedConfiguration(object):
     self, cdn_cache:bool, compress:CompressType, 
     compress_level:Optional[int], green:bool,
     mip:int, parallel:ParallelType, progress:bool, secrets:SecretsType,
-    spatial_index_db:Optional[str],
+    spatial_index_db:Optional[str], cache_locking:bool,
     *args, **kwargs
   ):
     if type(parallel) == bool:
@@ -46,6 +46,7 @@ class SharedConfiguration(object):
       parallel = int(parallel)
 
     self.cdn_cache = cdn_cache
+    self.cache_locking = bool(cache_locking)
     self.compress = compress
     self.compress_level = compress_level
     self.green = bool(green)
@@ -68,7 +69,8 @@ class CloudVolume:
     background_color:int=0, green_threads:bool=False, use_https:bool=False,
     max_redirects:int=10, mesh_dir:Optional[str]=None, skel_dir:Optional[str]=None, 
     agglomerate:bool=False, secrets:SecretsType=None, 
-    spatial_index_db:Optional[str]=None, lru_bytes:int = 0
+    spatial_index_db:Optional[str]=None, lru_bytes:int = 0,
+    cache_locking:bool = True
   ):
     """
     A "serverless" Python client for reading and writing arbitrarily large 
@@ -131,7 +133,8 @@ class CloudVolume:
 
           Note: This cache is totally separate from the LRU controlled by 
           lru_bytes.
-
+      cache_locking: (bool) Use CloudFiles inter-process file locking to make cache 
+        access safe for multiple simultaneous processes.
       cdn_cache: (int, bool, or str) Sets Cache-Control HTTP header on uploaded 
         image files. Most cloud providers perform some kind of caching. As of 
         this writing, Google defaults to 3600 seconds. Most of the time you'll 

--- a/cloudvolume/datasource/boss/__init__.py
+++ b/cloudvolume/datasource/boss/__init__.py
@@ -1,3 +1,5 @@
+from typing import Optional, Union
+
 from .image import BossImageSource
 from .metadata import BossMetadata
 
@@ -5,15 +7,20 @@ from ...frontends.precomputed import CloudVolumePrecomputed
 
 from .. import get_cache_path
 from ...cacheservice import CacheService
-from ...cloudvolume import SharedConfiguration, register_plugin
+from ...cloudvolume import (
+  register_plugin, SharedConfiguration,
+  CompressType, ParallelType, CacheType,
+  SecretsType
+)
 from ...paths import strict_extract
 
 def create_boss(
-    cloudpath, mip=0, bounded=True, autocrop=False,
-    fill_missing=False, cache=False, compress_cache=None,
-    cdn_cache=True, progress=False, info=None, provenance=None,
-    compress=None, non_aligned_writes=False, parallel=1,
-    delete_black_uploads=False, green_threads=False
+    cloudpath, mip:int = 0, bounded:bool = True, autocrop:bool = False,
+    fill_missing:bool = False, cache:CacheType = False, compress_cache:CompressType = None,
+    cdn_cache:bool = True, progress:bool = False, info:Optional[dict] = None, 
+    provenance:Optional[dict] = None, compress:CompressType = None, 
+    non_aligned_writes:bool = False, parallel:int = 1, delete_black_uploads:bool = False, 
+    green_threads:bool = False, cache_locking:bool = True,
   ):
     path = strict_extract(cloudpath)
     config = SharedConfiguration(
@@ -24,6 +31,9 @@ def create_boss(
       mip=mip,
       parallel=parallel,
       progress=progress,
+      secrets=secrets,
+      spatial_index_db=None,
+      cache_locking=cache_locking,
     )
     cache = CacheService(
       cloudpath=get_cache_path(cache, cloudpath),

--- a/cloudvolume/datasource/graphene/__init__.py
+++ b/cloudvolume/datasource/graphene/__init__.py
@@ -26,7 +26,7 @@ def create_graphene(
     mesh_dir:Optional[str]=None, skel_dir:Optional[str]=None, 
     agglomerate:bool=False, secrets:SecretsType=None, 
     spatial_index_db:Optional[str]=None, 
-    lru_bytes:int = 0,
+    lru_bytes:int = 0, cache_locking:bool = True,
     **kwargs
   ):
     from ...frontends import CloudVolumeGraphene
@@ -42,6 +42,7 @@ def create_graphene(
       progress=progress,
       secrets=secrets,
       spatial_index_db=spatial_index_db,
+      cache_locking=cache_locking,
     )
 
     def mkcache(cloudpath):

--- a/cloudvolume/datasource/n5/__init__.py
+++ b/cloudvolume/datasource/n5/__init__.py
@@ -20,7 +20,8 @@ def create_n5(
   cdn_cache:bool=True, progress:bool=False, 
   compress:CompressType=None, compress_level:Optional[int]=None,
   non_aligned_writes:bool=False, 
-  parallel:ParallelType=1,green_threads:bool=False, secrets:SecretsType=None, 
+  parallel:ParallelType=1,green_threads:bool=False, 
+  secrets:SecretsType=None, cache_locking:bool = True,
   **kwargs # absorb graphene arguments
 ):
     path = strict_extract(cloudpath)

--- a/cloudvolume/datasource/precomputed/__init__.py
+++ b/cloudvolume/datasource/precomputed/__init__.py
@@ -27,7 +27,7 @@ def create_precomputed(
     green_threads:bool=False, use_https:bool=False,
     max_redirects:int=10, mesh_dir:Optional[str]=None, skel_dir:Optional[str]=None,
     secrets:SecretsType=None, spatial_index_db:Optional[str]=None, 
-    lru_bytes:int = 0,
+    lru_bytes:int = 0, cache_locking:bool = True,
     **kwargs # absorb graphene arguments
   ):
     path = strict_extract(cloudpath)
@@ -41,6 +41,7 @@ def create_precomputed(
       progress=progress,
       secrets=secrets,
       spatial_index_db=spatial_index_db,
+      cache_locking=cache_locking,
     )
 
     cache_service = CacheService(

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -352,7 +352,7 @@ def download_single_voxel_unsharded(
       cache_enabled, compress_cache,
       secrets, background_color,
       partial(decode_single_voxel, requested_bbox.minpt - chunk_bbx.minpt),
-      locking
+      decompress=True, locking=locking
     )
 
   if renumber:

--- a/cloudvolume/datasource/precomputed/image/tx.py
+++ b/cloudvolume/datasource/precomputed/image/tx.py
@@ -283,7 +283,7 @@ def threaded_upload_chunks(
     img = img[ ..., np.newaxis ]
 
   remote = CloudFiles(meta.cloudpath, secrets=secrets)
-  local = CloudFiles('file://' + cache.path, secrets=secrets)
+  local = cache.cloudfiles()
 
   remote_compress = should_compress(meta.encoding(mip), compress, cache)
   cache_compress = should_compress(meta.encoding(mip), compress, cache, iscache=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3>=1.4.7
 chardet>=3.0.4
-cloud-files>=2.0.0
+cloud-files>=4.18.1
 compressed-segmentation>=2.1.1
 compresso>=3.0.0
 crackle-codec


### PR DESCRIPTION
Adds `CloudVolume(..., cache_locking=True)` flag (true by default). 

This starts using the new CloudFiles inter-process locking mechanism which uses `fasteners` to create locking files for local cache access but not for `file://` access generally.

This may have some performance implications, but can be switched off. It's only enabled for cache because otherwise the number of lock files will grow without bound. Caches get cleared periodically.