### PR TITLE
Fix Callable type annotation

### DIFF
--- a/cloudvolume/chunks.py
+++ b/cloudvolume/chunks.py
@@ -453,7 +453,7 @@ def transcode(
   ], 
   src_encoding:str, 
   dest_encoding:str,
-  chunk_size_fn:Callable[Union[str,int], ShapeType],
+  chunk_size_fn:Callable[[Union[str,int]], ShapeType],
   dtype:Union[str,np.dtype],
   background_color:int = 0,
   progress:bool = False,


### PR DESCRIPTION
On Python versions <3.9, the first argument must be a list. Later versions of Python automatically coerce the arguments to work, but this maintains compatibility with old versions of python.

Fixes #622 .