### PR TITLE
Fix Bbox docstring, add example

### DIFF
--- a/cloudvolume/lib.py
+++ b/cloudvolume/lib.py
@@ -331,8 +331,11 @@ FILENAME_RE = re.compile(fr'{FLT_RE}-{FLT_RE}_{FLT_RE}-{FLT_RE}_{FLT_RE}-{FLT_RE
 class Bbox(object):
   __slots__ = [ 'minpt', 'maxpt', '_dtype' ]
 
-  """Represents a three dimensional cuboid in space."""
   def __init__(self, a, b, dtype=None):
+    """
+    Represents a three dimensional cuboid in space. 
+    Ex: `bbox = Bbox((xmin, ymin, zmin), (xmax, ymax, zmax))`
+    """
     if dtype is None:
       if floating(a) or floating(b):
         dtype = np.float32


### PR DESCRIPTION
This puts the docstring for Bbox in the right place so IDEs can display it, and adds a basic example

Before:
<img width="457" alt="Screenshot 2024-06-13 at 3 47 58 PM" src="https://github.com/seung-lab/cloud-volume/assets/4590343/83b41c51-a7b7-4564-b465-83103481da50">

After:
<img width="457" alt="Screenshot 2024-06-13 at 3 47 38 PM" src="https://github.com/seung-lab/cloud-volume/assets/4590343/c2e05536-779a-45bd-8c95-d065379fa2d3">
