### PR TITLE
perf: Store numpy arrays directly in LRU cache instead of re-encoding

### DIFF
--- a/cloudvolume/chunks.py
+++ b/cloudvolume/chunks.py
@@ -151,7 +151,7 @@ def decode(
       return np.zeros(shape=shape, dtype=dtype, order="F")
     else:
       return np.full(shape=shape, fill_value=background_color, dtype=dtype, order="F")
-  elif isinstance(filedata, np.ndarray):
+  elif encoding == "numpy" or isinstance(filedata, np.ndarray):
     return filedata
   elif encoding == "raw":
     return decode_raw(filedata, shape=shape, dtype=dtype)

--- a/cloudvolume/chunks.py
+++ b/cloudvolume/chunks.py
@@ -151,7 +151,7 @@ def decode(
       return np.zeros(shape=shape, dtype=dtype, order="F")
     else:
       return np.full(shape=shape, fill_value=background_color, dtype=dtype, order="F")
-  elif encoding == "numpy" or isinstance(filedata, np.ndarray):
+  elif isinstance(filedata, np.ndarray):
     return filedata
   elif encoding == "raw":
     return decode_raw(filedata, shape=shape, dtype=dtype)

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -496,27 +496,24 @@ def repopulate_lru_from_shm(
   ))
 
   encoding = lru_encoding
-  if encoding == "same":
-    # Since the parallel version populates the LRU via an image and
-    # you don't get the benefit of accessing the raw downloaded bytes,
-    # there will be a performance regression for "same" since e.g.
-    # jpeg -> img -> jpeg will instead of decode -> img,lru you'll
-    # have decode -> img -> encode -> lru. Therefore, this is hacky,
-    # but backwards compatible and strictly expands the capabilities
-    # of the LRU.
-    encoding = "raw" # would ordinarily be: meta.encoding(mip)
-
-  for chunkname in core_chunks[-lru.size:]:
-    bbx = Bbox.from_filename(chunkname)
-    bbx -= requested_bbox.minpt
-    img3d = renderbuffer[ bbx.to_slices() ]
-    binary = chunks.encode(
-      img3d, encoding,
-      meta.compressed_segmentation_block_size(mip),
-      compression_params=meta.compression_params(mip),
-      num_threads=meta.config.codec_threads,
-    )
-    lru[chunkname] = (encoding, binary)
+  if encoding in ("same", "raw"):
+    for chunkname in core_chunks[-lru.size:]:
+      bbx = Bbox.from_filename(chunkname)
+      bbx -= requested_bbox.minpt
+      img3d = np.copy(renderbuffer[ bbx.to_slices() ])
+      lru[chunkname] = ("numpy", img3d)
+  else:
+    for chunkname in core_chunks[-lru.size:]:
+      bbx = Bbox.from_filename(chunkname)
+      bbx -= requested_bbox.minpt
+      img3d = renderbuffer[ bbx.to_slices() ]
+      binary = chunks.encode(
+        img3d, encoding,
+        meta.compressed_segmentation_block_size(mip),
+        compression_params=meta.compression_params(mip),
+        num_threads=meta.config.codec_threads,
+      )
+      lru[chunkname] = (encoding, binary)
 
 def child_process_download(
     meta, cache, 
@@ -611,18 +608,22 @@ def download_chunk(
     if lru is not None:
       lru[filename] = (encoding, content)
 
-  if no_deserialize:
+  if encoding == "numpy":
+    img3d = content
+  elif no_deserialize:
     img3d = content
   else:
     img3d = decode_fn(
-      meta, filename, content, 
-      fill_missing, mip, 
+      meta, filename, content,
+      fill_missing, mip,
       background_color=background_color,
       encoding=encoding,
     )
 
   if lru is not None and full_decode:
-    if lru_encoding not in [ "same", encoding ]:
+    if lru_encoding == "raw" and encoding != "numpy":
+      lru[filename] = ("numpy", img3d)
+    elif lru_encoding not in [ "same", "raw", encoding ]:
       content = None
       if img3d is not None:
         block_size = meta.compressed_segmentation_block_size(mip)
@@ -630,12 +631,12 @@ def download_chunk(
           block_size = (8,8,8)
 
         content = chunks.encode(
-          img3d, lru_encoding, 
+          img3d, lru_encoding,
           block_size,
           compression_params=meta.compression_params(mip),
           num_threads=meta.config.codec_threads,
         )
-        
+
       lru[filename] = (lru_encoding, content)
 
   return img3d, bbox

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -574,6 +574,7 @@ def download_chunk(
   cf = CloudFiles(cloudpath, secrets=secrets, locking=locking)
   no_deserialize = (cf.protocol == "mem" and encoding == "raw" and not enable_cache)
 
+  lru_miss = False
   try:
     encoding, content = lru[filename]
   except (TypeError, KeyError):
@@ -602,8 +603,7 @@ def download_chunk(
     if content is not None and decompress and not no_deserialize:
       content = compression.decompress(content, file['compress'])
 
-    if lru is not None:
-      lru[filename] = (encoding, content)
+    lru_miss = True
 
   if encoding == "numpy":
     img3d = content
@@ -617,10 +617,10 @@ def download_chunk(
       encoding=encoding,
     )
 
-  if lru is not None and full_decode:
-    if lru_encoding == "raw" and encoding != "numpy":
+  if lru is not None and lru_miss:
+    if full_decode and lru_encoding == "raw":
       lru[filename] = ("numpy", img3d)
-    elif lru_encoding not in [ "same", "raw", encoding ]:
+    elif full_decode and lru_encoding not in [ "same", "raw", encoding ]:
       content = None
       if img3d is not None:
         block_size = meta.compressed_segmentation_block_size(mip)
@@ -635,6 +635,8 @@ def download_chunk(
         )
 
       lru[filename] = (lru_encoding, content)
+    else:
+      lru[filename] = (encoding, content)
 
   return img3d, bbox
 

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -605,9 +605,7 @@ def download_chunk(
 
     lru_miss = True
 
-  if encoding == "numpy":
-    img3d = content
-  elif no_deserialize:
+  if no_deserialize:
     img3d = content
   else:
     img3d = decode_fn(
@@ -618,9 +616,9 @@ def download_chunk(
     )
 
   if lru is not None and lru_miss:
-    if full_decode and lru_encoding == "raw":
+    if full_decode and lru_encoding == "raw" and isinstance(img3d, np.ndarray):
       lru[filename] = ("numpy", img3d)
-    elif full_decode and lru_encoding not in [ "same", "raw", encoding ]:
+    elif full_decode and lru_encoding not in [ "same", encoding ]:
       content = None
       if img3d is not None:
         block_size = meta.compressed_segmentation_block_size(mip)
@@ -673,6 +671,9 @@ def download_chunks_threaded(
     )
     fn(labels, bbox)
 
+  # If there's an LRU sort the fetches so that the LRU ones are first
+  # otherwise the new downloads can kick out the cached ones and make the
+  # lru useless.
   if lru is not None and lru.size > 0 and not are_all_lru_hits:
     if not isinstance(locations['remote'], list):
       locations['remote'] = list(locations['remote'])

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -496,17 +496,14 @@ def repopulate_lru_from_shm(
   ))
 
   encoding = lru_encoding
-  if encoding in ("same", "raw"):
-    for chunkname in core_chunks[-lru.size:]:
-      bbx = Bbox.from_filename(chunkname)
-      bbx -= requested_bbox.minpt
-      img3d = np.copy(renderbuffer[ bbx.to_slices() ])
-      lru[chunkname] = ("numpy", img3d)
-  else:
-    for chunkname in core_chunks[-lru.size:]:
-      bbx = Bbox.from_filename(chunkname)
-      bbx -= requested_bbox.minpt
-      img3d = renderbuffer[ bbx.to_slices() ]
+  store_as_numpy = encoding in ("same", "raw")
+  for chunkname in core_chunks[-lru.size:]:
+    bbx = Bbox.from_filename(chunkname)
+    bbx -= requested_bbox.minpt
+    img3d = renderbuffer[ bbx.to_slices() ]
+    if store_as_numpy:
+      lru[chunkname] = ("numpy", np.copy(img3d, order="F"))
+    else:
       binary = chunks.encode(
         img3d, encoding,
         meta.compressed_segmentation_block_size(mip),

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -647,7 +647,20 @@ def download_chunks_threaded(
     decompress=True, full_decode=True,
   ):
   """fn is the postprocess callback. decode_fn is a decode fn."""
-  locations = cache.compute_data_locations(cloudpaths)
+
+  # If every chunk is an LRU hit, skip compute_data_locations
+  # which does os.listdir on the cache directory.
+  are_all_lru_hits = False
+  if lru is not None and lru.size > 0:
+    if not isinstance(cloudpaths, list):
+      cloudpaths = list(cloudpaths)
+    are_all_lru_hits = all(fname in lru for fname in cloudpaths)
+
+  if are_all_lru_hits:
+    locations = { 'local': [], 'remote': cloudpaths }
+  else:
+    locations = cache.compute_data_locations(cloudpaths)
+
   cachedir = 'file://' + cache.path
 
   def process(cloudpath, filename, enable_cache, locking):
@@ -660,16 +673,11 @@ def download_chunks_threaded(
     )
     fn(labels, bbox)
 
-  # If there's an LRU sort the fetches so that the LRU ones are first
-  # otherwise the new downloads can kick out the cached ones and make the
-  # lru useless.
-  are_all_lru_hits = False
-  if lru is not None and lru.size > 0:
+  if lru is not None and lru.size > 0 and not are_all_lru_hits:
     if not isinstance(locations['remote'], list):
-      locations['remote'] = list(locations['remote'])  
-    locations['local'].sort(key=lambda fname: fname in lru, reverse=True)  
+      locations['remote'] = list(locations['remote'])
+    locations['local'].sort(key=lambda fname: fname in lru, reverse=True)
     locations['remote'].sort(key=lambda fname: fname in lru, reverse=True)
-    are_all_lru_hits = all(( fname in lru for fname in locations['remote'] ))
 
   qualify = lambda fname: os.path.join(meta.key(mip), os.path.basename(fname))
 

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -615,10 +615,13 @@ def download_chunk(
       encoding=encoding,
     )
 
-  if lru is not None and lru_miss:
-    if full_decode and lru_encoding == "raw" and isinstance(img3d, np.ndarray):
+  if lru is not None:
+    # Transcode on hit too: a prior call with full_decode=False may have
+    # populated the LRU with the original encoding, which we can now upgrade
+    # to lru_encoding now that we have a decoded image.
+    if full_decode and lru_encoding == "raw" and encoding != "numpy" and isinstance(img3d, np.ndarray):
       lru[filename] = ("numpy", img3d)
-    elif full_decode and lru_encoding not in [ "same", encoding ]:
+    elif full_decode and lru_encoding not in [ "same", "raw", encoding ]:
       content = None
       if img3d is not None:
         block_size = meta.compressed_segmentation_block_size(mip)
@@ -633,7 +636,7 @@ def download_chunk(
         )
 
       lru[filename] = (lru_encoding, content)
-    else:
+    elif lru_miss:
       lru[filename] = (encoding, content)
 
   return img3d, bbox

--- a/cloudvolume/datasource/precomputed/image/tx.py
+++ b/cloudvolume/datasource/precomputed/image/tx.py
@@ -375,6 +375,8 @@ def threaded_upload_chunks(
     if lru is not None:
       if lru_encoding in ["same", encoding]:
         lru[cloudpath] = (encoding, encoded)
+      elif lru_encoding == "raw":
+        lru[cloudpath] = ("numpy", np.copy(imgchunk, order="F"))
       else:
         lru_encoded = chunks.encode(
           imgchunk, lru_encoding,


### PR DESCRIPTION
When lru_encoding is "raw", store decoded numpy arrays directly in the LRU cache instead of re-serializing them via encode_raw (which does np.asfortranarray + tobytes). This avoids significant overhead when reading non-"raw" data.