### PR TITLE
Postgresql support for spatial_index

### DIFF
--- a/cloudvolume/datasource/precomputed/spatial_index.py
+++ b/cloudvolume/datasource/precomputed/spatial_index.py
@@ -506,11 +506,17 @@ class SpatialIndex(object):
     if self.sql_db:
       conn = connect(self.sql_db)
       cur = conn.cursor()
-      cur.execute("""
+
+      db_type = parse_db_path(self.sql_db)["scheme"]
+      BIND = '?'
+      if db_type == 'mysql' or db_type in ('postgres', 'postgresql'):
+        BIND = '%s'
+
+      cur.execute(f"""
         select index_files.filename  
         from file_lookup, index_files
         where file_lookup.fid = index_files.id
-          and file_lookup.label = ?
+          and file_lookup.label = {BIND}
       """, (label,))
       iterator = [ self.fetch_index_files(( row[0] for row in cur.fetchall() )) ]
       conn.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ simplejpeg
 tenacity>=4.10.0
 tqdm
 urllib3[brotli]>=1.25.7
+psycopg2


### PR DESCRIPTION
Add psql support to ingest and serve spatial indices. Tested using a psql database for mesh frag forging. Does not seem to break mysql(mariadb) support, but I did not test sqlite. Gemini generate the commits, overall looks reasonable. Below are summary generated by Gemini:

## Summary

This pull request introduces support for using PostgreSQL as a backend for the spatial index, in addition to the existing SQLite and MySQL options. This provides users with a more robust and scalable option for managing spatial index data.

The implementation includes the necessary logic to connect to a PostgreSQL database, create the required database and tables, and ingest data in parallel. Several issues identified during development, including a connection race condition and dialect-specific syntax errors, have been resolved.

## Key Changes

- **PostgreSQL Connectivity**: The `connect` and `parse_db_path` functions were updated to handle `postgres://` and `postgresql://` URI schemes.
- **Dependency**: The `psycopg2` library, the standard PostgreSQL driver for Python, has been added to `requirements.txt`.
- **Database Creation**: A new `to_postgres` method was added to handle the specific workflow for creating a new database in PostgreSQL, which involves connecting to a default database first.
- **SQL Dialect Compatibility**: The `_to_sql_common` method was refactored to support PostgreSQL-specific SQL, including:
    - Using `BIGSERIAL` for auto-incrementing primary keys.
    - Using `BIGINT` for integer types.
    - Using `DROP TABLE ... CASCADE` to correctly handle foreign key constraints.
- **Race Condition Fix**: A critical race condition was resolved by adding a `conn.commit()` after the table creation statements. This ensures that the tables exist and are visible to all parallel insertion threads.
- **Robust URI Handling**: The logic for generating the initial database connection URI was improved by using `urllib.parse` to prevent malformed URIs.
- **Error Handling**: The `to_postgres` method now includes more specific error handling to provide clearer feedback on connection or permission issues (e.g., lack of `CREATEDB` privileges).

## Detailed Commit Log:
*   **feat: handle postgres schemes in connect**
    This commit adds support for PostgreSQL database connections in `cloudvolume/datasource/precomputed/spatial_index.py`. The `connect` function is modified to handle `postgres` and `postgresql` schemes in addition to the existing `mysql` and `sqlite` support. The code is refactored to use a more modular `if/elif/else` structure for handling the different database schemes. This makes the code cleaner and easier to extend in the future.
*   **feat: add to_postgres method and update to_sql**
    This commit introduces the `to_postgres` method in `cloudvolume/datasource/precomputed/spatial_index.py`, which allows creating a PostgreSQL database for the spatial index. The `to_sql` method is also updated to delegate to `to_postgres` when a PostgreSQL path is provided. The `to_postgres` method handles the creation of the database if it doesn't exist and then calls a common `_to_sql_common` method to populate it. This commit also includes error handling for database creation and connection.
*   **refactor: adapt _to_sql_common for postgres dialect**
    This commit refactors the `_to_sql_common` method in `cloudvolume/datasource/precomputed/spatial_index.py` to support the PostgreSQL dialect. It introduces a `postgres_syntax` flag and adjusts the SQL syntax for creating tables and defining data types based on which database is being used (MySQL, PostgreSQL, or SQLite). Specifically, it handles differences in auto-incrementing primary keys, integer types, and the `DROP TABLE` command. This makes the `_to_sql_common` method more generic and reusable across different database backends.
*   **refactor: adapt insertion logic for postgres**
    This commit adapts the data insertion logic in `cloudvolume/datasource/precomputed/spatial_index.py` to support PostgreSQL. It modifies the `thread_safe_insert` and `insert_index_files` functions to handle the PostgreSQL syntax for bindings and increases the block size for insertions to improve performance. It also updates `set_journaling_to_performance_mode` to set the transaction isolation level for PostgreSQL, which is important for performance in multi-threaded insertion scenarios.
*   **fix: use correct SQL parameter style in get_bbox**
    This commit fixes a bug in the `get_bbox` method in `cloudvolume/datasource/precomputed/spatial_index.py`. It ensures that the correct SQL parameter style (`?` for SQLite, `%s` for MySQL and PostgreSQL) is used when querying the database. Previously, it was hardcoded to use `?`, which would fail for MySQL and PostgreSQL. This commit makes the `get_bbox` method compatible with all supported database backends.
*   **build: add psycopg2 dependency for postgres support**
    This commit adds `psycopg2` to the `requirements.txt` file. This is the Python driver for PostgreSQL, and it's a necessary dependency for the PostgreSQL support that was added in the previous commits.