### PR TITLE
Fixes for lib.save_image

### DIFF
--- a/cloudvolume/lib.py
+++ b/cloudvolume/lib.py
@@ -1065,7 +1065,7 @@ def save_images(
 
       if img2d.dtype == np.uint8:
         img2d = Image.fromarray(img2d, 'L')
-      elif img2d.dtype == np.bool:
+      elif img2d.dtype == bool:
         img2d = img2d.astype(np.uint8) * 255
         img2d = Image.fromarray(img2d, 'L')
       else:

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setuptools.setup(
       "codecov",
       "requests_mock",
       "scipy",
+      "pillow",
     ],
   },
   author="William Silversmith, Nico Kemnitz, Ignacio Tartavull, and others",


### PR DESCRIPTION
This is meant to fix two issues with lib.save_image:
1. The function requires the pillow library, but it's not included in requirements.txt.
2. There's a check if the image is np.bool that throws an error with the latest versions of numpy (I think the [np.bool alias expired with 1.24](https://numpy.org/doc/stable/release/1.24.0-notes.html)), causing an error when writing any dtype other than uint8.