### PR TITLE
feat(bbox): handle plain lists of 6 ints in Bbox.create

### DIFF
--- a/cloudvolume/lib.py
+++ b/cloudvolume/lib.py
@@ -478,6 +478,8 @@ class Bbox(object):
     typ = type(obj)
     if typ is Bbox:
       obj = obj
+    elif typ in (list, tuple) and len(obj) == 6 and all(isinstance(x, integer_types) for x in obj):
+      obj = Bbox.from_list(obj)
     elif typ in (list, tuple, slice):
       obj = Bbox.from_slices(obj, context, bounded, autocrop)
     elif typ is Vec:


### PR DESCRIPTION
When the input to Bbox.create is a plain list or tuple of 6 integers, use Bbox.from_list instead of from_slices for more intuitive handling.

This makes it easier to create a bounding box from coordinates in the format [x_min, y_min, z_min, x_max, y_max, z_max].