### PR TITLE
feat: shard->shard transfers, memory cutout, transcoding images

### DIFF
--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -518,18 +518,32 @@ class PrecomputedImageSource(ImageSourceInterface):
 
     if not sharded and self.is_sharded(mip):
       return xfer.transfer_any_to_unsharded(
-        self, cloudpath, bbox, mip, 
-        compress, compress_level, encoding
+        self, cloudpath,         
+        bbox=bbox, 
+        mip=mip,
+        compress=compress, 
+        compress_level=compress_level, 
+        encoding=encoding,
       )
     elif sharded and self.is_sharded(mip):
       return xfer.transfer_sharded_to_sharded(
-        self, cloudpath, bbox, mip, 
-        compress, compress_level, encoding
+        self, cloudpath, 
+        bbox=bbox, 
+        mip=mip, 
+        block_size=block_size,
+        compress=compress, 
+        compress_level=compress_level, 
+        encoding=encoding,
       )
     elif not sharded and not self.is_sharded(mip):
       return xfer.transfer_unsharded_to_unsharded(
-        self, cloudpath, bbox, mip, 
-        compress, compress_level, encoding
+        self, cloudpath,
+        bbox=bbox, 
+        mip=mip,
+        block_size=block_size,
+        compress=compress, 
+        compress_level=compress_level, 
+        encoding=encoding,
       )
     else:
       raise ValueError(

--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -566,7 +566,10 @@ class PrecomputedImageSource(ImageSourceInterface):
         raise ValueError("mip {} does not have a sharding specification.".format(mip))
     return spec
 
-  def morton_codes(self, bbox, mip=None, spec=None, same_shard=True):
+  def morton_codes(
+    self, bbox, mip=None, spec=None,
+    same_shard=True, require_aligned=True
+  ):
     mip = mip if mip is not None else self.config.mip
     scale = self.meta.scale(mip)
     spec = self.shard_spec(mip, spec)
@@ -580,7 +583,7 @@ class PrecomputedImageSource(ImageSourceInterface):
     aligned_bbox = bbox.expand_to_chunk_size(
       self.meta.chunk_size(mip), offset=self.meta.voxel_offset(mip)
     )
-    if bbox != aligned_bbox:
+    if require_aligned and bbox != aligned_bbox:
       raise exceptions.AlignmentError(
         "Unable to create shard from a non-chunk aligned bounding box. Requested: {}, Aligned: {}".format(
         bbox, aligned_bbox

--- a/cloudvolume/datasource/precomputed/image/xfer.py
+++ b/cloudvolume/datasource/precomputed/image/xfer.py
@@ -68,12 +68,14 @@ def transfer_any_to_unsharded(
   cv.commit_info()
   mip = cv.mip
 
-  # To get the decompress info at this level will require
-  # significant refactoring. Not great news for "raw" encoding.
-  files = source.download_files(bbox, mip, decompress=True)
-
   src_encoding = source.meta.encoding(mip)
   dest_encoding = cv.meta.encoding(mip)
+
+  decompress = (src_encoding != dest_encoding) or (compress is not None)
+
+  # To get the decompress info at this level will require
+  # significant refactoring. Not great news for "raw" encoding.
+  files = source.download_files(bbox, mip, decompress=decompress)
 
   bounds = source.meta.bounds(mip)
   chunk_size = source.meta.chunk_size(mip)

--- a/cloudvolume/datasource/precomputed/image/xfer.py
+++ b/cloudvolume/datasource/precomputed/image/xfer.py
@@ -1,0 +1,356 @@
+import copy
+from typing import Dict, Tuple, Sequence, Union, Optional
+
+import numpy as np
+from tqdm import tqdm
+
+from cloudfiles import CloudFiles, compression
+
+from cloudvolume import lib, exceptions
+from ....types import CompressType, MipType
+from ....lib import Bbox, Vec, sip, first, BboxLikeType, toiter
+from .... import chunks
+
+from ... import autocropfn, readonlyguard, ImageSourceInterface
+from .. import sharding
+from .common import chunknames, gridpoints, compressed_morton_code, morton_code_to_bbox
+from . import tx
+
+def create_destination(source, cloudpath, mip, encoding):
+  from cloudvolume import CloudVolume
+  
+  commit = False
+  try:
+    destvol = CloudVolume(cloudpath, mip=mip)
+  except exceptions.InfoUnavailableError: 
+    info = copy.deepcopy(source.meta.info)
+    destvol = CloudVolume(cloudpath, mip=mip, info=info, provenance=source.meta.provenance.serialize())
+    commit = True
+  except exceptions.ScaleUnavailableError:
+    destvol = CloudVolume(cloudpath)
+    for i in range(len(destvol.scales) + 1, len(source.meta.scales)):
+      destvol.scales.append(
+        source.meta.scales[i]
+      )
+    commit = True
+
+  if encoding is not None:
+    destvol.meta.encoding(mip, encoding)
+    commit = commit or (destvol.meta.encoding(mip) != source.meta.encoding(mip))
+
+  if commit:
+    destvol.commit_info()
+    destvol.commit_provenance()
+
+  return destvol
+
+def transfer_any_to_unsharded(
+  source,
+  cloudpath:str,
+  bbox:BboxLikeType, 
+  mip:int,
+  compress:CompressType = None, 
+  compress_level:Optional[int] = None,
+  encoding:Optional[str] = None,
+):
+  """
+  Create a disposable in-memory CloudVolume (mem://) containing
+  the requested cutout region in the unsharded precomputed
+  format. The source volume may be sharded or unsharded.
+
+  You can specify an alternative encoding and compression 
+  settings for the new volume.
+  """
+  from cloudvolume import CloudVolume
+
+  cv = create_destination(source, cloudpath, mip, encoding)
+  cv.scale.pop("sharding", None)
+  cv.commit_info()
+  mip = cv.mip
+
+  # To get the decompress info at this level will require
+  # significant refactoring. Not great news for "raw" encoding.
+  files = source.download_files(bbox, mip, decompress=True)
+
+  src_encoding = source.meta.encoding(mip)
+  dest_encoding = cv.meta.encoding(mip)
+
+  bounds = source.meta.bounds(mip)
+  chunk_size = source.meta.chunk_size(mip)
+
+  filenames = list(files.keys())
+
+  for fname in filenames:
+    binary = files[fname]
+    if type(fname) == int:
+      bbx = morton_code_to_bbox(fname, bounds, chunk_size)
+    else:
+      bbx = Bbox.from_filename(fname)
+
+    if src_encoding != dest_encoding:
+      image = chunks.decode(
+        binary, src_encoding, 
+        shape=bbx.size(), 
+        dtype=source.meta.dtype,
+        block_size=source.meta.compressed_segmentation_block_size(mip),
+        background_color=source.background_color,
+      )
+      while image.ndim < 4:
+        image = image[..., np.newaxis]
+      binary = chunks.encode(
+        image, dest_encoding,
+        block_size=cv.meta.compressed_segmentation_block_size(mip),
+      )
+      del image
+
+    del files[fname]
+    files[bbx.to_filename()] = binary
+
+  CloudFiles(
+    cv.meta.join(cloudpath, cv.key)
+  ).puts(
+    files.items(), compress=compress, compression_level=compress_level
+  )
+
+  return cv
+
+def transfer_sharded_to_sharded(
+  source, 
+  cloudpath:str, 
+  bbox:BboxLikeType, 
+  mip:MipType, 
+  block_size:Optional[int] = None, 
+  compress:CompressType = True, 
+  compress_level:Optional[int] = None, 
+  encoding:Optional[str] = None,
+):
+  from cloudvolume import CloudVolume
+  if mip is None:
+    mip = source.config.mip
+
+  if not source.is_sharded(mip):
+    raise exceptions.UnsupportedFormatError(f"Unsharded sources are not supported. got: {source.meta.cloudpath}")
+
+  bbox = Bbox.create(bbox, source.meta.bounds(mip))
+  realized_bbox = bbox.expand_to_chunk_size(
+    source.meta.chunk_size(mip), offset=source.meta.voxel_offset(mip)
+  )
+  realized_bbox = Bbox.clamp(realized_bbox, source.meta.bounds(mip))
+
+  if bbox != realized_bbox:
+    raise exceptions.AlignmentError(
+      "Unable to transfer non-chunk aligned bounding boxes. Requested: {}, Realized: {}".format(
+        bbox, realized_bbox
+      ))
+
+
+  chunk_size = meta.chunk_size(mip)
+  grid_size = np.ceil(meta.bounds(mip).size3() / chunk_size).astype(np.uint32)
+
+  reader = sharding.ShardReader(meta, cache, spec)
+  bounds = meta.bounds(mip)
+  
+  spec = source.shard_spec(mip)
+  gpts, morton_codes = self.morton_codes(bbox, mip=mip, spec=spec)
+  reader = source.shard_reader()
+  shard_filenames = list(set([ 
+    reader.get_filename(code) for code in morton_codes 
+  ]))
+
+  destvol = create_destination(source, cloudpath, mip, encoding)
+
+  cfsrc = CloudFiles(
+    source.meta.join(source.meta.cloudpath, source.meta.key(mip)),
+    secrets=source.config.secrets
+  )
+  cfdest = CloudFiles(destvol.meta.join(
+    cloudpath, destvol.meta.key(mip)
+  ))
+
+  src_encoding = source.meta.encoding(mip)
+  dest_encoding = destvol.meta.encoding(mip)
+
+  def transcode(chunks):
+    nonlocal source
+    nonlocal destvol
+    labels = list(chunks.keys())
+    chunk_size = source.meta.chunk_size(mip)
+    for label in labels:
+      binary = chunks[label]
+      image = chunks.decode(
+        binary, src_encoding, 
+        shape=chunk_size, 
+        dtype=source.meta.dtype,
+        block_size=source.meta.compressed_segmentation_block_size(mip),
+        background_color=source.background_color,
+      )
+      while image.ndim < 4:
+        image = image[..., np.newaxis]
+      binary = chunks.encode(
+        image, dest_encoding,
+        block_size=destvol.meta.compressed_segmentation_block_size(mip),
+      )
+      chunks[label] = binary
+    return files
+
+  if src_encoding == dest_encoding:
+    cfsrc.transfer_to(
+      cfdest, 
+      paths=shard_filenames,
+      block_size=2,
+    )
+  else:
+    for filename in shard_filenames:
+      shard_binary = cfsrc.get(filename, raw=True)
+      chunks = reader.disassemble_shard(shard_binary)
+      del shard_binary
+      chunks = transcode(chunks)
+      shard_binary = reader.synthesize_shard(chunks)
+      del chunks
+      cfdest.put(filename, shard_binary, raw=True)
+
+def transfer_unsharded_to_unsharded(
+  source, 
+  cloudpath:str, 
+  bbox:BboxLikeType, 
+  mip:MipType, 
+  block_size:Optional[int] = None, 
+  compress:CompressType = True, 
+  compress_level:Optional[int] = None, 
+  encoding:Optional[str] = None,
+):
+  """
+  Transfer files from one storage location to another, bypassing
+  volume painting. This enables using a single CloudVolume instance
+  to transfer big volumes. In some cases, gsutil or aws s3 cli tools
+  may be more appropriate. This method is provided for convenience. It
+  may be optimized for better performance over time as demand requires.
+
+  cloudpath: path to storage layer
+  bbox: ROI to transfer
+  mip: resolution level
+  block_size: number of file chunks to transfer per I/O batch.
+  compress: Set to False to upload as uncompressed
+  compress_level: level to feed to compressor (means different things for
+    different algorithms)
+  encoding: if specified, transcode to this image encoding (otherwise taken
+    to be identical to source volume)
+  """
+  from cloudvolume import CloudVolume
+  if mip is None:
+    mip = source.config.mip
+
+  if source.is_sharded(mip):
+    raise exceptions.UnsupportedFormatError(f"Sharded sources are not supported. got: {source.meta.cloudpath}")
+
+  bbox = Bbox.create(bbox, source.meta.bounds(mip))
+  realized_bbox = bbox.expand_to_chunk_size(
+    source.meta.chunk_size(mip), offset=source.meta.voxel_offset(mip)
+  )
+  realized_bbox = Bbox.clamp(realized_bbox, source.meta.bounds(mip))
+
+  if bbox != realized_bbox:
+    raise exceptions.AlignmentError(
+      "Unable to transfer non-chunk aligned bounding boxes. Requested: {}, Realized: {}".format(
+        bbox, realized_bbox
+      ))
+
+  default_block_size_MB = 50 # MB
+  chunk_MB = source.meta.chunk_size(mip).rectVolume() * np.dtype(source.meta.dtype).itemsize * source.meta.num_channels
+  if source.meta.layer_type == 'image':
+    # kind of an average guess for some EM datasets, have seen up to 1.9x and as low as 1.1
+    # affinites are also images, but have very different compression ratios. e.g. 3x for kempressed
+    chunk_MB /= 1.3 
+  else: # segmentation
+    chunk_MB /= 100.0 # compression ratios between 80 and 800....
+  chunk_MB /= 1024.0 * 1024.0
+
+  if block_size:
+    step = block_size
+  else:
+    step = int(default_block_size_MB // chunk_MB) + 1
+
+  destvol = create_destination(source, cloudpath, mip, encoding)
+
+  if destvol.image.is_sharded(mip):
+    raise exceptions.UnsupportedFormatError(f"Sharded destinations are not supported. got: {destvol.cloudpath}")
+
+  num_blocks = np.ceil(source.meta.bounds(mip).volume() / source.meta.chunk_size(mip).rectVolume()) / step
+  num_blocks = int(np.ceil(num_blocks))
+
+  src_encoding = source.meta.encoding(mip)
+  dest_encoding = destvol.meta.encoding(mip)
+
+  cloudpaths = chunknames(
+    bbox, source.meta.bounds(mip), 
+    source.meta.key(mip), source.meta.chunk_size(mip),
+    protocol=source.meta.path.protocol
+  )
+
+  pbar = tqdm(
+    desc='Transferring Blocks of {} Chunks'.format(step), 
+    unit='blocks', 
+    disable=(not source.config.progress),
+    total=num_blocks,
+  )
+
+  cfsrc = CloudFiles(source.meta.cloudpath, secrets=source.config.secrets)
+  cfdest = CloudFiles(cloudpath)
+
+  def check(files):
+    if source.fill_missing:
+      for file in files:
+        if file['content'] is None:
+          file['content'] = b''
+    errors = [
+      file for file in files if \
+      (file['content'] is None or file['error'] is not None)
+    ]
+    if errors:
+      error_paths = [ f['path'] for f in errors ]
+      raise exceptions.EmptyFileException(f"{', '.join(error_paths)} were empty or had IO errors.")
+    return files
+
+  def transcode(files):
+    for file in files:
+      binary = file["content"]
+      bbx = Bbox.from_filename(file["path"])
+      image = chunks.decode(
+        binary, src_encoding, 
+        shape=bbx.size(), 
+        dtype=source.meta.dtype,
+        block_size=source.meta.compressed_segmentation_block_size(mip),
+        background_color=source.background_color,
+      )
+      while image.ndim < 4:
+        image = image[..., np.newaxis]
+      binary = chunks.encode(
+        image, dest_encoding,
+        block_size=destvol.meta.compressed_segmentation_block_size(mip),
+      )
+      file["content"] = binary
+    return files
+
+  content_type = tx.content_type(destvol)
+
+  with pbar:
+    for srcpaths in sip(cloudpaths, step):
+      if src_encoding == dest_encoding:
+          cfdest.transfer_from(
+            cfsrc, srcpaths, 
+            reencode=compress,
+            content_type=content_type,
+            allow_missing=source.fill_missing,
+          )
+      else:
+        files = check(cfsrc.get(srcpaths))
+        files = transcode(files)
+        cfdest.puts(
+          files, 
+          content_type=content_type,
+          compress=compress,
+          compression_level=compress_level,
+        )
+      pbar.update()
+  
+  return destvol

--- a/cloudvolume/datasource/precomputed/sharding.py
+++ b/cloudvolume/datasource/precomputed/sharding.py
@@ -14,7 +14,7 @@ from cloudfiles import CloudFiles
 
 from . import mmh3
 from ... import compression
-from ...lib import jsonify, toiter, first
+from ...lib import jsonify, toiter, first, Vec, Bbox
 from ...lru import LRU
 from ...exceptions import SpecViolation, EmptyFileException
 
@@ -216,7 +216,50 @@ class ShardingSpecification(object):
 
     if self.data_encoding not in ('raw', 'gzip'):
       raise SpecViolation("data_encoding only supports values 'raw' or 'gzip'.")
-    
+
+  def image_shard_shape(self, dataset_size, chunk_size):
+    """For image shards, compute their shape"""
+    chunk_size = Vec(*chunk_size, dtype=np.uint64)
+    dataset_size = Vec(*dataset_size, dtype=np.uint64)
+    preshift_bits = np.uint64(self.preshift_bits)
+    minishard_bits = np.uint64(self.minishard_bits)
+    shape_bits = preshift_bits + minishard_bits
+
+    grid_size = np.ceil(dataset_size / chunk_size).astype(np.uint64)
+    one = np.uint64(1)
+
+    if shape_bits >= 64:
+      raise ValueError(
+        f"preshift_bits ({preshift_bits}) + minishard_bits ({minishard_bits}) must be < 64. Sum: {shape_bits}"
+      )
+
+    def compute_shape_bits():
+      shape = Vec(0,0,0, dtype=np.uint64)
+
+      i = 0
+      over = [ False, False, False ]
+      while i < shape_bits:
+        changed = False
+        for dim in range(3):
+          if 2 ** (shape[dim] + 1) < grid_size[dim] * 2 and not over[dim]:
+            if 2 ** (shape[dim] + 1) >= grid_size[dim]:
+              over[dim] = True
+            shape[dim] += one
+            i += 1
+            changed = True
+
+          if i >= shape_bits:
+            return shape
+
+        if not changed:
+          return shape
+
+      return shape
+
+    shape = compute_shape_bits()
+    shape = Vec(2 ** shape.x, 2 ** shape.y, 2 ** shape.z, dtype=np.uint64)
+    return chunk_size * shape
+
   def __str__(self):
     return "ShardingSpecification::" + str(self.to_dict())
 

--- a/cloudvolume/frontends/precomputed.py
+++ b/cloudvolume/frontends/precomputed.py
@@ -504,7 +504,11 @@ class CloudVolumePrecomputed(object):
     """
     return self.image.delete(bbox_or_slices)
 
-  def transfer_to(self, cloudpath, bbox, block_size=None, compress=True, encoding=None):
+  def transfer_to(
+    self, cloudpath, bbox, 
+    block_size=None, compress=True, encoding=None,
+    sharded=None,
+  ):
     """
     Transfer files from one storage location to another, bypassing
     volume painting. This enables using a single CloudVolume instance
@@ -519,7 +523,8 @@ class CloudVolumePrecomputed(object):
     """
     return self.image.transfer_to(
       cloudpath, bbox, self.mip, 
-      block_size, compress, encoding=encoding
+      block_size, compress, 
+      encoding=encoding, sharded=sharded,
     )
 
   def coordinate_indexing(self, slices):
@@ -1134,3 +1139,6 @@ class CloudVolumePrecomputed(object):
     if name is None:
       name = 'to-dask-' + tokenize(self, chunks)
     return da.from_array(self, chunks, name=name)
+
+  def __del__(self):
+    pass

--- a/cloudvolume/frontends/precomputed.py
+++ b/cloudvolume/frontends/precomputed.py
@@ -504,7 +504,7 @@ class CloudVolumePrecomputed(object):
     """
     return self.image.delete(bbox_or_slices)
 
-  def transfer_to(self, cloudpath, bbox, block_size=None, compress=True):
+  def transfer_to(self, cloudpath, bbox, block_size=None, compress=True, encoding=None):
     """
     Transfer files from one storage location to another, bypassing
     volume painting. This enables using a single CloudVolume instance
@@ -517,7 +517,10 @@ class CloudVolumePrecomputed(object):
     block_size (int): number of file chunks to transfer per I/O batch.
     compress (bool): Set to False to upload as uncompressed
     """
-    return self.image.transfer_to(cloudpath, bbox, self.mip, block_size, compress)
+    return self.image.transfer_to(
+      cloudpath, bbox, self.mip, 
+      block_size, compress, encoding=encoding
+    )
 
   def coordinate_indexing(self, slices):
     """

--- a/cloudvolume/types.py
+++ b/cloudvolume/types.py
@@ -1,6 +1,7 @@
-from typing import Union, Optional
+from typing import Union, Optional, List
 
 CompressType = Optional[Union[str,bool]]
 ParallelType = Union[int,bool]
 CacheType = Union[bool,str]
 SecretsType = Optional[Union[str,dict]]
+MipType = Union[int, List[int]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3>=1.4.7
 chardet>=3.0.4
-cloud-files>=4.18.1,<5.0.0
+cloud-files>=4.24.0,<5.0.0
 compressed-segmentation>=2.1.1
 compresso>=3.0.0
 crackle-codec>=0.8.0,<2.0.0

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -1510,6 +1510,18 @@ def test_transfer():
 
   assert np.all(img == dcv[:])
 
+  dcv.image.delete(dcv.bounds)
+  cv.transfer_to('file:///tmp/removeme/transfer2/', cv.bounds, encoding="png", compress=False)
+
+  dcv = CloudVolume('file:///tmp/removeme/transfer2/')
+
+  assert np.all(img == dcv[:])
+
+  dcv.image.delete(dcv.bounds)
+
+
+
+
 def test_cdn_cache_control():
   delete_layer()
   create_layer(size=(128,10,10,1), offset=(0,0,0))


### PR DESCRIPTION
Adds:
- unsharded->unsharded transcoding (transfer_to pre-existed)
- shard->shard + transcoding
- any -> unsharded + transcoding
- Anonymous memory based cutouts via cv.image.memory_cutout

Not covered:
- unsharded -> sharded (but it is in Igneous), it probably wouldn't be too much work but requires importing logic from igneous
