### PR TITLE
perf(precomputed): re-enable multithreading for local file reads/writes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,7 +2,7 @@ Forrest Collman <forrest.collman@gmail.com>
 Jingpeng Wu <jingpeng.wu@gmail.com>
 Manuel Castro <macastro@princeton.edu>
 Nicholas Turner <nturner.stanford@gmail.com>
-Nico Kemnitz <nkemnitz@princeton.edu>
+Nico Kemnitz <nico@zetta.ai>
 Pat Gunn <pgunn01@gmail.com>
 Shang Mu <smu@princeton.edu>
 Thomas Macrina <thomas.macrina@gmail.com>

--- a/cloudvolume/datasource/precomputed/image/rx.py
+++ b/cloudvolume/datasource/precomputed/image/rx.py
@@ -712,7 +712,7 @@ def download_chunks_threaded(
 
   total = len(locations["local"]) + len(locations["remote"])
   n_threads = DEFAULT_THREADS
-  if meta.path.protocol in ("file", "mem") or are_all_lru_hits:
+  if meta.path.protocol == "mem" or are_all_lru_hits:
     n_threads = 0
 
   with tqdm(desc=progress, total=total, disable=(not progress)) as pbar:

--- a/cloudvolume/datasource/precomputed/image/tx.py
+++ b/cloudvolume/datasource/precomputed/image/tx.py
@@ -461,7 +461,7 @@ def threaded_upload_chunks(
     if callable(progress):
       progress()
 
-  if remote.protocol in ("file", "mem"):
+  if remote.protocol == "mem":
     n_threads = 0
 
   schedule_jobs(


### PR DESCRIPTION
With https://github.com/seung-lab/cloud-files/pull/126 compression/decompression running GIL-free, preserving the ThreadPool also makes sense for local precomputed layers. (And it would for mem and LRU cache if we ever decide to allow compressed data there, too)