### PR TITLE
fix: use explicit spawn context for all multiprocessing primitives

### DIFF
--- a/cloudvolume/datasource/precomputed/image/common.py
+++ b/cloudvolume/datasource/precomputed/image/common.py
@@ -63,9 +63,13 @@ def parallel_execution(
 ):
   global error_queue
 
-  error_queue = mp.Queue()
-  progress_queue = mp.Queue()
-  fs_lock = mp.Lock()
+  # Ensure processes do not accidentally inherit
+  # locks from forking and deadlock. Instead launch
+  # new interpreters.
+  ctx = mp.get_context("spawn")
+  error_queue = ctx.Queue()
+  progress_queue = ctx.Queue()
+  fs_lock = ctx.Lock()
 
   if parallel is True:
     parallel = mp.cpu_count()
@@ -103,11 +107,6 @@ def parallel_execution(
         args=(progress_queue,total,desc)
       )
       proc.start()
-
-    # Ensure processes do not accidentally inherit
-    # locks from forking and deadlock. Instead launch
-    # new interpreters.
-    ctx = mp.get_context("spawn")
 
     with concurrent.futures.ProcessPoolExecutor(
       max_workers=parallel,

--- a/cloudvolume/datasource/precomputed/image/common.py
+++ b/cloudvolume/datasource/precomputed/image/common.py
@@ -72,7 +72,7 @@ def parallel_execution(
   fs_lock = ctx.Lock()
 
   if parallel is True:
-    parallel = mp.cpu_count()
+    parallel = ctx.cpu_count()
   elif parallel <= 0:
     raise ValueError(f"Parallel must be a positive number or boolean (True: all cpus). Got: {parallel}")
 
@@ -102,8 +102,8 @@ def parallel_execution(
 
   try:
     if progress:
-      proc = mp.Process(
-        target=progress_queue_listener, 
+      proc = ctx.Process(
+        target=progress_queue_listener,
         args=(progress_queue,total,desc)
       )
       proc.start()


### PR DESCRIPTION
`Queue`, `Lock`, and `ProcessPoolExecutor` were using different mp contexts. `mp.Queue()` and `mp.Lock()` used the default context (fork on Linux), while `ProcessPoolExecutor` used an explicit spawn context. Passing fork-context primitives to spawn-context workers raises `RuntimeError`.

This worked inconsistently because `cloudfiles` calls `multiprocessing.set_start_method("spawn", force=True)` as a side effect during its first download. If that ran before `parallel_execution`, the default context was already `spawn` and it matched. Otherwise it crashed.

Fix: create all primitives from the same explicit `spawn` context.

Note the following subtlety:

If a CV has a mesh directory, during `CloudVolume.__getitem__`, it calls `PrecomputedMeshMetadata.fetch_info() → cache.download_json() → cloudfiles.get() → cloudfiles.parallel_execute → set_start_method("spawn", force=True)`. This happens before `parallel_execution` runs - so it works fine; it only manifests for volumes without meshes.

Also, `CloudFiles` _really_ should not force change the global `start_method` for a download.