### PR TITLE
feat+perf: allow specifying LRU encoding type

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,10 @@ vol.image.lru.clear()
 len(vol.image.lru) # number of items in lru
 vol.image.lru.nbytes # size in bytes (not counting LRU structures, nor recursive)
 vol.image.lru.items() # etc, also functions as a dict
+# Can use more memory, but generally faster access to LRU cache
+# You can set the encoding to anything valid for this image type
+# to e.g. save space and/or accelerate certain query types.
+vol = CloudVolume(..., lru_bytes=num_bytes, lru_encoding='raw') 
 
 # Evaluating the on-disk Cache
 vol.cache.list() # list files in cache at this mip level

--- a/cloudvolume/chunks.py
+++ b/cloudvolume/chunks.py
@@ -148,6 +148,8 @@ def decode(
       return np.zeros(shape=shape, dtype=dtype, order="F")
     else:
       return np.full(shape=shape, fill_value=background_color, dtype=dtype, order="F")
+  elif isinstance(filedata, np.ndarray):
+    return filedata
   elif encoding == "raw":
     return decode_raw(filedata, shape=shape, dtype=dtype)
   elif encoding == "kempressed":
@@ -360,6 +362,8 @@ def labels(
 
   if filedata is None or len(filedata) == 0:
     return np.zeros((0,), dtype=dtype)
+  elif isinstance(filedata, np.ndarray):
+    return fastremap.unique(filedata)
   elif encoding == "raw":
     img = decode(filedata, encoding, shape, dtype, block_size, background_color)
     return fastremap.unique(img)
@@ -395,6 +399,9 @@ def remap(
     return compresso.remap(filedata, mapping, preserve_missing_labels=preserve_missing_labels)
   elif encoding == "crackle":
     return crackle.remap(filedata, mapping, preserve_missing_labels=preserve_missing_labels)
+  elif isinstance(filedata, np.ndarray):
+    img = fastremap.remap(filedata, mapping, preserve_missing_labels=preserve_missing_labels, in_place=False)
+    return encode(img, encoding, block_size)    
   else:
     img = decode(filedata, encoding, shape, dtype, block_size)
     fastremap.remap(img, mapping, preserve_missing_labels=preserve_missing_labels, in_place=True)
@@ -428,6 +435,8 @@ def read_voxel(
     out = np.empty((1,1,1,1), dtype=dtype, order="F")
     out[0,0,0,0] = arr[tuple(xyz)]
     return out
+  elif isinstance(filedata, np.ndarray):
+    return filedata[tuple(xyz)][:, np.newaxis, np.newaxis, np.newaxis]
   else:
     img = decode(filedata, encoding, shape, dtype, block_size, background_color)
     return img[tuple(xyz)][:, np.newaxis, np.newaxis, np.newaxis]
@@ -453,6 +462,8 @@ def contains(
   elif encoding == "crackle":
     arr = crackle.CrackleArray(filedata)
     return label in arr
+  elif isinstance(filedata, np.ndarray):
+    return bool(np.isin(label, filedata))
   else:
     arr = decode(filedata, encoding, shape, dtype, block_size, 0)
     return bool(np.isin(label, arr))

--- a/cloudvolume/cloudvolume.py
+++ b/cloudvolume/cloudvolume.py
@@ -70,7 +70,7 @@ class CloudVolume:
     max_redirects:int=10, mesh_dir:Optional[str]=None, skel_dir:Optional[str]=None, 
     agglomerate:bool=False, secrets:SecretsType=None, 
     spatial_index_db:Optional[str]=None, lru_bytes:int = 0,
-    cache_locking:bool = True
+    cache_locking:bool = True, lru_encoding:str = "same",
   ):
     """
     A "serverless" Python client for reading and writing arbitrarily large 
@@ -179,6 +179,12 @@ class CloudVolume:
         tiles in memory. This is an in-memory cache and is completely separate from
         the `cache` parameter that handles disk IO. Tiles are stripped over only their
         second stage compression.
+      lru_encoding: (str) You can set the LRU encoding to be different from the source
+        encoding. This can help reduce the memory usage of the LRU or take advantage of
+        special codec properties. "same" means use the same encoding as the source.
+        Using "raw" will speed up the LRU at the expense of memory if the source encoding is 
+        not raw. Using a different encoding than the source encoding, other than "raw", will
+        initially be slower as chunks will need to be reencoded.
       info: (dict) In lieu of fetching a neuroglancer info file, use this one.
           This is useful when creating new datasets and for repeatedly initializing
           a new cloudvolume instance.

--- a/cloudvolume/datasource/precomputed/__init__.py
+++ b/cloudvolume/datasource/precomputed/__init__.py
@@ -27,7 +27,7 @@ def create_precomputed(
     green_threads:bool=False, use_https:bool=False,
     max_redirects:int=10, mesh_dir:Optional[str]=None, skel_dir:Optional[str]=None,
     secrets:SecretsType=None, spatial_index_db:Optional[str]=None, 
-    lru_bytes:int = 0, cache_locking:bool = True,
+    lru_bytes:int = 0, cache_locking:bool = True, lru_encoding:str = "same",
     **kwargs # absorb graphene arguments
   ):
     path = strict_extract(cloudpath)
@@ -97,6 +97,7 @@ def create_precomputed(
       background_color=background_color,
       readonly=readonly,
       lru_bytes=lru_bytes,
+      lru_encoding=lru_encoding,
     )
 
     mesh = PrecomputedMeshSource(meta, cache_service, config, readonly)

--- a/cloudvolume/datasource/precomputed/image/__init__.py
+++ b/cloudvolume/datasource/precomputed/image/__init__.py
@@ -310,7 +310,10 @@ class PrecomputedImageSource(ImageSourceInterface):
       spec = sharding.ShardingSpecification.from_dict(scale['sharding'])
       return rx.unique_sharded(
         bbox, mip, 
-        self.meta, self.cache, self.lru, spec,
+        self.meta, self.cache, 
+        lru=self.lru, 
+        lru_encoding=self._lru_encoding,
+        spec=spec,
         compress=self.config.compress,
         progress=self.config.progress,
         fill_missing=self.fill_missing,
@@ -322,6 +325,7 @@ class PrecomputedImageSource(ImageSourceInterface):
         meta=self.meta,
         cache=self.cache,
         lru=self.lru,
+        lru_encoding=self._lru_encoding,
         parallel=1,
         fill_missing=self.fill_missing,
         progress=self.config.progress,

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -478,7 +478,7 @@ def repopulate_lru_from_shm(
       meta.compressed_segmentation_block_size(mip),
       compression_params=meta.compression_params(mip),
     )
-    lru[chunkname] = ("raw", binary)
+    lru[chunkname] = (encoding, binary)
 
 def child_process_download(
     meta, cache, 

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -467,7 +467,14 @@ def repopulate_lru_from_shm(
 
   encoding = lru_encoding
   if encoding == "same":
-    encoding = meta.encoding(mip)
+    # Since the parallel version populates the LRU via an image and
+    # you don't get the benefit of accessing the raw downloaded bytes,
+    # there will be a performance regression for "same" since e.g.
+    # jpeg -> img -> jpeg will instead of decode -> img,lru you'll
+    # have decode -> img -> encode -> lru. Therefore, this is hacky,
+    # but backwards compatible and strictly expands the capabilities
+    # of the LRU.
+    encoding = "raw" # would ordinarily be: meta.encoding(mip)
 
   for chunkname in core_chunks[-lru.size:]:
     bbx = Bbox.from_filename(chunkname)

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -185,7 +185,8 @@ def download_raw_unsharded(
   def noop_decode(
     meta, input_bbox, 
     content, fill_missing, 
-    mip, background_color=0
+    mip, background_color=0,
+    encoding=None,
   ):
     return content
 

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -505,7 +505,7 @@ def child_process_download(
       progress_queue.put(1)
 
   download_chunks_threaded(
-    meta, cache, None, mip, cloudpaths,
+    meta, cache, None, "same", mip, cloudpaths,
     fn=process, decode_fn=decode, fill_missing=fill_missing,
     progress=False, compress_cache=compress_cache,
     green=green, secrets=secrets, background_color=background_color
@@ -811,7 +811,7 @@ def _decode_helper(
 
 def unique_unsharded(
   requested_bbox, mip, 
-  meta, cache, lru,
+  meta, cache, lru, lru_encoding,
   fill_missing, progress,
   parallel,
   compress, 
@@ -875,7 +875,7 @@ def unique_unsharded(
     shell_chunks.sort(key=lambda fname: fname in lru, reverse=True)
 
   download_chunks_threaded(
-    meta, cache, lru, mip, core_chunks, 
+    meta, cache, lru, lru_encoding, mip, core_chunks, 
     fn=process_core, decode_fn=decode_unique, fill_missing=fill_missing,
     progress=progress, compress_cache=compress_cache, 
     green=green, secrets=secrets, background_color=background_color,
@@ -884,7 +884,7 @@ def unique_unsharded(
 
   if len(shell_chunks) > 0:
     download_chunks_threaded(
-      meta, cache, lru, mip, shell_chunks, 
+      meta, cache, lru, lru_encoding, mip, shell_chunks, 
       fn=process_shell, decode_fn=decode, fill_missing=fill_missing,
       progress=progress, compress_cache=compress_cache, 
       green=green, secrets=secrets, background_color=background_color,
@@ -895,7 +895,8 @@ def unique_unsharded(
 
 def unique_sharded(
   requested_bbox, mip,
-  meta, cache, lru, spec,
+  meta, cache, 
+  lru, lru_encoding, spec,
   compress, progress,
   fill_missing, background_color
 ):

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -191,7 +191,7 @@ def download_raw_unsharded(
 
   download_chunks_threaded(
     meta, cache, 
-    lru=None, mip=mip, cloudpaths=cloudpaths, 
+    lru=None, lru_encoding="same", mip=mip, cloudpaths=cloudpaths, 
     fn=store_result, decode_fn=noop_decode, fill_missing=fill_missing,
     progress=progress, compress_cache=compress_cache, 
     green=green, secrets=secrets, background_color=background_color,

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -569,7 +569,7 @@ def download_chunk(
   )
   
   if lru is not None and full_decode: 
-    if lru_encoding not in [ "same", meta.encoding(mip) ]:
+    if lru_encoding not in [ "same", encoding ]:
       content = chunks.encode(
         img3d, lru_encoding, 
         meta.compressed_segmentation_block_size(mip),

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -39,7 +39,7 @@ fs_lock = None # defined in common.initialize_synchronization
 
 def download_sharded(
   requested_bbox, mip,
-  meta, cache, lru, spec,
+  meta, cache, lru, lru_encoding, spec,
   compress, progress,
   fill_missing, 
   order, background_color,
@@ -194,14 +194,15 @@ def download_raw_unsharded(
     lru=None, mip=mip, cloudpaths=cloudpaths, 
     fn=store_result, decode_fn=noop_decode, fill_missing=fill_missing,
     progress=progress, compress_cache=compress_cache, 
-    green=green, secrets=secrets, background_color=background_color
+    green=green, secrets=secrets, background_color=background_color,
+    full_decode=True,
   )
 
   return results
 
 def download(
   requested_bbox, mip, 
-  meta, cache, lru,
+  meta, cache, lru, lru_encoding,
   fill_missing, progress,
   parallel, location, 
   retain, use_shared_memory, 
@@ -249,7 +250,7 @@ def download(
 
   if requested_bbox.volume() == 1:
     return download_single_voxel_unsharded(
-      meta, cache, lru,
+      meta, cache, lru, lru_encoding,
       requested_bbox, first(cloudpaths), 
       mip, fill_missing, compress_cache,
       secrets, renumber, background_color,
@@ -308,15 +309,16 @@ def download(
       fn = process_renumber  
 
     download_chunks_threaded(
-      meta, cache, lru, mip, cloudpaths, 
+      meta, cache, lru, lru_encoding, mip, cloudpaths, 
       fn=fn, decode_fn=decode_fn, fill_missing=fill_missing,
       progress=progress, compress_cache=compress_cache, 
-      green=green, secrets=secrets, background_color=background_color
+      green=green, secrets=secrets, background_color=background_color,
+      full_decode=True,
     )
   else:
     handle, renderbuffer = multiprocess_download(
       requested_bbox, mip, cloudpaths,
-      meta, cache, lru, compress_cache,
+      meta, cache, lru, lru_encoding, compress_cache,
       fill_missing, progress,
       parallel, location, retain, 
       use_shared_memory=(use_file == False),
@@ -335,7 +337,7 @@ def download(
   return out
 
 def download_single_voxel_unsharded(
-  meta, cache, lru,
+  meta, cache, lru, lru_encoding,
   requested_bbox, filename, 
   mip, fill_missing, compress_cache,
   secrets, renumber, background_color,
@@ -362,13 +364,13 @@ def download_single_voxel_unsharded(
   else:
     chunk_bbx = Bbox.from_filename(filename)
     label, _ = download_chunk(
-      meta, cache, lru,
+      meta, cache, lru, lru_encoding,
       cloudpath, mip,
       filename, fill_missing,
       cache_enabled, compress_cache,
       secrets, background_color,
       partial(decode_single_voxel, requested_bbox.minpt - chunk_bbx.minpt),
-      decompress=True, locking=locking
+      decompress=True, locking=locking, full_decode=False,
     )
 
   if segid is not None:
@@ -387,7 +389,7 @@ def download_single_voxel_unsharded(
 
 def multiprocess_download(
     requested_bbox, mip, cloudpaths,
-    meta, cache, lru, compress_cache,
+    meta, cache, lru, lru_encoding, compress_cache,
     fill_missing, progress,
     parallel, location, 
     retain, use_shared_memory, order,
@@ -428,7 +430,7 @@ def multiprocess_download(
     )
 
   if meta.encoding(mip) == "raw":
-    repopulate_lru_from_shm(meta, mip, lru, renderbuffer, requested_bbox)
+    repopulate_lru_from_shm(meta, mip, lru, lru_encoding, renderbuffer, requested_bbox)
 
   if not retain:
     if use_shared_memory:
@@ -439,7 +441,7 @@ def multiprocess_download(
   return mmap_handle, renderbuffer
 
 def repopulate_lru_from_shm(
-  meta, mip, lru, 
+  meta, mip, lru, lru_encoding,
   renderbuffer, requested_bbox
 ):
   """
@@ -514,16 +516,25 @@ def child_process_download(
   return len(cloudpaths)
 
 def download_chunk(
-  meta, cache, lru,
+  meta, cache, lru, lru_encoding,
   cloudpath, mip,
   filename, fill_missing,
   enable_cache, compress_cache,
   secrets, background_color,
-  decode_fn, decompress=True, locking=False
+  decode_fn, decompress=True, locking=False,
+  full_decode=True,
 ):
   content = None
+  encoding = meta.encoding(mip)
+  bbox = Bbox.from_filename(filename) # possible off by one error w/ exclusive bounds
+
   try:
-    content = lru[filename]
+    encoding, content = lru[filename]
+    if isinstance(content, np.ndarray):
+      if full_decode:
+        return content, bbox
+      else:
+        encoding = "raw"
   except (TypeError, KeyError):
     (file,) = CloudFiles(
       cloudpath, secrets=secrets, locking=locking
@@ -540,7 +551,7 @@ def download_chunk(
       cache.cloudfiles().put(
         path=filename, 
         content=(cache_content or b''), 
-        content_type=content_type(meta.encoding(mip)), 
+        content_type=content_type(encoding), 
         compress=compress_cache,
         raw=bool(cache_content),
       )
@@ -553,18 +564,28 @@ def download_chunk(
       content = compression.decompress(content, file['compress'])
 
     if lru is not None:
-      lru[filename] = content
+      lru[filename] = (encoding, content)
 
-  bbox = Bbox.from_filename(filename) # possible off by one error w/ exclusive bounds
-  img3d = decode_fn(meta, filename, content, fill_missing, mip, 
-                       background_color=background_color)
+  img3d = decode_fn(
+    meta, filename, content, 
+    fill_missing, mip, 
+    background_color=background_color,
+    encoding=encoding,
+  )
+  
+  if lru is not None and full_decode: 
+    if lru_encoding == "raw" or (lru_encoding == "same" and meta.encoding(mip) == "raw"):
+      lru[filename] = ("raw", img3d)
+    elif lru_encoding not in [ "same", meta.encoding(mip) ]:
+      lru[filename] = (lru_encoding, chunks.encode(img3d, lru_encoding))
+
   return img3d, bbox
 
 def download_chunks_threaded(
-    meta, cache, lru, mip, cloudpaths, fn, decode_fn,
+    meta, cache, lru, lru_encoding, mip, cloudpaths, fn, decode_fn,
     fill_missing, progress, compress_cache,
     green=False, secrets=None, background_color=0,
-    decompress=True,
+    decompress=True, full_decode=True,
   ):
   """fn is the postprocess callback. decode_fn is a decode fn."""
   locations = cache.compute_data_locations(cloudpaths)
@@ -572,11 +593,11 @@ def download_chunks_threaded(
 
   def process(cloudpath, filename, enable_cache, locking):
     labels, bbox = download_chunk(
-      meta, cache, lru, cloudpath, mip,
+      meta, cache, lru, lru_encoding, cloudpath, mip,
       filename, fill_missing,
       enable_cache, compress_cache,
       secrets, background_color,
-      decode_fn, decompress, locking
+      decode_fn, decompress, locking, full_decode,
     )
     fn(labels, bbox)
 
@@ -629,6 +650,7 @@ def decode(
   content, fill_missing, 
   mip, background_color=0,
   allow_none=True,
+  encoding=None,
 ):
   """
   Decode content from bytes into a numpy array using the 
@@ -645,7 +667,7 @@ def decode(
     meta, input_bbox, 
     content, fill_missing, 
     mip, background_color,
-    allow_none,
+    allow_none, encoding,
   )
 
 def decode_binary_image(
@@ -653,6 +675,7 @@ def decode_binary_image(
   content, fill_missing, 
   mip, background_color=0, 
   allow_none=True,
+  encoding=None,
 ):
   bbox = Bbox.create(input_bbox)
   shape = list(bbox.size3()) + [ meta.num_channels ]
@@ -693,12 +716,14 @@ def decode_binary_image(
     mip, 
     background_color=background_color,
     allow_none=allow_none,
+    encoding=encoding,
   )
 
 def decode_unique(
   meta, input_bbox, 
   content, fill_missing, 
-  mip, background_color=0
+  mip, background_color=0,
+  encoding=None,
 ):
   """Gets the unique labels present in a given chunk."""
   return _decode_helper(  
@@ -706,12 +731,14 @@ def decode_unique(
     meta, input_bbox, 
     content, fill_missing, 
     mip, background_color,
+    encoding=encoding,
   )
 
 def decode_single_voxel(
   xyz, meta, input_bbox, 
   content, fill_missing, 
-  mip, background_color=0
+  mip, background_color=0,
+  encoding=None,
 ):
   """
   Specialized decode that for some file formats
@@ -733,13 +760,15 @@ def decode_single_voxel(
     meta, input_bbox,
     content, fill_missing, 
     mip, background_color,
+    encoding=encoding,
   )
 
 def _decode_helper(  
   fn, meta, input_bbox, 
-  content, fill_missing, 
-  mip, background_color=0,
-  allow_none=True,
+  content, fill_missing, mip, 
+  background_color=0,
+  allow_none=True, 
+  encoding=None,
 ):
   bbox = Bbox.create(input_bbox)
   content_len = len(content) if content is not None else 0
@@ -755,14 +784,17 @@ def _decode_helper(
   if not content and allow_none:
     return None
 
+  if encoding is None:
+    encoding = meta.encoding(mip)
+
   try:
     return fn(
-      content, 
-      encoding=meta.encoding(mip), 
-      shape=shape, 
-      dtype=meta.dtype, 
+      content,
+      encoding=encoding,
+      shape=shape,
+      dtype=meta.dtype,
       block_size=meta.compressed_segmentation_block_size(mip),
-      background_color=background_color
+      background_color=background_color,
     )
   except Exception as error:
     print(red('File Read Error: {} bytes, {}, {}, errors: {}'.format(
@@ -839,6 +871,7 @@ def unique_unsharded(
     fn=process_core, decode_fn=decode_unique, fill_missing=fill_missing,
     progress=progress, compress_cache=compress_cache, 
     green=green, secrets=secrets, background_color=background_color,
+    full_decode=False,
   )
 
   if len(shell_chunks) > 0:
@@ -847,6 +880,7 @@ def unique_unsharded(
       fn=process_shell, decode_fn=decode, fill_missing=fill_missing,
       progress=progress, compress_cache=compress_cache, 
       green=green, secrets=secrets, background_color=background_color,
+      full_decode=False,
     )
 
   return all_labels

--- a/cloudvolume/datasource/precomputed/image/tx.py
+++ b/cloudvolume/datasource/precomputed/image/tx.py
@@ -279,6 +279,7 @@ def threaded_upload_chunks(
     green=False,
     compress_level=None,
     secrets=None,
+    lru_encoding="same",
   ):
   
   if cache.enabled:

--- a/cloudvolume/datasource/precomputed/image/tx.py
+++ b/cloudvolume/datasource/precomputed/image/tx.py
@@ -34,7 +34,7 @@ progress_queue = None # defined in common.initialize_synchronization
 fs_lock = None # defined in common.initialize_synchronization
 
 def upload(
-    meta, cache, lru,
+    meta, cache, lru, lru_encoding,
     image, offset, mip,
     compress=None,
     compress_level=None,
@@ -82,7 +82,8 @@ def upload(
     "delete_black_uploads": delete_black_uploads,
     "background_color": background_color,
     "green": green,
-    "secrets": secrets,  
+    "secrets": secrets,
+    "lru_encoding": lru_encoding,
   }
 
   expanded = bounds.expand_to_chunk_size(meta.chunk_size(mip), meta.voxel_offset(mip))
@@ -132,19 +133,19 @@ def upload(
       compress=compress, cdn_cache=cdn_cache,
       progress=False, n_threads=0, 
       delete_black_uploads=delete_black_uploads,
-      green=green, secrets=secrets
+      green=green, secrets=secrets, lru_encoding=lru_encoding,
     )
 
   compress_cache = should_compress(meta.encoding(mip), compress, cache, iscache=True)
 
   decode_fn = partial(decode, allow_none=False)
   download_chunks_threaded(
-    meta, cache, None, mip, shell_chunks, 
+    meta, cache, None, lru_encoding, mip, shell_chunks, 
     fn=shade_and_upload, decode_fn=decode_fn,
     fill_missing=fill_missing, 
     progress=("Shading Border" if progress else None), 
     compress_cache=compress_cache,
-    green=green, secrets=secrets
+    green=green, secrets=secrets,
   )
 
 def upload_aligned(
@@ -164,6 +165,7 @@ def upload_aligned(
     background_color=0,
     green=False,
     secrets=None,
+    lru_encoding="same",
   ):
   global fs_lock
 
@@ -178,7 +180,7 @@ def upload_aligned(
       delete_black_uploads=delete_black_uploads,
       background_color=background_color,
       green=green, compress_level=compress_level,
-      secrets=secrets
+      secrets=secrets, lru_encoding=lru_encoding,
     )
     return
 
@@ -309,18 +311,28 @@ def threaded_upload_chunks(
     nonlocal cache_compress
     nonlocal preencoded
 
+    encoding = meta.encoding(mip)
+
     if preencoded:
       encoded = preencoded[i]
       preencoded[i] = None
     else:
       encoded = chunks.encode(
-        imgchunk, meta.encoding(mip), 
+        imgchunk, encoding, 
         meta.compressed_segmentation_block_size(mip),
         compression_params=meta.compression_params(mip),
       )
 
     if lru is not None:
-      lru[cloudpath] = encoded
+      if lru_encoding in ["same", encoding]:
+        lru[cloudpath] = (encoding, encoded)
+      else:
+        lru_encoded = chunks.encode(
+          imgchunk, lru_encoding, 
+          meta.compressed_segmentation_block_size(mip),
+          compression_params=meta.compression_params(mip),
+        )
+        lru[cloudpath] = (lru_encoding, lru_encoded)
     
     if cache_compress is None and cache.enabled:
       cache_encoded = encoded

--- a/cloudvolume/datasource/precomputed/image/tx.py
+++ b/cloudvolume/datasource/precomputed/image/tx.py
@@ -325,9 +325,7 @@ def threaded_upload_chunks(
       )
 
     if lru is not None:
-      if lru_encoding == "raw" or (lru_encoding == "same" and encoding == "raw"):
-        lru[cloudpath] = ("raw", imgchunk)
-      elif lru_encoding in ["same", encoding]:
+      if lru_encoding in ["same", encoding]:
         lru[cloudpath] = (encoding, encoded)
       else:
         lru_encoded = chunks.encode(

--- a/cloudvolume/datasource/precomputed/image/tx.py
+++ b/cloudvolume/datasource/precomputed/image/tx.py
@@ -325,7 +325,7 @@ def threaded_upload_chunks(
       )
 
     if lru is not None:
-      if lru_encoding == "raw":
+      if lru_encoding == "raw" or (lru_encoding == "same" and encoding == "raw"):
         lru[cloudpath] = ("raw", imgchunk)
       elif lru_encoding in ["same", encoding]:
         lru[cloudpath] = (encoding, encoded)

--- a/cloudvolume/datasource/precomputed/image/tx.py
+++ b/cloudvolume/datasource/precomputed/image/tx.py
@@ -325,7 +325,9 @@ def threaded_upload_chunks(
       )
 
     if lru is not None:
-      if lru_encoding in ["same", encoding]:
+      if lru_encoding == "raw":
+        lru[cloudpath] = ("raw", imgchunk)
+      elif lru_encoding in ["same", encoding]:
         lru[cloudpath] = (encoding, encoded)
       else:
         lru_encoded = chunks.encode(

--- a/cloudvolume/lru.py
+++ b/cloudvolume/lru.py
@@ -1,6 +1,14 @@
 import sys
 import threading
 
+def getsizeof(val:int) -> int:
+  """does sizeof at depth 2"""
+  nbytes = 0
+  if isinstance(val, (tuple, list)):
+    for elem in val:
+      nbytes += sys.getsizeof(elem)
+  return nbytes + sys.getsizeof(val)
+
 class DoublyLinkedListIterator:
   def __init__(self, node, reverse=False):
     self.node = ListNode(None, node, node)
@@ -239,7 +247,7 @@ class LRU:
       while self.is_oversized():
         (key,val) = self.queue.delete_tail()
         del self.hash[key]
-        self.nbytes -= sys.getsizeof(val)
+        self.nbytes -= getsizeof(val)
 
   def delete(self, key):
     with self.lock:
@@ -249,7 +257,7 @@ class LRU:
       node = self.hash[key]
       self.queue.delete(node)
       del self.hash[key]
-      self.nbytes -= sys.getsizeof(node.val)
+      self.nbytes -= getsizeof(node.val)
       return node.val
 
   def pop(self, key, *args):
@@ -286,12 +294,12 @@ class LRU:
 
       self.queue.prepend(pair)
       self.hash[key] = self.queue.head
-      self.nbytes += sys.getsizeof(val)
+      self.nbytes += getsizeof(val)
 
       while self.is_oversized():
         (tkey,tval) = self.queue.delete_tail()
         del self.hash[tkey]
-        self.nbytes -= sys.getsizeof(tval)
+        self.nbytes -= getsizeof(tval)
 
   def __contains__(self, key):
     return key in self.hash

--- a/cloudvolume/lru.py
+++ b/cloudvolume/lru.py
@@ -2,7 +2,7 @@ import sys
 import threading
 
 def getsizeof(val:int) -> int:
-  """does sizeof at depth 2"""
+  """does sizeof at depth 2 for tuples and lists"""
   nbytes = 0
   if isinstance(val, (tuple, list)):
     for elem in val:
@@ -193,7 +193,8 @@ class LRU:
     If size_in_bytes is True, this refers to the size in bytes of the
     stored elements (not counting internal data structures of the LRU)
     as measured by sys.getsizeof which does not handle nested objects
-    (unless they implement a __sizeof__ handler).
+    (unless they implement a __sizeof__ handler). It also handles
+    one level of tuples and lists through custom logic.
 
     Therefore, size_in_bytes is most easily used with Python base types.
     It was designed for with byte strings in mind that represent file

--- a/cloudvolume/paths.py
+++ b/cloudvolume/paths.py
@@ -1,6 +1,7 @@
 import cloudfiles.paths
 
 from collections import namedtuple
+from functools import lru_cache
 import os
 import posixpath
 import re
@@ -117,6 +118,7 @@ def strict_extract(cloudpath, windows=None, disable_toabs=False):
 
   return path
 
+@lru_cache(maxsize=10, typed=False)
 def extract(cloudpath, windows=None, disable_toabs=False):
   """
   Given a valid cloudpath of the form 
@@ -138,6 +140,8 @@ def extract(cloudpath, windows=None, disable_toabs=False):
   """
   if len(cloudpath) == 0:
     return ExtractedPath('','','','','','','')
+
+  cloudpath = cloudfiles.paths.normalize(cloudpath)
 
   windows_file_re = re.compile(r'((?:\w:\\)[\d\w_\.\-]+)')
   bucket_re = re.compile(r'^(/?[~\d\w_\.\-]+(?::\d+)?)(?:\b|$)') # posix /what/a/great/path

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -238,10 +238,15 @@ def test_read_binary_image(green, encoding, lru_bytes):
 @pytest.mark.parametrize('green', (True, False))
 @pytest.mark.parametrize('encoding', ('raw', 'compresso', 'compressed_segmentation'))
 @pytest.mark.parametrize('lru_bytes', (0,1e6,10e6))
-def test_point_reads_sharded(shard_vol, shard_vol_data_cpso, green, encoding, lru_bytes):
+@pytest.mark.parametrize('lru_encoding', ["same", "raw", "crackle"])
+def test_point_reads_sharded(
+  shard_vol, shard_vol_data_cpso, green, 
+  encoding, lru_bytes, lru_encoding
+):
   cv = shard_vol
   data = shard_vol_data_cpso
   cv.green_threads = green
+  cv.image._lru_encoding = lru_encoding
   cv.image.lru.resize(lru_bytes)
 
   N = 25
@@ -257,13 +262,15 @@ def test_point_reads_sharded(shard_vol, shard_vol_data_cpso, green, encoding, lr
 @pytest.mark.parametrize('green', (True, False))
 @pytest.mark.parametrize('encoding', ('raw', 'compresso', 'compressed_segmentation'))
 @pytest.mark.parametrize('lru_bytes', (0,1e6,10e6))
-def test_point_reads(green, encoding, lru_bytes):
+@pytest.mark.parametrize('lru_encoding', ["same", "raw", "crackle"])
+def test_point_reads_unsharded(green, encoding, lru_bytes, lru_encoding):
   delete_layer()
   cv, data = create_layer(
     size=(256,256,100,1), offset=(0,0,0), 
     encoding=encoding, layer_type="segmentation"
   )
   cv.green_threads = green
+  cv.image._lru_encoding = lru_encoding
   cv.image.lru.resize(lru_bytes)  
 
   N = 200

--- a/test/test_cloudvolume.py
+++ b/test/test_cloudvolume.py
@@ -224,8 +224,7 @@ def test_read_binary_image(green, encoding, lru_bytes):
   img = cv.download(bbox, mip=0, label=0)
   assert img.dtype == bool
   assert np.all(img == (data == 0))
-
-
+  
   bbox = Bbox([1,1,1], [2,2,2])
   img = cv.download(bbox, mip=0, label=data[1,1,1])
   assert img.dtype == bool

--- a/test/test_dask.py
+++ b/test/test_dask.py
@@ -15,7 +15,7 @@ def test_roundtrip_3d():
     d = 'file://' + d
     dasklib.to_cloudvolume(a, d)
     a2 = dasklib.from_cloudvolume(d)
-    da.utils.assert_eq(a, a2[..., 0], check_meta=False)
+    assert np.all(np.array(a) == np.array(a2)[...,0])
     assert a.chunks == a2.chunks[:-1]
 
 @pytest.mark.skipif(sys.version_info[0] < 3, reason="Python 2 not supported.")
@@ -27,7 +27,7 @@ def test_roundtrip_4d():
     d = 'file://' + d
     dasklib.to_cloudvolume(a, d)
     a2 = dasklib.from_cloudvolume(d)
-    da.utils.assert_eq(a, a2, check_type=False)
+    assert np.all(np.array(a) == np.array(a2))
     assert a.chunks == a2.chunks
 
 @pytest.mark.skipif(sys.version_info[0] < 3, reason="Python 2 not supported.")

--- a/test/test_lru.py
+++ b/test/test_lru.py
@@ -6,6 +6,25 @@ import time
 import random
 import sys
 
+def test_lru_size_w_tuple():
+  lru = LRU(int(1e6), size_in_bytes=True)
+  assert lru.nbytes == 0
+  val = (1, b'0' * 1000, b'1' * 1000)
+  lru[1] = val
+
+  ans = (
+    sys.getsizeof(val) 
+    + sys.getsizeof(val[0])
+    + sys.getsizeof(val[1])
+    + sys.getsizeof(val[2])
+  )
+  assert 2000 < ans < 2200
+  assert lru.nbytes == ans
+  val = b'2' * 500
+  lru[2] = val
+  ans += sys.getsizeof(val)
+  assert lru.nbytes == ans
+
 @pytest.mark.parametrize("size_in_bytes", (False,True))
 def test_lru(size_in_bytes):
   base_size = 5


### PR DESCRIPTION
This PR adds the `lru_encoding` flag to CloudVolume at the top level. This allows you to choose the image encoding type of the LRU. This can be useful for either conserving additional space by choosing a higher compression type or for accelerating chunk reuse by selecting e.g. `raw` at the expense of more memory.

There may even be times when you can pick a faster and smaller compression type for certain queries.

The default value for `lru_encoding` is `"same"` which is whatever the current mip level's encoding is.

This change also makes parallel download compatible with non-raw LRU at the expense of additional encoding time.
