### PR TITLE
perf: accelerate raw encoding speed for f order images w/o compression

### DIFF
--- a/cloudvolume/datasource/precomputed/image/tx.py
+++ b/cloudvolume/datasource/precomputed/image/tx.py
@@ -300,7 +300,7 @@ def threaded_upload_chunks(
     and meta.num_channels == 1
     and meta.encoding(mip) == "raw"
   ):
-    preencoded = fastremap.tobytes(img[:,:,:,0], meta.chunk_size(mip))
+    preencoded = fastremap.tobytes(img[:,:,:,0], meta.chunk_size(mip), order="F")
 
   def do_upload(i, imgchunk, cloudpath):
     nonlocal remote_compress

--- a/cloudvolume/datasource/precomputed/image/tx.py
+++ b/cloudvolume/datasource/precomputed/image/tx.py
@@ -296,6 +296,7 @@ def threaded_upload_chunks(
   if (
     img.flags.f_contiguous
     and not np.any(np.remainder(np.array(img.shape[:3]), meta.chunk_size(mip)))
+    and not np.all(np.array(img.shape[:3]) == meta.chunk_size(mip))
     and meta.num_channels == 1
     and meta.encoding(mip) == "raw"
   ):

--- a/cloudvolume/datasource/precomputed/image/tx.py
+++ b/cloudvolume/datasource/precomputed/image/tx.py
@@ -309,6 +309,7 @@ def threaded_upload_chunks(
 
     if preencoded:
       encoded = preencoded[i]
+      preencoded[i] = None
     else:
       encoded = chunks.encode(
         imgchunk, meta.encoding(mip), 

--- a/cloudvolume/datasource/precomputed/image/tx.py
+++ b/cloudvolume/datasource/precomputed/image/tx.py
@@ -1,8 +1,9 @@
 from functools import partial
 import os
 
-import numpy as np
 import fastremap
+import numpy as np
+import psutil
 from tqdm import tqdm
 
 from cloudfiles import CloudFiles, reset_connection_pools, compression
@@ -295,10 +296,10 @@ def threaded_upload_chunks(
   preencoded = None
   if (
     img.flags.f_contiguous
-    and not np.any(np.remainder(np.array(img.shape[:3]), meta.chunk_size(mip)))
-    and not np.all(np.array(img.shape[:3]) == meta.chunk_size(mip))
-    and meta.num_channels == 1
     and meta.encoding(mip) == "raw"
+    and not np.any(np.remainder(np.array(img.shape[:3]), meta.chunk_size(mip)))
+    and meta.num_channels == 1
+    and psutil.virtual_memory().available > 2 * img.nbytes
   ):
     preencoded = fastremap.tobytes(img[:,:,:,0], meta.chunk_size(mip), order="F")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ compressed-segmentation>=2.1.1
 compresso>=3.0.0
 crackle-codec
 DracoPy>=1.0.0,<2.0.0
-fastremap>=1.12.0
+fastremap>=1.14.0
 fpzip>=1.2.0,<2.0.0
 gevent
 google-auth>=1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ protobuf>=3.3.0
 pyspng-seunglab>=1.0.0
 python-dateutil
 requests>=2.22.0
+psutil
 pysimdjson>=3.1.1
 simplejpeg
 six>=1.10.0


### PR DESCRIPTION
Use a bulk encoding technique for transforming Fortran order image arrays into chunked fortran order byte objects. This uses more memory but is faster. We only use this new technique when the input image is appropriate and there is available RAM as measured by `psutil.virtual_memory().available`