### PR TITLE
feat: Add "unit" to Bbox + accept physical Bbox in CV image functions

### DIFF
--- a/cloudvolume/datasource/precomputed/metadata.py
+++ b/cloudvolume/datasource/precomputed/metadata.py
@@ -118,6 +118,8 @@ class PrecomputedMetadata(object):
     if precision == 0:
       res_dtype = int
 
+    resolution = np.asarray(resolution, dtype=res_dtype)
+
     info = {
       "num_channels": int(num_channels),
       "type": layer_type,

--- a/cloudvolume/lib.py
+++ b/cloudvolume/lib.py
@@ -371,7 +371,7 @@ class Bbox(object):
     self, unit, 
     resolution=[1,1,1], resolution_unit="nm"
   ):
-    f"""
+    """
     Convert the units of this bounding box either 
     from voxels to physical units (e.g. nanometers) or
     vice-versa, or convert between differing physical 
@@ -383,7 +383,8 @@ class Bbox(object):
     the resolution is ignored.
 
     Allowed Units:
-      vx, {",".join(UNIT_SCALES.keys())}
+      dimensionless: vx (means voxels)
+      physical: pm, nm, um, mm, m, km, Mm, Gm, Tm
     """
     if self.unit == "vx" and unit == "vx":
       return self.clone()

--- a/cloudvolume/lib.py
+++ b/cloudvolume/lib.py
@@ -328,13 +328,32 @@ def floating(lst):
 FLT_RE = r'(-?\d+(?:\.\d+)?)' # floating point regexp
 FILENAME_RE = re.compile(fr'{FLT_RE}-{FLT_RE}_{FLT_RE}-{FLT_RE}_{FLT_RE}-{FLT_RE}(?:\.gz|\.br|\.zstd)?$')
 
-class Bbox(object):
-  __slots__ = [ 'minpt', 'maxpt', '_dtype' ]
+UNIT_SCALES = {
+  "pm": 1e-12,
+  "nm": 1e-9,
+  "um": 1e-6,
+  "mm": 1e-3,
+  "m": 1.0,
+  "km": 1e3,
+  "Mm": 1e6,
+  "Gm": 1e9,
+  "Tm": 1e12,
+}
 
-  def __init__(self, a, b, dtype=None):
+class Bbox(object):
+  __slots__ = [ 'minpt', 'maxpt', '_dtype', 'unit' ]
+
+  def __init__(self, a, b, dtype=None, unit='vx'):
     """
     Represents a three dimensional cuboid in space. 
     Ex: `bbox = Bbox((xmin, ymin, zmin), (xmax, ymax, zmax))`
+
+    Example Units:
+      vx: voxels
+      nm: nanometers
+      um: micrometers
+      mm: millimeters
+      m: meters
     """
     if dtype is None:
       if floating(a) or floating(b):
@@ -346,6 +365,53 @@ class Bbox(object):
     self.maxpt = Vec(*[ max(ai,bi) for ai,bi in zip(a,b) ], dtype=dtype)
 
     self._dtype = np.dtype(dtype)
+    self.unit = unit
+
+  def convert_units(
+    self, unit, 
+    resolution=[1,1,1], resolution_unit="nm"
+  ):
+    f"""
+    Convert the units of this bounding box either 
+    from voxels to physical units (e.g. nanometers) or
+    vice-versa, or convert between differing physical 
+    scales such as um to nm.
+
+    To convert either way between voxels ("vx") and 
+    a physical dimension, you must provide a resolution.
+    For voxel to voxel or physical units to physical units,
+    the resolution is ignored.
+
+    Allowed Units:
+      vx, {",".join(UNIT_SCALES.keys())}
+    """
+    if self.unit == "vx" and unit == "vx":
+      return self.clone()
+    elif self.unit == "vx" and unit != "vx":
+      bbx = self.clone()
+      bbx *= np.array(resolution)
+      bbx.unit = unit
+      return bbx
+    elif self.unit != "vx" and unit == "vx":
+      bbx = self.clone()
+      bbx *= np.round(UNIT_SCALES[resolution_unit] / UNIT_SCALES[self.unit])
+      bbx //= np.array(resolution) 
+      bbx.unit = unit
+      return bbx
+    else:
+      bbx = self.astype(np.float32)
+      scale_factor = UNIT_SCALES[unit] / UNIT_SCALES[self.unit]
+      bbx /= scale_factor
+      bbx.unit = unit
+
+      if scale_factor > 0:
+        return bbx
+      else:
+        return bbx.astype(self.dtype)
+
+  @property
+  def is_physical(self):
+    return self.unit != 'vx'
 
   @classmethod
   def deserialize(cls, bbx_data):
@@ -801,7 +867,7 @@ class Bbox(object):
     )
 
   def clone(self):
-    return Bbox(self.minpt, self.maxpt, dtype=self.dtype)
+    return Bbox(self.minpt, self.maxpt, dtype=self.dtype, unit=self.unit)
 
   def astype(self, typ):
     tmp = self.clone()
@@ -907,13 +973,13 @@ class Bbox(object):
     return not (self == other)
 
   def __eq__(self, other):
-    return np.array_equal(self.minpt, other.minpt) and np.array_equal(self.maxpt, other.maxpt)
+    return np.array_equal(self.minpt, other.minpt) and np.array_equal(self.maxpt, other.maxpt) and self.unit == other.unit
 
   def __hash__(self):
     return int(''.join(map(str, map(int, self.to_list()))))
 
   def __repr__(self):
-    return f"Bbox({list(self.minpt)},{list(self.maxpt)}, dtype={self.dtype})"
+    return f"Bbox({list(self.minpt)},{list(self.maxpt)}, dtype=np.{self.dtype}, unit='{self.unit}')"
 
 BboxLikeType = Union[Bbox, Sequence[slice], str, Vec]
 

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -1517,8 +1517,8 @@ def test_transfer():
 
   dcv.image.delete(dcv.bounds)
 
-  with pytest.raises(ValueError):
-    dcv.image.transfer_to("n5://s3://hello-world.", dcv.bounds, 0)
+  with pytest.raises(Exception):
+    dcv.image.transfer_to("n5://file:///tmp/removeme/n5transfer.", dcv.bounds, 0)
 
 
 def test_cdn_cache_control():

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -289,6 +289,24 @@ def test_bbox_to_filename():
 
   assert bbx.to_filename(3) == "1.100-2.000_3.200-4.000_5.490-6.124"
 
+def test_bbox_convert_units():
+  bbx = Bbox([0,0,0], [1,1,1])
+  nm_bbx = bbx.convert_units('nm', [4,4,40])
+  assert nm_bbx == Bbox([0,0,0], [4, 4, 40], dtype=int, unit="nm")
+  um_bbx = nm_bbx.convert_units('um')
+  assert um_bbx == Bbox([0,0,0], [0.004, 0.004, 0.04], dtype=np.float32, unit="um")
+
+  nm_bbx = um_bbx.convert_units("nm")
+  assert nm_bbx == Bbox([0,0,0], [4,4,40], dtype=int, unit="nm")
+
+  mm_bbx = um_bbx.convert_units("mm")
+  assert mm_bbx == Bbox([0,0,0], [4e-6,4e-6,4e-5], dtype=np.float32, unit="mm")
+
+  vx_bbx = nm_bbx.convert_units('vx', [4,4,40])
+  assert vx_bbx == bbx
+
+  vx_bbx2 = vx_bbx.convert_units('vx', [4,4,40])
+  assert vx_bbx == vx_bbx2
 
 
 


### PR DESCRIPTION
This PR adds `unit='vx'` as a parameter to the Bbox class.

Supported units: vx (voxels), pm (picometers), nm (nanometers), um (micrometers), ...etc

The default unit Neuroglancer works in is nanometers so nm is the default assumption when physical units are used. vx is the default unit for Bbox.

```python
from cloudvolume import Bbox

Bbox([0,0,0], [1,1,1], unit='vx')
Bbox([0,0,0], [1,1,1], unit='nm')
Bbox([0,0,0], [1,1,1], unit='um')

bbox = Bbox.from_delta([106820, 84304, 21360], 512) # units "vx" by default
print(bbox)
>>> Bbox([106820, 84304, 21360],[107332, 84816, 21872], dtype=np.int32, unit='vx')

# resolution units are nm by default
physical_bbox = bbox.convert_units("nm", resolution=[8,8,40], resolution_units="nm") 
print(physical_bbox)
>>> Bbox([854560, 674432, 854400],[858656, 678528, 874880], dtype=np.int64, unit='nm')

cv = CloudVolume(..., mip=2)
image = cv[physical_bbox] # works for any mip
```


