### PR TITLE
feat: add skeleton sharded uploads

### DIFF
--- a/cloudvolume/datasource/graphene/mesh/__init__.py
+++ b/cloudvolume/datasource/graphene/mesh/__init__.py
@@ -17,7 +17,15 @@ class GrapheneMeshSource(object):
     return GrapheneUnshardedMeshSource(mesh_meta, cache, config, readonly)
 
   @classmethod
-  def from_cloudpath(cls, cloudpath, cache=False, progress=False):
+  def from_cloudpath(
+    cls, 
+    cloudpath:str, 
+    cache=False, 
+    progress=False,
+    secrets=None,
+    spatial_index_db:Optional[str]=None, 
+    cache_locking:bool = True,
+  ):
     config = SharedConfiguration(
       cdn_cache=False,
       compress=True,
@@ -26,6 +34,9 @@ class GrapheneMeshSource(object):
       mip=0,
       parallel=1,
       progress=progress,
+      secrets=secrets,
+      spatial_index_db=spatial_index_db,
+      cache_locking=cache_locking,
     )
 
     cache = CacheService(

--- a/cloudvolume/datasource/graphene/mesh/__init__.py
+++ b/cloudvolume/datasource/graphene/mesh/__init__.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from .sharded import GrapheneShardedMeshSource
 from .unsharded import GrapheneUnshardedMeshSource
 from .metadata import GrapheneMeshMetadata
@@ -21,9 +23,9 @@ class GrapheneMeshSource(object):
     cls, 
     cloudpath:str, 
     cache=False, 
-    progress=False,
+    progress:bool = False,
     secrets=None,
-    spatial_index_db:Optional[str]=None, 
+    spatial_index_db:Optional[str] = None, 
     cache_locking:bool = True,
   ):
     config = SharedConfiguration(

--- a/cloudvolume/datasource/precomputed/__init__.py
+++ b/cloudvolume/datasource/precomputed/__init__.py
@@ -102,11 +102,17 @@ def create_precomputed(
     mesh = PrecomputedMeshSource(meta, cache_service, config, readonly)
     skeleton = PrecomputedSkeletonSource(meta, cache_service, config, readonly)
 
-    return CloudVolumePrecomputed(
+    cv = CloudVolumePrecomputed(
       meta, cache_service, config, 
       image, mesh, skeleton,
       mip
     )
+
+    skeleton.meta.cv = cv # assigned as a weakref
+    mesh.meta.cv = cv # assigned as a weakref
+
+    return cv
+
 
 def register():
   register_plugin('precomputed', create_precomputed)

--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -679,6 +679,7 @@ class PrecomputedImageSource(ImageSourceInterface):
     return (shard_filename, spec.synthesize_shard(labels, progress=progress))
 
   def to_sharded(
+    self,
     uncompressed_shard_bytesize:int = int(3.5e9),
     max_shard_index_bytes:int = 8192, # 2^13
     max_minishard_index_bytes:int = 40000,
@@ -700,7 +701,12 @@ class PrecomputedImageSource(ImageSourceInterface):
       max_labels_per_minishard=max_labels_per_minishard,
       minishard_index_encoding=minishard_index_encoding,
       data_encoding=data_encoding,
-    ) 
+    )
+    self.meta.scale(mip)["sharding"] = spec.to_dict()
+
+  def to_unsharded(self, mip=None):
+    mip = mip if mip is not None else self.config.mip
+    self.meta.scale(mip).pop("sharding", None)
 
   def shard_shape(self, mip=None):
     mip = mip if mip is not None else self.config.mip

--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -66,7 +66,7 @@ class PrecomputedImageSource(ImageSourceInterface):
   def unlink_shared_memory(self):
     """Unlink the current shared memory location from the filesystem."""
     return sharedmemory.unlink(self.shared_memory_id)
-
+    
   def grid_size(self, mip=None):
     mip = mip if mip is not None else self.config.mip
     return np.ceil(self.meta.volume_size(mip) / self.meta.chunk_size(mip)).astype(np.int64)

--- a/cloudvolume/datasource/precomputed/mesh/__init__.py
+++ b/cloudvolume/datasource/precomputed/mesh/__init__.py
@@ -14,7 +14,7 @@ from ....cloudvolume import SharedConfiguration
 
 class PrecomputedMeshSource(object):
   def __new__(cls, meta, cache, config, readonly=False, info=None):
-    mesh_meta = PrecomputedMeshMetadata(meta, cache, info=info)
+    mesh_meta = PrecomputedMeshMetadata(meta, cache, config, info=info)
     if mesh_meta.info.get('@type', None) == 'neuroglancer_multilod_draco':
       sharding = mesh_meta.info.get('sharding', None)
       if sharding and sharding['@type'] == 'neuroglancer_uint64_sharded_v1':

--- a/cloudvolume/datasource/precomputed/mesh/__init__.py
+++ b/cloudvolume/datasource/precomputed/mesh/__init__.py
@@ -13,8 +13,8 @@ from ....paths import strict_extract
 from ....cloudvolume import SharedConfiguration
 
 class PrecomputedMeshSource(object):
-  def __new__(cls, meta, cache, config, readonly=False):
-    mesh_meta = PrecomputedMeshMetadata(meta, cache)
+  def __new__(cls, meta, cache, config, readonly=False, info=None):
+    mesh_meta = PrecomputedMeshMetadata(meta, cache, info=info)
     if mesh_meta.info.get('@type', None) == 'neuroglancer_multilod_draco':
       sharding = mesh_meta.info.get('sharding', None)
       if sharding and sharding['@type'] == 'neuroglancer_uint64_sharded_v1':

--- a/cloudvolume/datasource/precomputed/mesh/__init__.py
+++ b/cloudvolume/datasource/precomputed/mesh/__init__.py
@@ -14,7 +14,7 @@ from ....cloudvolume import SharedConfiguration
 
 class PrecomputedMeshSource(object):
   def __new__(cls, meta, cache, config, readonly=False, info=None):
-    mesh_meta = PrecomputedMeshMetadata(meta, cache, config, info=info)
+    mesh_meta = PrecomputedMeshMetadata(meta, cache, config, readonly=readonly, info=info)
     if mesh_meta.info.get('@type', None) == 'neuroglancer_multilod_draco':
       sharding = mesh_meta.info.get('sharding', None)
       if sharding and sharding['@type'] == 'neuroglancer_uint64_sharded_v1':

--- a/cloudvolume/datasource/precomputed/mesh/metadata.py
+++ b/cloudvolume/datasource/precomputed/mesh/metadata.py
@@ -1,6 +1,9 @@
+from typing import Optional
+
 import re
 
 from ....lib import jsonify
+from ..sharding import ShardingSpecification, compute_shard_params_for_hashed
 
 import numpy as np
 

--- a/cloudvolume/datasource/precomputed/mesh/metadata.py
+++ b/cloudvolume/datasource/precomputed/mesh/metadata.py
@@ -176,7 +176,9 @@ class PrecomputedMeshMetadata(object):
   def _refresh_mesh_interface(self):
     from cloudvolume.datasource.precomputed.mesh import PrecomputedMeshSource
     if self.cv:
-      self.cv.mesh = PrecomputedMeshSource(self.meta, self.cache, info=self.info)
+      mesh_src = PrecomputedMeshSource(self.meta, self.cache, None, info=self.info)
+      mesh_src.meta.cv = self.cv()
+      self.cv().mesh = mesh_src
 
   def to_multi_resolution(self, vertex_quantization_bits:int):
     if vertex_quantization_bits not in [10, 16]:

--- a/cloudvolume/datasource/precomputed/mesh/metadata.py
+++ b/cloudvolume/datasource/precomputed/mesh/metadata.py
@@ -97,6 +97,85 @@ class PrecomputedMeshMetadata(object):
       'spatial_index': None, # { 'chunk_size': physical units }
     }
 
+  def compute_sharding_specification(
+    self, 
+    num_labels:int,
+    shard_index_bytes:int = 2**13,
+    minishard_index_bytes:int = 2**15,
+    min_shards:int = 1,
+    minishard_index_encoding:str = 'gzip', 
+    data_encoding:str = 'gzip',
+    max_labels_per_shard:Optional[int] = None,
+  ) -> ShardingSpecification:
+    """
+    Calculate the shard parameters for this volume given
+    the total number of labels in the volume.
+    """
+    if max_labels_per_shard is not None:
+      assert max_labels_per_shard >= 1
+      min_shards = max(int(np.ceil(len(all_labels) / max_labels_per_shard)), min_shards)
+
+    (shard_bits, minishard_bits, preshift_bits) = \
+      compute_shard_params_for_hashed(
+        num_labels=num_labels,
+        shard_index_bytes=int(shard_index_bytes),
+        minishard_index_bytes=int(minishard_index_bytes),
+        min_shards=int(min_shards),
+      )
+
+    return ShardingSpecification(
+      type='neuroglancer_uint64_sharded_v1',
+      preshift_bits=preshift_bits,
+      hash='murmurhash3_x86_128',
+      minishard_bits=minishard_bits,
+      shard_bits=shard_bits,
+      minishard_index_encoding=minishard_index_encoding,
+      data_encoding=data_encoding,
+    )
+
+  def to_sharded(
+    self, 
+    num_labels:int,
+    shard_index_bytes:int = 2**13,
+    minishard_index_bytes:int = 2**15,
+    min_shards:int = 1,
+    minishard_index_encoding:str = 'gzip', 
+    data_encoding:str = 'gzip',
+    max_labels_per_shard:Optional[int] = None,
+  ):
+    """Adds a computed sharding property to the info."""
+    spec = self.compute_sharding_specification(
+      num_labels=num_labels, 
+      shard_index_bytes=shard_index_bytes, 
+      minishard_index_bytes=minishard_index_bytes, 
+      min_shards=min_shards,
+      minishard_index_encoding=minishard_index_encoding,
+      data_encoding=data_encoding,
+      max_labels_per_shard=max_labels_per_shard,
+    )
+    self.info['sharding'] = spec.to_dict()
+
+  def to_multi_resolution(self, vertex_quantization_bits:int):
+    if vertex_quantization_bits not in [10, 16]:
+      raise ValueError(f"vertex_quantization_bits must by 10 or 16. Got: {vertex_quantization_bits}")
+
+    res = self.meta.resolution(self.mip)
+
+    self.info['@type'] = "neuroglancer_multilod_draco"
+    self.info['vertex_quantization_bits'] = vertex_quantization_bits
+    self.info['transform'] = [ 
+      res[0], 0,      0,      0,
+      0,      res[1], 0,      0,
+      0,      0,      res[2], 0,
+    ]
+    self.info['lod_scale_multiplier'] = 1.0
+
+  def to_single_resolution(self):
+    self.info['@type'] = "neuroglancer_legacy_mesh"
+    self.info.pop("vertex_quantization_bits", None)
+    self.info.pop("transform", None)
+    self.info.pop("lod_scale_multiplier", None)
+
   def is_sharded(self):
     if 'sharding' not in self.info:
       return False

--- a/cloudvolume/datasource/precomputed/mesh/metadata.py
+++ b/cloudvolume/datasource/precomputed/mesh/metadata.py
@@ -11,10 +11,11 @@ import numpy as np
 MESH_MIP_REGEXP = re.compile(r'mesh_mip_(\d+)')
 
 class PrecomputedMeshMetadata(object):
-  def __init__(self, meta, cache=None, config=None, info=None):
+  def __init__(self, meta, cache=None, config=None, info=None, readonly=False):
     self.meta = meta
     self.cache = cache
     self.config = config
+    self.readonly = readonly
     self._cv = None
 
     if info:
@@ -177,7 +178,7 @@ class PrecomputedMeshMetadata(object):
   def _refresh_mesh_interface(self):
     from cloudvolume.datasource.precomputed.mesh import PrecomputedMeshSource
     if self.cv:
-      mesh_src = PrecomputedMeshSource(self.meta, self.cache, self.config, info=self.info)
+      mesh_src = PrecomputedMeshSource(self.meta, self.cache, self.config, self.readonly, info=self.info)
       mesh_src.meta.cv = self.cv()
       self.cv().mesh = mesh_src
 

--- a/cloudvolume/datasource/precomputed/mesh/metadata.py
+++ b/cloudvolume/datasource/precomputed/mesh/metadata.py
@@ -11,9 +11,10 @@ import numpy as np
 MESH_MIP_REGEXP = re.compile(r'mesh_mip_(\d+)')
 
 class PrecomputedMeshMetadata(object):
-  def __init__(self, meta, cache=None, info=None):
+  def __init__(self, meta, cache=None, config=None, info=None):
     self.meta = meta
     self.cache = cache
+    self.config = config
     self._cv = None
 
     if info:
@@ -176,7 +177,7 @@ class PrecomputedMeshMetadata(object):
   def _refresh_mesh_interface(self):
     from cloudvolume.datasource.precomputed.mesh import PrecomputedMeshSource
     if self.cv:
-      mesh_src = PrecomputedMeshSource(self.meta, self.cache, None, info=self.info)
+      mesh_src = PrecomputedMeshSource(self.meta, self.cache, self.config, info=self.info)
       mesh_src.meta.cv = self.cv()
       self.cv().mesh = mesh_src
 

--- a/cloudvolume/datasource/precomputed/mesh/unsharded.py
+++ b/cloudvolume/datasource/precomputed/mesh/unsharded.py
@@ -320,3 +320,27 @@ class UnshardedLegacyPrecomputedMeshSource(object):
 
     segids = self.spatial_index.query(bbox)
     return self.get(segids, fuse=False)
+
+  def to_sharded(
+    self,
+    num_labels:int,
+    shard_index_bytes:int = 2**13,
+    minishard_index_bytes:int = 2**15,
+    min_shards:int = 1,
+    minishard_index_encoding:str = 'gzip', 
+    data_encoding:str = 'gzip',
+    max_labels_per_shard:Optional[int] = None,
+  ):
+    return self.meta.to_sharded(
+      num_labels=num_labels,
+      shard_index_bytes=shard_index_bytes,
+      minishard_index_bytes=minishard_index_bytes,
+      min_shards=min_shards,
+      minishard_index_encoding=minishard_index_encoding,
+      data_encoding=data_encoding,
+      max_labels_per_shard=max_labels_per_shard,
+    )
+
+  def to_unsharded(self):
+    return self.meta.to_unsharded()
+

--- a/cloudvolume/datasource/precomputed/skeleton/__init__.py
+++ b/cloudvolume/datasource/precomputed/skeleton/__init__.py
@@ -19,7 +19,15 @@ class PrecomputedSkeletonSource(object):
     return UnshardedPrecomputedSkeletonSource(skel_meta, cache, config, readonly)
 
   @classmethod
-  def from_cloudpath(cls, cloudpath, cache=False, progress=False):
+  def from_cloudpath(
+    cls, 
+    cloudpath:str, 
+    cache=False, 
+    progress=False,
+    secrets=None,
+    spatial_index_db:Optional[str]=None, 
+    cache_locking:bool = True,
+  ):
     config = SharedConfiguration(
       cdn_cache=False,
       compress=True,
@@ -28,8 +36,11 @@ class PrecomputedSkeletonSource(object):
       mip=0,
       parallel=1,
       progress=progress,
+      secrets=secrets,
+      spatial_index_db=spatial_index_db,
+      cache_locking=cache_locking,
     )
-
+    
     cache = CacheService(
       cloudpath=(cache if type(cache) == str else cloudpath),
       enabled=bool(cache),

--- a/cloudvolume/datasource/precomputed/skeleton/__init__.py
+++ b/cloudvolume/datasource/precomputed/skeleton/__init__.py
@@ -10,8 +10,8 @@ from ....paths import strict_extract
 from ....cloudvolume import SharedConfiguration
 
 class PrecomputedSkeletonSource(object):
-  def __new__(cls, meta, cache, config, readonly=False):
-    skel_meta = PrecomputedSkeletonMetadata(meta, cache)
+  def __new__(cls, meta, cache, config, readonly=False, info=None):
+    skel_meta = PrecomputedSkeletonMetadata(meta, cache, config, info=info)
 
     if skel_meta.is_sharded():
       return ShardedPrecomputedSkeletonSource(skel_meta, cache, config, readonly) 

--- a/cloudvolume/datasource/precomputed/skeleton/__init__.py
+++ b/cloudvolume/datasource/precomputed/skeleton/__init__.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import os
 
 from .metadata import PrecomputedSkeletonMetadata

--- a/cloudvolume/datasource/precomputed/skeleton/__init__.py
+++ b/cloudvolume/datasource/precomputed/skeleton/__init__.py
@@ -11,7 +11,7 @@ from ....cloudvolume import SharedConfiguration
 
 class PrecomputedSkeletonSource(object):
   def __new__(cls, meta, cache, config, readonly=False, info=None):
-    skel_meta = PrecomputedSkeletonMetadata(meta, cache, config, info=info)
+    skel_meta = PrecomputedSkeletonMetadata(meta, cache, config, readonly=readonly, info=info)
 
     if skel_meta.is_sharded():
       return ShardedPrecomputedSkeletonSource(skel_meta, cache, config, readonly) 

--- a/cloudvolume/datasource/precomputed/skeleton/metadata.py
+++ b/cloudvolume/datasource/precomputed/skeleton/metadata.py
@@ -12,9 +12,10 @@ import numpy as np
 SKEL_MIP_REGEXP = re.compile(r'skeletons_mip_(\d+)')
 
 class PrecomputedSkeletonMetadata(object):
-  def __init__(self, meta, cache=None, info=None):
+  def __init__(self, meta, cache=None, config=None, info=None):
     self.meta = meta
     self.cache = cache
+    self.config = config
     self._cv = None
 
     if info:

--- a/cloudvolume/datasource/precomputed/skeleton/metadata.py
+++ b/cloudvolume/datasource/precomputed/skeleton/metadata.py
@@ -199,7 +199,9 @@ class PrecomputedSkeletonMetadata(object):
   def _refresh_skeleton_interface(self):
     from cloudvolume.datasource.precomputed.skeleton import PrecomputedSkeletonSource
     if self.cv:
-      self.cv.skeleton = PrecomputedSkeletonSource(self.meta, self.cache, self.config, info=self.info)
+      skeleton_src = PrecomputedSkeletonSource(self.meta, self.cache, self.config, info=self.info)
+      skeleton_src.meta.cv = self.cv()
+      self.cv().skeleton = skeleton_src
 
   def is_sharded(self):
     if 'sharding' not in self.info:

--- a/cloudvolume/datasource/precomputed/skeleton/metadata.py
+++ b/cloudvolume/datasource/precomputed/skeleton/metadata.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import copy
 import re
 

--- a/cloudvolume/datasource/precomputed/skeleton/metadata.py
+++ b/cloudvolume/datasource/precomputed/skeleton/metadata.py
@@ -12,10 +12,11 @@ import numpy as np
 SKEL_MIP_REGEXP = re.compile(r'skeletons_mip_(\d+)')
 
 class PrecomputedSkeletonMetadata(object):
-  def __init__(self, meta, cache=None, config=None, info=None):
+  def __init__(self, meta, cache=None, config=None, info=None, readonly=False):
     self.meta = meta
     self.cache = cache
     self.config = config
+    self.readonly = readonly
     self._cv = None
 
     if info:
@@ -200,7 +201,7 @@ class PrecomputedSkeletonMetadata(object):
   def _refresh_skeleton_interface(self):
     from cloudvolume.datasource.precomputed.skeleton import PrecomputedSkeletonSource
     if self.cv:
-      skeleton_src = PrecomputedSkeletonSource(self.meta, self.cache, self.config, info=self.info)
+      skeleton_src = PrecomputedSkeletonSource(self.meta, self.cache, self.config, self.readonly, info=self.info)
       skeleton_src.meta.cv = self.cv()
       self.cv().skeleton = skeleton_src
 

--- a/cloudvolume/datasource/precomputed/skeleton/sharded.py
+++ b/cloudvolume/datasource/precomputed/skeleton/sharded.py
@@ -89,6 +89,10 @@ class ShardedPrecomputedSkeletonSource(object):
       cache_control='no-cache',      
     )
 
+  # harmonize interface with mesh sources
+  def put(self, *args, **kwargs):
+    return self.upload(*args, **kwargs)
+
   def get_bbox(self, bbox):
     if self.spatial_index is None:
       raise IndexError("A spatial index has not been created.")

--- a/cloudvolume/datasource/precomputed/skeleton/sharded.py
+++ b/cloudvolume/datasource/precomputed/skeleton/sharded.py
@@ -83,7 +83,7 @@ class ShardedPrecomputedSkeletonSource(object):
         f"Expected: {self.shard_no} Got: {', '.join(shard_files.keys())} "
       )
 
-    cf = CloudFiles(self.meta.layerpath, progress=self.progress)
+    cf = CloudFiles(self.meta.layerpath, progress=self.config.progress)
     cf.puts( 
       ( (fname, data) for fname, data in shard_files.items() ),
       compress=False,

--- a/cloudvolume/datasource/precomputed/skeleton/sharded.py
+++ b/cloudvolume/datasource/precomputed/skeleton/sharded.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 
 from ..sharding import ShardingSpecification, ShardReader, synthesize_shard_files
@@ -90,6 +92,29 @@ class ShardedPrecomputedSkeletonSource(object):
       content_type='application/octet-stream',
       cache_control='no-cache',      
     )
+
+  def to_sharded(
+    self,
+    num_labels:int,
+    shard_index_bytes:int = 2**13,
+    minishard_index_bytes:int = 2**15,
+    min_shards:int = 1,
+    minishard_index_encoding:str = 'gzip', 
+    data_encoding:str = 'gzip',
+    max_labels_per_shard:Optional[int] = None,
+  ):
+    return self.meta.to_sharded(
+      num_labels=num_labels,
+      shard_index_bytes=shard_index_bytes,
+      minishard_index_bytes=minishard_index_bytes,
+      min_shards=min_shards,
+      minishard_index_encoding=minishard_index_encoding,
+      data_encoding=data_encoding,
+      max_labels_per_shard=max_labels_per_shard,
+    )
+
+  def to_unsharded(self):
+    return self.meta.to_unsharded()
 
   # harmonize interface with mesh sources
   def put(self, *args, **kwargs):

--- a/cloudvolume/datasource/precomputed/skeleton/sharded.py
+++ b/cloudvolume/datasource/precomputed/skeleton/sharded.py
@@ -5,6 +5,8 @@ from ....skeleton import Skeleton
 from ..spatial_index import CachedSpatialIndex
 from ....exceptions import EmptyFileException
 
+from cloudfiles import CloudFiles
+
 class ShardedPrecomputedSkeletonSource(object):
   def __init__(self, meta, cache, config, readonly=False):
     self.meta = meta
@@ -81,7 +83,7 @@ class ShardedPrecomputedSkeletonSource(object):
         f"Expected: {self.shard_no} Got: {', '.join(shard_files.keys())} "
       )
 
-    cf = CloudFiles(cv.skeleton.meta.layerpath, progress=self.progress)
+    cf = CloudFiles(self.meta.layerpath, progress=self.progress)
     cf.puts( 
       ( (fname, data) for fname, data in shard_files.items() ),
       compress=False,

--- a/cloudvolume/datasource/precomputed/skeleton/unsharded.py
+++ b/cloudvolume/datasource/precomputed/skeleton/unsharded.py
@@ -109,7 +109,7 @@ class UnshardedPrecomputedSkeletonSource(object):
       vertex_types, segid=segid
     )
     return self.upload(skel)
-  
+
   @readonlyguard
   def upload(self, skeletons):
 
@@ -126,6 +126,10 @@ class UnshardedPrecomputedSkeletonSource(object):
       compress=compress, 
       cache_control=cdn_cache_control(self.config.cdn_cache)
     )
+
+  # harmonize interface with mesh sources
+  def put(self, *args, **kwargs):
+    return self.upload(*args, **kwargs)
 
   def get_bbox(self, bbox):
     if self.spatial_index is None:

--- a/cloudvolume/datasource/precomputed/skeleton/unsharded.py
+++ b/cloudvolume/datasource/precomputed/skeleton/unsharded.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import datetime
 import os
 
@@ -137,3 +139,27 @@ class UnshardedPrecomputedSkeletonSource(object):
 
     segids = self.spatial_index.query(bbox)
     return self.get(segids)
+
+  def to_sharded(
+    self,
+    num_labels:int,
+    shard_index_bytes:int = 2**13,
+    minishard_index_bytes:int = 2**15,
+    min_shards:int = 1,
+    minishard_index_encoding:str = 'gzip', 
+    data_encoding:str = 'gzip',
+    max_labels_per_shard:Optional[int] = None,
+  ):
+    return self.meta.to_sharded(
+      num_labels=num_labels,
+      shard_index_bytes=shard_index_bytes,
+      minishard_index_bytes=minishard_index_bytes,
+      min_shards=min_shards,
+      minishard_index_encoding=minishard_index_encoding,
+      data_encoding=data_encoding,
+      max_labels_per_shard=max_labels_per_shard,
+    )
+
+  def to_unsharded(self):
+    return self.meta.to_unsharded()
+

--- a/test/test_sharding.py
+++ b/test/test_sharding.py
@@ -1,16 +1,30 @@
 import pytest
 
+import operator
+from functools import reduce
+
 from cloudvolume import CloudVolume, Skeleton
 from cloudvolume.storage import SimpleStorage
-from cloudvolume.datasource.precomputed.image.common import compressed_morton_code
-from cloudvolume.datasource.precomputed.sharding import ShardingSpecification
+from cloudvolume.datasource.precomputed.image.common import (
+  gridpoints, compressed_morton_code
+)
+from cloudvolume.datasource.precomputed.sharding import (
+  ShardingSpecification, 
+  ShardReader,
+  compute_shard_params_for_hashed,
+  compute_shard_params_for_image,
+  image_shard_shape_from_spec,
+)
 from cloudvolume.exceptions import SpecViolation, EmptyVolumeException
 
-from cloudvolume import Vec
+from cloudvolume import Vec, lib, Bbox
 from cloudvolume import exceptions
 from layer_harness import delete_layer, create_layer
 
 import numpy as np
+
+def prod(x):
+  return reduce(operator.mul, x, 1)
 
 def test_actual_example_hash():
   spec = ShardingSpecification.from_dict({
@@ -337,4 +351,173 @@ def test_write_image_shard_partly_empty(delete_black_uploads, background_color):
 
   assert np.all(data == sharded_data)
 
+SCALES = [
+  {
+    'chunk_sizes': [[128, 128, 64]],
+    'encoding': 'jpeg',
+    'key': '48_48_30',
+    'resolution': [48, 48, 30],
+    'size': [1536, 1408, 2046],
+    'voxel_offset': [0, 0, 0]
+  },
+  {
+    'chunk_sizes': [[128, 128, 64]],
+    'encoding': 'jpeg',
+    'key': '24_24_30',
+    'resolution': [24, 24, 30],
+    'size': [3072, 2816, 2046],
+    'voxel_offset': [0, 0, 0]
+  },
+  {
+    'chunk_sizes': [[128, 128, 20]],
+    'encoding': 'raw',
+    'key': '4_4_40',
+    'resolution': [4, 4, 40],
+    'size': [40960, 40960, 990],
+    'voxel_offset': [69632, 36864, 4855],
+  },
+]
+
+@pytest.mark.parametrize("scale", SCALES)
+def test_sharded_image_bits(scale):
+  dataset_size = Vec(*scale["size"])
+  chunk_size = Vec(*scale["chunk_sizes"][0])
+
+  spec = compute_shard_params_for_image( 
+    dataset_size=dataset_size,
+    chunk_size=chunk_size,
+    encoding=scale["encoding"],
+    dtype=np.uint8
+  )
+
+  shape = image_shard_shape_from_spec(
+    spec.to_dict(), dataset_size, chunk_size
+  )
+
+  shape = lib.min2(shape, dataset_size)
+  dataset_bbox = Bbox.from_vec(dataset_size)
+  gpts = list(gridpoints(dataset_bbox, dataset_bbox, chunk_size))
+  grid_size = np.ceil(dataset_size / chunk_size).astype(np.int64)
+
+  reader = ShardReader(None, None, spec)
+
+  morton_codes = compressed_morton_code(gpts, grid_size)
+  min_num_shards = prod(dataset_size / shape)
+  max_num_shards = prod(np.ceil(dataset_size / shape))
+  
+  assert 0 < min_num_shards <= 2 ** spec.shard_bits
+  assert 0 < max_num_shards <= 2 ** spec.shard_bits
+
+  real_num_shards = len(set(map(reader.get_filename, morton_codes)))
+
+  assert min_num_shards <= real_num_shards <= max_num_shards
+
+def test_broken_dataset():
+  """
+  This dataset was previously returning 19 total bits
+  when 20 were needed to cover all the morton codes.
+  """
+  scale = {
+    'chunk_sizes': [[128, 128, 20]],
+    'encoding': 'raw',
+    'key': '16_16_40',
+    'resolution': [16, 16, 40],
+    'size': [10240,10240,990],
+    'voxel_offset': [17408,9216,4855],
+  }
+
+  dataset_size = Vec(*scale["size"])
+  chunk_size = Vec(*scale["chunk_sizes"][0])
+
+  spec = compute_shard_params_for_image( 
+    dataset_size=dataset_size,
+    chunk_size=chunk_size,
+    encoding="jpeg",
+    dtype=np.uint8
+  )
+  total_bits = spec.shard_bits + spec.minishard_bits + spec.preshift_bits
+  assert total_bits == 20
+
+def test_shard_bits_calculation_for_hashed():
+  sb, msb, psb = compute_shard_params_for_hashed(
+    num_labels=10**9, 
+    shard_index_bytes=2**13, 
+    minishard_index_bytes=2**15
+  )
+  assert psb == 0
+  assert msb == 9
+  assert sb == 11
+
+  sb, msb, psb = compute_shard_params_for_hashed(
+    num_labels=10**6, 
+    shard_index_bytes=2**13, 
+    minishard_index_bytes=2**15
+  )
+  assert psb == 0
+  assert msb == 9
+  assert sb == 1
+
+  sb, msb, psb = compute_shard_params_for_hashed(
+    num_labels=10**7, 
+    shard_index_bytes=2**13, 
+    minishard_index_bytes=2**15
+  )
+  assert psb == 0
+  assert msb == 9
+  assert sb == 4
+
+  sb, msb, psb = compute_shard_params_for_hashed(
+    num_labels=1000, 
+    shard_index_bytes=2**13, 
+    minishard_index_bytes=2**15
+  )
+  assert psb == 0
+  assert msb == 0
+  assert sb == 0
+
+  sb, msb, psb = compute_shard_params_for_hashed(
+    num_labels=1000, 
+    shard_index_bytes=2**13, 
+    minishard_index_bytes=2**15,
+    min_shards=1000,
+  )
+  assert psb == 0
+  assert msb == 0
+  assert sb == 10
+
+  sb, msb, psb = compute_shard_params_for_hashed(
+    num_labels=0, 
+    shard_index_bytes=0, 
+    minishard_index_bytes=0
+  )
+  assert psb == 0
+  assert msb == 0
+  assert sb == 0
+
+  sb, msb, psb = compute_shard_params_for_hashed(
+    num_labels=10000, 
+    shard_index_bytes=2**13, 
+    minishard_index_bytes=2**15
+  )
+  assert psb == 0
+  assert msb == 3
+  assert sb == 0
+
+  sb, msb, psb = compute_shard_params_for_hashed(
+    num_labels=10**9, 
+    shard_index_bytes=2**10, 
+    minishard_index_bytes=2**15
+  )
+  assert psb == 0
+  assert msb == 6
+  assert sb == 14
+
+  sb, msb, psb = compute_shard_params_for_hashed(
+    num_labels=10**9, 
+    shard_index_bytes=2**13, 
+    minishard_index_bytes=2**13
+  )
+  assert psb == 0
+  assert msb == 9
+  assert sb == 13
 

--- a/test/test_sharding.py
+++ b/test/test_sharding.py
@@ -266,6 +266,20 @@ def test_skeleton_shard_unshard():
   cv.skeleton.to_sharded(num_labels=1000)
   assert cv.skeleton.meta.is_sharded()
 
+def test_mesh_shard_unshard():
+  cv = CloudVolume('gs://seunglab-test/sharded')
+  
+  cv.mesh.to_unsharded()
+  assert not cv.mesh.meta.is_sharded()
+  cv.mesh.to_unsharded()
+  assert not cv.mesh.meta.is_sharded()
+
+  cv.mesh.to_sharded(num_labels=1000)
+
+  assert cv.mesh.meta.is_sharded()
+  cv.mesh.to_sharded(num_labels=1000)
+  assert cv.mesh.meta.is_sharded()
+
 def test_image_fidelity():
   point = (142195, 64376, 3130)
   cv = CloudVolume('gs://seunglab-test/sharded')


### PR DESCRIPTION
Adds logic for doing simple shard uploads for skeletons and adds logic for adding sharding specifications for images, meshes, and skeletons.

The shard specification logic is imported from Igneous.

```
N = 10000000
cv.image.to_sharded()
cv.mesh.to_sharded(num_labels=N)
cv.skeleton.to_sharded(num_labels=N)
cv.commit_info()
```