### PR TITLE
fix(spatial_index): Replace StrEnum with str, Enum for Python 3.10 compatibility

### DIFF
--- a/cloudvolume/datasource/precomputed/spatial_index.py
+++ b/cloudvolume/datasource/precomputed/spatial_index.py
@@ -7,7 +7,7 @@ import queue
 import sqlite3
 import threading
 import time
-from enum import StrEnum
+from enum import Enum
 
 import tenacity
 import numpy as np
@@ -23,7 +23,7 @@ from ...lib import (
   toiter, sip, nvl, getprecision
 )
 
-class DbType(StrEnum):
+class DbType(str, Enum):
   SQLITE = "sqlite"
   MYSQL = "mysql"
   POSTGRES = "postgres"


### PR DESCRIPTION
Fixes #675. Replaced StrEnum with str, Enum to support Python 3.10.